### PR TITLE
bugfix；国战去除": function "

### DIFF
--- a/character/collab/skill.js
+++ b/character/collab/skill.js
@@ -958,11 +958,11 @@ const skills = {
 				charlotte: true,
 				mod: {
 					cardUsable(card) {
-						if (get.number(card) === "unsure" || card.cards?.some(card => card.hasGaintag("dcbeijin_buff"))) return Infinity;
+						if (get.number(card) === "unsure" || card.cards?.some(card => card.hasGaintag("dcbeijin_effect"))) return Infinity;
 					},
 					aiOrder(player, card, num) {
 						if (player.hasSkill("dcbeijin_buff") && typeof card === "object") {
-							if (get.itemtype(card) === "card" || card.cards?.some(card => card.hasGaintag("dcbeijin_buff"))) return num + 100;
+							if (get.itemtype(card) === "card" || card.cards?.some(card => card.hasGaintag("dcbeijin_effect"))) return num + 100;
 							return num / (get.tag(card, "recover") ? 1 : 1145141919810);
 						}
 					},
@@ -991,6 +991,7 @@ const skills = {
 				charlotte: true,
 				trigger: { player: ["useCard", "dcbeijinBegin"] },
 				forced: true,
+				popup: false,
 				content() {
 					player.removeSkill(event.name);
 					if (player.hasCard(card => card.hasGaintag("dcbeijin_effect"))) player.loseHp();

--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -4037,9 +4037,9 @@ const skills = {
 			backup: {},
 			effect: {
 				charlotte: true,
-				trigger: { global: "useCardToBegin" },
+				trigger: { player: "useCardToBegin" },
 				filter(event, player) {
-					return event.skill === "olsbweilin_backup";
+					return event.target?.isIn() && event.skill === "olsbweilin_backup";
 				},
 				forced: true,
 				popup: false,

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -13551,7 +13551,7 @@ const skills = {
 		content() {
 			"step 0";
 			player
-				.chooseTarget(get.prompt2("xindiaodu"), function (card, player, current) {
+				.chooseTarget(get.prompt2(event.name), function (card, player, current) {
 					return lib.skill.xindiaodu.isFriendOf(current, player) && current.countGainableCards(player, "e") > 0;
 				})
 				.setHiddenSkill(event.name).ai = function (target) {
@@ -13564,8 +13564,7 @@ const skills = {
 			"step 1";
 			if (result.bool) {
 				event.target1 = result.targets[0];
-				player.logSkill("xindiaodu", event.target1);
-				player.line(event.target1, "xindiaodu");
+				player.logSkill(event.name, event.target1);
 				player.gainPlayerCard(event.target1, "e", true);
 			} else event.finish();
 			"step 2";
@@ -19903,11 +19902,11 @@ const skills = {
 			});
 		},
 		direct: true,
-		preHidden: ["reduanbing_sha"],
+		preHidden: ["reduanbing", "reduanbing_sha"],
 		content() {
 			"step 0";
 			player
-				.chooseTarget(get.prompt("reduanbing"), "为" + get.translation(trigger.card) + "增加一个目标", function (card, player, target) {
+				.chooseTarget(get.prompt(event.name), "为" + get.translation(trigger.card) + "增加一个目标", function (card, player, target) {
 					return !_status.event.sourcex.includes(target) && get.distance(player, target) <= 1 && player.canUse(_status.event.card, target);
 				})
 				.set("sourcex", trigger.targets)
@@ -19925,7 +19924,7 @@ const skills = {
 				event.finish();
 			}
 			"step 2";
-			player.logSkill("reduanbing", event.target);
+			player.logSkill(event.name, event.target);
 			trigger.targets.push(event.target);
 		},
 		ai: {

--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -1459,15 +1459,7 @@ export default () => {
 				audio: "duanbing",
 				inherit: "reduanbing",
 				preHidden: ["fakeduanbing_sha"],
-				group: ["fakeduanbing_sha"],
-				get content() {
-					let content = get.info("reduanbing").content;
-					content = content.toString().replaceAll("reduanbing", "fakeduanbing");
-					content = new Function("return " + content)();
-					delete this.content;
-					this.content = content;
-					return content;
-				},
+				group: ["fakeduanbing", "fakeduanbing_sha"],
 				subSkill: {
 					sha: {
 						audio: "duanbing",
@@ -1560,7 +1552,7 @@ export default () => {
 										.set("_backupevent", "fakeduoshi_backup")
 										.set("custom", {
 											add: {},
-											replace: { window: function () {} },
+											replace: { window() {} },
 										})
 										.set("addCount", false)
 										.set("oncard", () => _status.event.directHit.addArray(game.players))
@@ -1774,14 +1766,6 @@ export default () => {
 				audio: "diaodu",
 				inherit: "xindiaodu",
 				group: "fakediaodu_use",
-				get content() {
-					let content = get.info("xindiaodu").content;
-					content = content.toString().replaceAll("xindiaodu", "fakediaodu");
-					content = new Function("return " + content)();
-					delete this.content;
-					this.content = content;
-					return content;
-				},
 				subSkill: {
 					use: {
 						trigger: { global: "useCard" },
@@ -2695,7 +2679,7 @@ export default () => {
 			},
 			fakexibing: {
 				audio: "xibing",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player == event.player || event.targets.length != 1 || event.player.countCards("h") >= event.player.hp) return false;
 					var bool = function (card) {
 						return (card.name == "sha" || get.type(card, null, false) == "trick") && get.color(card, false) == "black";
@@ -2710,7 +2694,7 @@ export default () => {
 					);
 				},
 				logTarget: "player",
-				check: function (event, player) {
+				check(event, player) {
 					var target = event.player;
 					var att = get.attitude(player, target);
 					var num2 = Math.min(5, target.hp) - target.countCards("h");
@@ -2752,7 +2736,7 @@ export default () => {
 				subSkill: {
 					banned: {
 						mod: {
-							cardEnabled2: function (card) {
+							cardEnabled2(card) {
 								if (get.position(card) == "h") return false;
 							},
 						},
@@ -2869,7 +2853,7 @@ export default () => {
 				unique: true,
 				audio: "zhiwei",
 				inherit: "zhiwei",
-				filter: function (event, player, name) {
+				filter(event, player, name) {
 					if (!game.hasPlayer(current => current != player)) return false;
 					return (
 						event.name == "showCharacter" &&
@@ -4407,7 +4391,7 @@ export default () => {
 						.set("_backupevent", "fakeqingleng_backup")
 						.set("custom", {
 							add: {},
-							replace: { window: function () {} },
+							replace: { window() {} },
 						})
 						.set("targetRequired", true)
 						.set("complexSelect", true)
@@ -5695,7 +5679,7 @@ export default () => {
 			gzdiaodu: {
 				audio: "diaodu",
 				trigger: { player: "phaseUseBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return current.isFriendOf(player) && current.countGainableCards(player, "e") > 0;
 					});
@@ -5703,7 +5687,7 @@ export default () => {
 				direct: true,
 				frequent: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt2("gzdiaodu"), function (card, player, current) {
@@ -5748,11 +5732,11 @@ export default () => {
 				subSkill: {
 					use: {
 						trigger: { global: "useCard" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return get.type(event.card) == "equip" && event.player.isIn() && event.player.isFriendOf(player) && (player == event.player || player.hasSkill("gzdiaodu"));
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							var next = trigger.player.chooseBool(get.prompt("gzdiaodu"), "摸一张牌");
 							if (player.hasSkill("gzdiaodu")) next.set("frequentSkill", "gzdiaodu");
@@ -5769,34 +5753,34 @@ export default () => {
 			//徐庶
 			gzqiance: {
 				trigger: { global: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!event.isFirstTarget || get.type(/*2*/ event.card) != "trick") return false; //延时锦囊不能响应有个锤用
 					return event.player.isFriendOf(player) && event.targets.some(target => target.isMajor());
 				},
-				check: function (event, player) {
+				check(event, player) {
 					var num = 0,
 						targets = event.targets.filter(target => target.isMajor());
 					for (var target of targets) num += get.sgn(get.attitude(player, target) * get.effect(target, event.card, event.player, player));
 					return num >= 0;
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					trigger.getParent().directHit.addArray(trigger.targets.filter(target => target.isMajor()));
 				},
 			},
 			gzjujian: {
-				init: function (player) {
+				init(player) {
 					if (player.checkViceSkill("gzjujian") && !player.viceChanged) player.removeMaxHp();
 				},
 				viceSkill: true,
 				audio: "gzjiancai",
 				trigger: { global: "dying" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isFriendOf(player);
 				},
 				forced: true,
 				logTarget: "player",
-				content: function () {
+				content() {
 					trigger.player.recover(1 - trigger.player.hp);
 					player.changeVice();
 				},
@@ -5805,12 +5789,12 @@ export default () => {
 			gztongling: {
 				audio: "daming",
 				trigger: { source: "damageSource" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.player.isFriendOf(player)) return false;
 					return player.isPhaseUsing() && event.player.isIn() && !player.hasSkill("gztongling_used");
 				},
 				direct: true,
-				content: function () {
+				content() {
 					"step 0";
 					var str = "";
 					if (get.itemtype(trigger.cards) == "cards" && trigger.cards.filterInD().length) str += "；未造成伤害，其获得" + get.translation(trigger.cards.filterInD());
@@ -5865,7 +5849,7 @@ export default () => {
 			gzjinyu: {
 				audio: "xiaoni",
 				trigger: { player: "showCharacterAfter" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (
 						!game.hasPlayer(function (current) {
 							return get.distance(player, current) <= 1;
@@ -5874,7 +5858,7 @@ export default () => {
 						return false;
 					return event.toShow.some(name => get.character(name, 3).includes("gzjinyu"));
 				},
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					return game
 						.filterPlayer(function (current) {
 							return get.distance(player, current) <= 1;
@@ -5883,7 +5867,7 @@ export default () => {
 				},
 				forced: true,
 				locked: false,
-				content: function () {
+				content() {
 					"step 0";
 					event.targets = game
 						.filterPlayer(function (current) {
@@ -5930,12 +5914,12 @@ export default () => {
 				audio: "gzhuaiyi",
 				enable: "phaseUse",
 				locked: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") > 0;
 				},
 				usable: 1,
 				delay: false,
-				content: function () {
+				content() {
 					"step 0";
 					player.showHandcards();
 					var hs = player.getCards("h"),
@@ -6015,7 +5999,7 @@ export default () => {
 				ai: {
 					order: 10,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							var map = {};
 							for (var i of ["red", "black", "none"]) {
 								if (player.countCards("h", { color: i })) map[i] = true;
@@ -6034,19 +6018,19 @@ export default () => {
 				},
 				marktext: "异",
 				intro: {
-					mark: function (dialog, storage, player) {
+					mark(dialog, storage, player) {
 						var cards = player.getCards("s", function (card) {
 							return card.hasGaintag("gzrehuaiyi");
 						});
 						if (!cards || !cards.length) return;
 						dialog.addAuto(cards);
 					},
-					markcount: function (storage, player) {
+					markcount(storage, player) {
 						return player.countCards("s", function (card) {
 							return card.hasGaintag("gzrehuaiyi");
 						});
 					},
-					onunmark: function (storage, player) {
+					onunmark(storage, player) {
 						var cards = player.getCards("s", function (card) {
 							return card.hasGaintag("gzrehuaiyi");
 						});
@@ -6056,7 +6040,7 @@ export default () => {
 					},
 				},
 				mod: {
-					aiOrder: function (player, card, num) {
+					aiOrder(player, card, num) {
 						if (get.itemtype(card) == "card" && card.hasGaintag("gzrehuaiyi"))
 							return (
 								num +
@@ -6071,7 +6055,7 @@ export default () => {
 				subSkill: {
 					unmark: {
 						trigger: { player: "loseAfter" },
-						filter: function (event, player) {
+						filter(event, player) {
 							if (!event.ss || !event.ss.length) return false;
 							return !player.countCards("s", function (card) {
 								return card.hasGaintag("gzrehuaiyi");
@@ -6080,7 +6064,7 @@ export default () => {
 						charlotte: true,
 						forced: true,
 						silent: true,
-						content: function () {
+						content() {
 							player.unmarkSkill("gzrehuaiyi");
 							player.removeSkill("gzrehuaiyi_unmark");
 						},
@@ -6090,7 +6074,7 @@ export default () => {
 			gzrezisui: {
 				audio: "gzzisui",
 				trigger: { player: "phaseDrawBegin2" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						!event.numFixed &&
 						player.countCards("s", function (card) {
@@ -6099,7 +6083,7 @@ export default () => {
 					);
 				},
 				forced: true,
-				content: function () {
+				content() {
 					trigger.num += player.countCards("s", function (card) {
 						return card.hasGaintag("gzrehuaiyi");
 					});
@@ -6109,7 +6093,7 @@ export default () => {
 					die: {
 						audio: "gzzisui",
 						trigger: { player: "phaseJieshuBegin" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								player.countCards("s", function (card) {
 									return card.hasGaintag("gzrehuaiyi");
@@ -6117,7 +6101,7 @@ export default () => {
 							);
 						},
 						forced: true,
-						content: function () {
+						content() {
 							player.die();
 						},
 					},
@@ -6148,7 +6132,7 @@ export default () => {
 				},
 				audio: "tianshu",
 				inherit: "taipingyaoshu",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!player.hasEmptySlot(2) || game.hasPlayer(target => target.getVEquip("taipingyaoshu"))) return false;
 					return lib.skill.taipingyaoshu.filter(event, player);
 				},
@@ -6170,7 +6154,7 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				//delay:0,
-				content: function () {
+				content() {
 					"step 0";
 					if (!player.storage.gzrejinghe_tianshu) {
 						var list = lib.skill.gzrejinghe.derivation.slice(0);
@@ -6237,7 +6221,7 @@ export default () => {
 				intro: {
 					name: "写满技能的天书",
 					markcount: () => 8,
-					mark: function (dialog, storage, player) {
+					mark(dialog, storage, player) {
 						dialog.content.style["overflow-x"] = "visible";
 						var list = player.storage.gzrejinghe_tianshu;
 						var core = document.createElement("div");
@@ -6263,7 +6247,7 @@ export default () => {
 				derivation: ["gzrejinghe_faq", "leiji", "nhyinbing", "nhhuoqi", "nhguizhu", "nhxianshou", "nhlundao", "nhguanyue", "nhyanzheng"],
 				subSkill: {
 					clear: {
-						onremove: function (player) {
+						onremove(player) {
 							game.countPlayer(function (current) {
 								current.removeAdditionalSkills("gzrejinghe_" + player.playerid);
 							});
@@ -6279,12 +6263,12 @@ export default () => {
 				group: "gzrebushi_give",
 				audio: "gzbushi",
 				trigger: { player: ["phaseZhunbeiBegin", "phaseAfter"] },
-				check: function (event, player) {
+				check(event, player) {
 					return event.name == "phase";
 				},
 				forced: true,
 				locked: false,
-				content: function () {
+				content() {
 					"step 0";
 					if (trigger.name == "phaseZhunbei") {
 						var num = game.countPlayer() - player.hp - 2;
@@ -6301,12 +6285,12 @@ export default () => {
 				subSkill: {
 					give: {
 						trigger: { global: "phaseZhunbeiBegin" },
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.player == player) return false;
 							return player.hasMark("gzrebushi") && player.countCards("he");
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							player.chooseCard(get.prompt("gzrebushi"), "he", "失去1个“义舍”标记，将一张牌交给" + get.translation(trigger.player) + "并摸两张牌").set("ai", function (card) {
 								var player = _status.event.player;
@@ -6337,10 +6321,10 @@ export default () => {
 				group: "gzremidao_change",
 				audio: "gzmidao",
 				trigger: { player: "phaseJieshuBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return !player.getExpansions("gzremidao").length;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.draw(2);
 					"step 1";
@@ -6356,18 +6340,18 @@ export default () => {
 					content: "expansion",
 					markcount: "expansion",
 				},
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
 				subSkill: {
 					change: {
 						trigger: { global: "judge" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getExpansions("gzremidao").length && event.player.isAlive();
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							var list = player.getExpansions("gzremidao");
 							player
@@ -6428,7 +6412,7 @@ export default () => {
 				audio: "biaozhao",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					var players = game.filterPlayer(current => current != player);
 					if (players.length < 2) return false;
 					for (var i = 0; i < players.length - 1; i++) {
@@ -6442,14 +6426,14 @@ export default () => {
 				complexTarget: true,
 				complexSelect: true,
 				selectTarget: 2,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (target == player) return false;
 					var targets = ui.selected.targets;
 					if (targets.length == 0) return player.canUse("zhibi", target);
 					return target.isEnemyOf(targets[0]);
 				},
 				targetprompt: ["被知己知彼", "获得牌"],
-				content: function () {
+				content() {
 					"step 0";
 					player.useCard({ name: "zhibi", isCard: true }, targets[0]);
 					"step 1";
@@ -6463,11 +6447,11 @@ export default () => {
 				ai: {
 					order: 6,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							if (ui.selected.targets.length) return 0.1;
 							return get.effect(target, { name: "zhibi" }, player, player) + 0.1;
 						},
-						target: function (player, target) {
+						target(player, target) {
 							if (ui.selected.targets.length) return 2;
 							return 0;
 						},
@@ -6482,10 +6466,10 @@ export default () => {
 				skillAnimation: true,
 				animationColor: "gray",
 				logTarget: "source",
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.source && event.source.isIn() && player.canUse("sha", event.source, false);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var target = trigger.source;
 					event.target = target;
@@ -6534,7 +6518,7 @@ export default () => {
 					unsavable: {
 						charlotte: true,
 						mod: {
-							targetEnabled: function (card, player, target) {
+							targetEnabled(card, player, target) {
 								if (card.name == "tao" && target.isDying() && player.isFriendOf(target) && target != player) return false;
 							},
 						},
@@ -6543,7 +6527,7 @@ export default () => {
 						charlotte: true,
 						ai: {
 							unequip: true,
-							skillTagFilter: function (player, tag, arg) {
+							skillTagFilter(player, tag, arg) {
 								if (!arg || !arg.card || !arg.card.storage || !arg.card.storage.gzyechou) return false;
 							},
 						},
@@ -6555,7 +6539,7 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				filterTarget: lib.filter.notMe,
-				content: function () {
+				content() {
 					"step 0";
 					event.targets = game
 						.filterPlayer(function (current) {
@@ -6613,7 +6597,7 @@ export default () => {
 				subSkill: {
 					effect: {
 						mod: {
-							cardUsable: function (card, player, num) {
+							cardUsable(card, player, num) {
 								if (card.name == "sha") return num + player.countMark("gzyinpan_effect");
 							},
 						},
@@ -6627,10 +6611,10 @@ export default () => {
 				trigger: { global: "gainAfter" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.getParent().name == "draw" && event.getParent(2).name == "die";
 				},
-				content: function () {
+				content() {
 					player.draw();
 				},
 				ai: {
@@ -6642,7 +6626,7 @@ export default () => {
 			gzgongjian: {
 				audio: "gongjian",
 				trigger: { global: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!event.isFirstTarget || event.card.name != "sha") return false;
 					var history = game.getAllGlobalHistory("useCard", function (evt) {
 						return evt.card.name == "sha";
@@ -6659,7 +6643,7 @@ export default () => {
 				prompt2: "弃置这些角色的各两张牌",
 				preHidden: ["gzgongjian_gain"],
 				subfrequent: ["gain"],
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					var history = game.getAllGlobalHistory("useCard", function (evt) {
 						return evt.card.name == "sha";
 					});
@@ -6670,7 +6654,7 @@ export default () => {
 						return evt0.targets.includes(target) && target.countCards("he") > 0;
 					});
 				},
-				check: function (event, player) {
+				check(event, player) {
 					var targets = lib.skill.gzgongjian.logTarget(event, player),
 						att = 0;
 					for (var i of targets) {
@@ -6678,7 +6662,7 @@ export default () => {
 					}
 					return att < 0;
 				},
-				content: function () {
+				content() {
 					var history = game.getAllGlobalHistory("useCard", function (evt) {
 						return evt.card.name == "sha";
 					});
@@ -6699,7 +6683,7 @@ export default () => {
 						trigger: {
 							global: ["loseAfter", "loseAsyncAfter"],
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.name == "lose") {
 								if (event.type != "discard" || event.player == player) return false;
 								if ((event.discarder || event.getParent(event.getParent(2).name == "chooseToDiscard" ? 3 : 2).player) != player) return false;
@@ -6717,13 +6701,13 @@ export default () => {
 							return false;
 						},
 						frequent: true,
-						prompt2: function (event, player) {
+						prompt2(event, player) {
 							var cards = event.getd(null, "cards2");
 							cards.removeArray(event.getd(player, "cards2"));
 							cards = cards.filter(card => card.name == "sha");
 							return "获得" + get.translation(cards);
 						},
-						content: function () {
+						content() {
 							var cards = trigger.getd(null, "cards2");
 							cards.removeArray(trigger.getd(player, "cards2"));
 							cards = cards.filter(card => card.name == "sha");
@@ -6737,14 +6721,14 @@ export default () => {
 				trigger: { source: "die" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var target = event.player;
 					if (target.isFriendOf(player)) return false;
 					var prev = target.getPrevious(),
 						next = target.getNext();
 					return (prev && prev.isFriendOf(target)) || (next && next.isFriendOf(target));
 				},
-				content: function () {
+				content() {
 					player.draw(2);
 				},
 			},
@@ -6757,7 +6741,7 @@ export default () => {
 				},
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.name != "damage") return true;
 					if (player.identity != "unknown")
 						return !game.hasPlayer(function (current) {
@@ -6765,7 +6749,7 @@ export default () => {
 						});
 					return !player.wontYe("wei") || !game.hasPlayer(current => current.identity == "wei");
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return (
 						!event.player.hasSkillTag("filterDamage", null, {
 							player: event.source,
@@ -6773,11 +6757,11 @@ export default () => {
 						}) && get.damageEffect(event.player, event.source, player, _status.event.player) > 0
 					);
 				},
-				content: function () {
+				content() {
 					trigger.num++;
 				},
 				mod: {
-					globalFrom: function (player, target, num) {
+					globalFrom(player, target, num) {
 						if (target.isMajor()) return num - 1;
 					},
 				},
@@ -6790,7 +6774,7 @@ export default () => {
 				skillAnimation: true,
 				animationColor: "thunder",
 				filterTarget: lib.filter.notMe,
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("gzhongju");
 					event.players = game
@@ -6837,12 +6821,12 @@ export default () => {
 				forced: true,
 				mainSkill: true,
 				preHidden: true,
-				init: function (player) {
+				init(player) {
 					if (player.checkMainSkill("gzduanshi")) {
 						player.removeMaxHp();
 					}
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					var evt = event.getParent();
 					if (evt.name != "die") return false;
 					if (player.identity == "unknown") {
@@ -6851,7 +6835,7 @@ export default () => {
 					return evt.player.isFriendOf(player);
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					trigger.num--;
 					if (trigger.num < 1) trigger.cancel();
 					if (!trigger.gzduanshi) trigger.gzduanshi = [];
@@ -6864,10 +6848,10 @@ export default () => {
 						forced: true,
 						charlotte: true,
 						popup: false,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.gzduanshi && event.gzduanshi.includes(player);
 						},
-						content: function () {
+						content() {
 							player.draw();
 						},
 					},
@@ -6875,7 +6859,7 @@ export default () => {
 			},
 			gzjingce: {
 				audio: "decadejingce",
-				getDiscardNum: function () {
+				getDiscardNum() {
 					var cards = [];
 					//因为是线下武将 所以同一张牌重复进入只算一张
 					game.getGlobalHistory("cardMove", function (evt) {
@@ -6884,11 +6868,11 @@ export default () => {
 					return cards.length;
 				},
 				trigger: { player: "phaseEnd" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.getHistory("useCard").length >= player.hp) return true;
 					return lib.skill.gzjingce.getDiscardNum() >= player.hp;
 				},
-				prompt2: function (event, player) {
+				prompt2(event, player) {
 					var num1 = player.getHistory("useCard").length,
 						num2 = lib.skill.gzjingce.getDiscardNum();
 					if (num1 >= player.hp && num2 >= player.hp) return "执行一套额外的摸牌阶段和出牌阶段";
@@ -6896,7 +6880,7 @@ export default () => {
 				},
 				preHidden: true,
 				frequent: true,
-				content: function () {
+				content() {
 					var num1 = player.getHistory("useCard").length,
 						num2 = lib.skill.gzjingce.getDiscardNum();
 					var num3 = player.hp;
@@ -6919,14 +6903,14 @@ export default () => {
 				audio: "xinfu_dianhu",
 				trigger: { player: "showCharacterAfter" },
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						event.toShow.some(name => {
 							return get.character(name, 3).includes("gzdianhu");
 						}) && !player.storage.gzdianhu_effect
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseTarget("请选择【点虎】的目标", true, "给一名角色标上“虎”标记。当你或你的队友对该角色造成伤害后摸一张牌。", lib.filter.notMe).set("ai", function (target) {
 						var player = _status.event.player;
@@ -6954,13 +6938,13 @@ export default () => {
 						trigger: { global: "damageEnd" },
 						forced: true,
 						charlotte: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (!player.getStorage("gzdianhu_effect").includes(event.player)) return false;
 							var source = event.source;
 							return source && source.isAlive() && source.isFriendOf(player);
 						},
 						logTarget: "source",
-						content: function () {
+						content() {
 							trigger.source.draw();
 						},
 					},
@@ -6970,7 +6954,7 @@ export default () => {
 				audio: "xinfu_jianji",
 				inherit: "xinfu_jianji",
 				filterTarget: true,
-				content: function () {
+				content() {
 					"step 0";
 					target.draw("visible");
 					"step 1";
@@ -6984,7 +6968,7 @@ export default () => {
 					) {
 						target.chooseToUse({
 							prompt: "是否使用" + get.translation(card) + "？",
-							filterCard: function (cardx, player, target) {
+							filterCard(cardx, player, target) {
 								return cardx == _status.event.cardx;
 							},
 							cardx: card,
@@ -7003,7 +6987,7 @@ export default () => {
 					player: "loseAfter",
 					global: "loseAsyncAfter",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.type != "discard" || event.getlx === false || player != _status.currentPhase) return false;
 					var evt = event.getl(player);
 					if (!evt || !evt.cards2 || !evt.cards2.length) return false;
@@ -7029,7 +7013,7 @@ export default () => {
 				},
 				ai: {
 					effect: {
-						player_use: function (card, player, target) {
+						player_use(card, player, target) {
 							if (
 								typeof card == "object" &&
 								player == _status.currentPhase &&
@@ -7053,7 +7037,7 @@ export default () => {
 				trigger: { player: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget([1, 2], "选择至多两名角色获得“追还”效果")
@@ -7092,7 +7076,7 @@ export default () => {
 				subSkill: {
 					timeout: {
 						charlotte: true,
-						onremove: function (player) {
+						onremove(player) {
 							var id = "gzzhuihuan_" + player.playerid;
 							game.countPlayer(current => current.removeAdditionalSkill(id));
 						},
@@ -7102,11 +7086,11 @@ export default () => {
 						trigger: { player: "damageEnd" },
 						forced: true,
 						forceDie: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.source && event.source.isAlive();
 						},
 						logTarget: "source",
-						content: function () {
+						content() {
 							player.removeSkill("gzzhuihuan_damage");
 							trigger.source.damage();
 						},
@@ -7124,11 +7108,11 @@ export default () => {
 						trigger: { player: "damageEnd" },
 						forced: true,
 						forceDie: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.source && event.source.isAlive();
 						},
 						logTarget: "source",
-						content: function () {
+						content() {
 							player.removeSkill("gzzhuihuan_discard");
 							trigger.source.chooseToDiscard(2, "he", true);
 						},
@@ -7147,7 +7131,7 @@ export default () => {
 			gzzhenxi: {
 				audio: "twzhenxi",
 				trigger: { player: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.card.name != "sha") return false;
 					if (
 						event.target.countCards("he") ||
@@ -7161,11 +7145,11 @@ export default () => {
 						return true;
 					return false;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return get.attitude(player, event.target) < 0;
 				},
 				direct: true,
-				content: function () {
+				content() {
 					"step 0";
 					var target = trigger.target;
 					event.target = target;
@@ -7225,14 +7209,14 @@ export default () => {
 					}
 				},
 				ai: { unequip_ai: true },
-				contentx: function () {
+				contentx() {
 					"step 0";
 					player.chooseCard({
 						position: "hes",
 						forced: true,
 						prompt: "震袭",
 						prompt2: "将一张♦非锦囊牌当做【乐不思蜀】或♣非锦囊牌当做【兵粮寸断】对" + get.translation(target) + "使用",
-						filterCard: function (card, player) {
+						filterCard(card, player) {
 							if (get.itemtype(card) != "card" || get.type2(card) == "trick" || !["diamond", "club"].includes(get.suit(card))) return false;
 							var cardx = { name: get.suit(card) == "diamond" ? "lebu" : "bingliang" };
 							return player.canUse(get.autoViewAs(cardx, [card]), _status.event.getParent().target, false);
@@ -7243,7 +7227,7 @@ export default () => {
 				},
 			},
 			gzjiansu: {
-				init: function (player) {
+				init(player) {
 					if (player.checkViceSkill("gzjiansu") && !player.viceChanged) player.removeMaxHp();
 				},
 				viceSkill: true,
@@ -7252,27 +7236,27 @@ export default () => {
 					player: "gainAfter",
 					global: "loseAsyncAfter",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player == _status.currentPhase) return false;
 					return event.getg(player).length;
 				},
 				frequent: true,
 				group: "gzjiansu_use",
 				preHidden: ["gzjiansu_use"],
-				content: function () {
+				content() {
 					player.showCards(trigger.getg(player), get.translation(player) + "发动了【俭素】");
 					player.addGaintag(trigger.getg(player), "gzjiansu_tag");
 					player.markSkill("gzjiansu");
 				},
 				intro: {
-					mark: function (dialog, content, player) {
+					mark(dialog, content, player) {
 						var hs = player.getCards("h", function (card) {
 							return card.hasGaintag("gzjiansu_tag");
 						});
 						if (hs.length) dialog.addSmall(hs);
 						else dialog.addText("无已展示手牌");
 					},
-					content: function (content, player) {
+					content(content, player) {
 						var hs = player.getCards("h", function (card) {
 							return card.hasGaintag("gzjiansu_tag");
 						});
@@ -7284,7 +7268,7 @@ export default () => {
 					use: {
 						audio: "gzjiansu",
 						trigger: { player: "phaseUseBegin" },
-						filter: function (event, player) {
+						filter(event, player) {
 							var num = player.countCards("h", function (card) {
 								return card.hasGaintag("gzjiansu_tag");
 							});
@@ -7296,27 +7280,27 @@ export default () => {
 							);
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseCardTarget({
 									prompt: get.prompt("gzjiansu"),
 									prompt2: "弃置任意张“俭”，令一名体力值不大于你以此法弃置的牌数的角色回复1点体力",
-									filterCard: function (card) {
+									filterCard(card) {
 										return get.itemtype(card) == "card" && card.hasGaintag("gzjiansu_tag");
 									},
 									selectCard: [1, Infinity],
-									filterTarget: function (card, player, target) {
+									filterTarget(card, player, target) {
 										return target.isDamaged();
 									},
-									filterOk: function () {
+									filterOk() {
 										return ui.selected.targets.length && ui.selected.targets[0].hp <= ui.selected.cards.length;
 									},
-									ai1: function (card) {
+									ai1(card) {
 										if (ui.selected.targets.length && ui.selected.targets[0].hp <= ui.selected.cards.length) return 0;
 										return 6 - get.value(card);
 									},
-									ai2: function (target) {
+									ai2(target) {
 										var player = _status.event.player;
 										return get.recoverEffect(target, player, player);
 									},
@@ -7338,15 +7322,15 @@ export default () => {
 			gzzhuidu: {
 				audio: "twzhuidu",
 				trigger: { source: "damageBegin3" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.isPhaseUsing();
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return get.attitude(player, event.player) < 0;
 				},
 				usable: 1,
 				logTarget: "player",
-				content: function () {
+				content() {
 					"step 0";
 					var target = trigger.player;
 					event.target = target;
@@ -7383,14 +7367,14 @@ export default () => {
 			gzshigong: {
 				audio: "twshigong",
 				trigger: { player: "dying" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return _status.currentPhase && _status.currentPhase != player && _status.currentPhase.isIn() && player.hasViceCharacter() && player.hp <= 0;
 				},
 				skillAnimation: true,
 				animationColor: "gray",
 				limited: true,
 				logTarget: () => _status.currentPhase,
-				check: function (event, player) {
+				check(event, player) {
 					if (
 						player.countCards("h", function (card) {
 							var mod2 = game.checkMod(card, player, "unchanged", "cardEnabled2", player);
@@ -7406,7 +7390,7 @@ export default () => {
 						return false;
 					return true;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var target = _status.currentPhase;
 					event.target = target;
@@ -7451,17 +7435,17 @@ export default () => {
 				audio: "new_reyaowu",
 				limited: true,
 				trigger: { source: "damageSource" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.isUnseen(0) && lib.character[player.name1][3].includes("gzyaowu")) return true;
 					if (player.isUnseen(1) && lib.character[player.name2][3].includes("gzyaowu")) return true;
 					return false;
 				},
 				skillAnimation: true,
 				animationColor: "fire",
-				check: function (event, player) {
+				check(event, player) {
 					return player.isDamaged() || player.hp <= 2;
 				},
-				content: function () {
+				content() {
 					player.awakenSkill("gzyaowu");
 					player.gainMaxHp(2);
 					player.recover(2);
@@ -7472,7 +7456,7 @@ export default () => {
 					die: {
 						audio: "new_reyaowu",
 						trigger: { player: "dieAfter" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return game.hasPlayer(function (current) {
 								return current != player && current.isFriendOf(player);
 							});
@@ -7482,12 +7466,12 @@ export default () => {
 						charlotte: true,
 						skillAnimation: true,
 						animationColor: "fire",
-						logTarget: function (event, player) {
+						logTarget(event, player) {
 							return game.filterPlayer(function (current) {
 								return current != player && current.isFriendOf(player);
 							});
 						},
-						content: function () {
+						content() {
 							for (var target of lib.skill.gzyaowu_die.logTarget(trigger, player)) target.loseHp();
 						},
 					},
@@ -7497,17 +7481,17 @@ export default () => {
 				audio: "shiyong",
 				derivation: "gzshiyongx",
 				trigger: { player: "damageEnd" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!event.card) return false;
 					if (player.awakenedSkills.includes("gzyaowu")) return event.source && event.source.isIn() && get.color(event.card) != "black";
 					return get.color(event.card) != "red";
 				},
 				forced: true,
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					if (player.awakenedSkills.includes("gzyaowu")) return event.source;
 					return;
 				},
-				content: function () {
+				content() {
 					(lib.skill.gzshiyong.logTarget(trigger, player) || player).draw();
 				},
 			},
@@ -7515,14 +7499,14 @@ export default () => {
 			gztanfeng: {
 				audio: "twtanfeng",
 				trigger: { player: "phaseZhunbeiBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return !current.isFriendOf(player) && current.countDiscardableCards("hej", player) > 0;
 					});
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt2("gztanfeng"), function (card, player, target) {
@@ -7600,7 +7584,7 @@ export default () => {
 			gzwanyi: {
 				audio: "wanyi",
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.getStorage("gzwanyi2").length >= 4) return false;
 					if (_status.mode == "yingbian")
 						return player.hasCard(function (i) {
@@ -7611,41 +7595,41 @@ export default () => {
 					}, "hs");
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var list = ["lianjunshengyan", "huoshaolianying", "xietianzi", "lulitongxin"];
 						if (_status.mode == "yingbian") list = ["zhujinqiyuan", "chuqibuyi", "shuiyanqijunx", "dongzhuxianji"];
 						list.removeArray(player.getStorage("gzwanyi2"));
 						return ui.create.dialog("婉嫕", [list, "vcard"], "hidden");
 					},
-					filter: function (button, player) {
+					filter(button, player) {
 						return lib.filter.filterCard({ name: button.link[2] }, player, _status.event.getParent());
 					},
-					check: function (button) {
+					check(button) {
 						return _status.event.player.getUseValue({ name: button.link[2] });
 					},
-					backup: function (links) {
+					backup(links) {
 						return {
 							audio: "wanyi",
 							popname: true,
 							viewAs: {
 								name: links[0][2],
 							},
-							filterCard: function (card) {
+							filterCard(card) {
 								if (_status.mode == "yingbian") return get.is.yingbian(card);
 								return card.hasTag("lianheng");
 							},
-							check: function (card) {
+							check(card) {
 								return 1 / Math.max(1, get.value(card));
 							},
 							position: "hs",
-							onuse: function (links, player) {
+							onuse(links, player) {
 								if (!player.storage.gzwanyi2) player.storage.gzwanyi2 = [];
 								player.storage.gzwanyi2.add(links.card.name);
 								player.addTempSkill("gzwanyi2");
 							},
 						};
 					},
-					prompt: function (links) {
+					prompt(links) {
 						if (_status.mode == "yingbian") return "将一张应变牌当做" + get.translation(links[0][2]) + "使用";
 						return "将一张合纵牌当做" + get.translation(links[0][2]) + "使用";
 					},
@@ -7659,13 +7643,13 @@ export default () => {
 				limited: true,
 				trigger: { global: "useCardToTarget" },
 				logTarget: "player",
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.name == "sha" && event.target.isIn() && event.target.isFriendOf(player);
 				},
 				preHidden: true,
 				skillAnimation: true,
 				animationColor: "thunder",
-				check: function (event, player) {
+				check(event, player) {
 					var source = event.player,
 						targets = event.targets,
 						card = event.card;
@@ -7675,7 +7659,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					player.awakenSkill("gzmaihuo");
 					trigger.targets.length = 0;
 					trigger.getParent().triggeredTargets2.length = 0;
@@ -7690,10 +7674,10 @@ export default () => {
 						forced: true,
 						charlotte: true,
 						popup: false,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzmaihuo_effect").includes(event.player) && event.player.canUse("sha", player, false);
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var target = trigger.player;
 							player.unmarkAuto("gzmaihuo_effect", [target]);
@@ -7707,10 +7691,10 @@ export default () => {
 					remove: {
 						trigger: { player: "damageBegin2" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.card && event.card.name == "sha" && event.getParent().skill == "gzmaihuo_effect";
 						},
-						content: function () {
+						content() {
 							trigger.cancel();
 							player.draw(2);
 							if (player.checkMainSkill("gzmaihuo", false)) {
@@ -7735,7 +7719,7 @@ export default () => {
 				trigger: { player: "phaseJieshuBegin" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var num1 = player.countCards("h"),
 						num2 = num1;
 					player.getHistory("gain", function (evt) {
@@ -7746,7 +7730,7 @@ export default () => {
 					});
 					return num1 >= num2;
 				},
-				content: function () {
+				content() {
 					player.chooseDrawRecover(2, true);
 				},
 			},
@@ -7755,14 +7739,14 @@ export default () => {
 				audio: "zhaosong",
 				enable: "phaseUse",
 				preHidden: ["gzzhaosong_dying", "gzzhaosong_sha"],
-				filter: function (event, player) {
+				filter(event, player) {
 					return !player.getStorage("gzzhaosong").includes("效果②") && game.hasPlayer(current => lib.skill.gzzhaosong.filterTarget(null, player, current));
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && (target.isUnseen(2) || target.countCards("h") > 0);
 				},
 				promptfunc: () => "出牌阶段，你可观看一名其他角色的所有暗置武将牌和手牌，然后可以获得其区域内的一张牌。",
-				content: function () {
+				content() {
 					player.markAuto("gzzhaosong", ["效果②"]);
 					if (target.isUnseen(2)) player.viewCharacter(target, 2);
 					if (target.countCards("hej") > 0) player.gainPlayerCard(target, "hej", "visible");
@@ -7770,7 +7754,7 @@ export default () => {
 				ai: {
 					order: 11,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							return get.effect(target, { name: "zhibi" }, player, player) + get.effect(target, { name: "shunshou_copy" }, player, player);
 						},
 					},
@@ -7781,14 +7765,14 @@ export default () => {
 						audio: "zhaosong",
 						trigger: { global: "dying" },
 						logTarget: "player",
-						filter: function (event, player) {
+						filter(event, player) {
 							return !player.getStorage("gzzhaosong").includes("效果①") && event.player.isDying() && event.player.hp <= 0;
 						},
 						prompt2: "令该角色回复至2点体力并摸一张牌",
-						check: function (event, player) {
+						check(event, player) {
 							return event.player.isFriendOf(player) && get.attitude(player, event.player) > 0;
 						},
-						content: function () {
+						content() {
 							player.markAuto("gzzhaosong", ["效果①"]);
 							var target = trigger.player,
 								num = 2 - target.hp;
@@ -7800,13 +7784,13 @@ export default () => {
 						audio: "zhaosong",
 						trigger: { global: "useCard2" },
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.card.name != "sha" || player.getStorage("gzzhaosong").includes("效果③")) return false;
 							return game.hasPlayer(function (current) {
 								return !event.targets.includes(current) && lib.filter.filterTarget(event.card, event.player, current);
 							});
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget([1, 2], get.prompt("gzzhaosong"), "为" + get.translation(trigger.card) + "增加至多两个目标", function (card, player, target) {
@@ -7846,11 +7830,11 @@ export default () => {
 			gzlisi: {
 				audio: "lisi",
 				trigger: { global: "dieAfter" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isFriendOf(player) && player.getStorage("gzzhaosong").length > 0;
 				},
 				direct: true,
-				content: function () {
+				content() {
 					"step 0";
 					var list = player.getStorage("gzzhaosong").slice(0);
 					list.push("cancel2");
@@ -7866,7 +7850,7 @@ export default () => {
 			gzxuanbei: {
 				audio: "xuanbei",
 				trigger: { player: "showCharacterAfter" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						!player.storage.gzxuanbei &&
 						event.toShow.some(name => {
@@ -7876,7 +7860,7 @@ export default () => {
 				},
 				forced: true,
 				locked: false,
-				content: function () {
+				content() {
 					"step 0";
 					player.storage.gzxuanbei = true;
 					var cards = [];
@@ -7900,10 +7884,10 @@ export default () => {
 						forced: true,
 						popup: false,
 						charlotte: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return get.cardtag(event.card, "lianheng");
 						},
-						content: function () {
+						content() {
 							player.draw();
 						},
 						ai: { forceYingbian: true },
@@ -7917,7 +7901,7 @@ export default () => {
 						forceDie: true,
 						skillAnimation: true,
 						animationColor: "thunder",
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget(get.prompt("gzxuanbei"), "令一名其他角色变更副将", lib.filter.notMe)
@@ -7947,7 +7931,7 @@ export default () => {
 				audio: "yimie",
 				inherit: "yimie",
 				mainSkill: true,
-				init: function (player) {
+				init(player) {
 					if (player.checkMainSkill("gzyimie")) {
 						player.removeMaxHp(2);
 					}
@@ -7956,7 +7940,7 @@ export default () => {
 			gztairan: {
 				audio: "tairan",
 				trigger: { player: "phaseUseBegin" },
-				check: function (event, player) {
+				check(event, player) {
 					return (
 						player.isDamaged() &&
 						player.hasCard(function (card) {
@@ -7964,7 +7948,7 @@ export default () => {
 						}, "he")
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var list = [],
 						num = 0;
@@ -8007,14 +7991,14 @@ export default () => {
 					effect: {
 						audio: "tairan",
 						trigger: { player: "phaseEnd" },
-						filter: function (event, player) {
+						filter(event, player) {
 							var storage = player.storage.gztairan_effect;
 							return storage && storage.length == 2 && (storage[1] > 0 || player.isDamaged());
 						},
 						forced: true,
 						charlotte: true,
 						onremove: true,
-						content: function () {
+						content() {
 							var storage = player.storage.gztairan_effect;
 							if (storage[0] > 0) player.recover(storage[0]);
 							if (storage[1] > 0) player.draw(storage[1]);
@@ -8119,7 +8103,7 @@ export default () => {
 				global: "gzbolan_global",
 				enable: "phaseUse",
 				usable: 1,
-				content: function () {
+				content() {
 					"step 0";
 					if ((event.num && event.num > 0) || !_status.characterlist.length) {
 						event.finish();
@@ -8165,7 +8149,7 @@ export default () => {
 				subSkill: {
 					global: {
 						inherit: "gzbolan",
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								!player.hasSkill("gzbolan", true) &&
 								game.hasPlayer(function (current) {
@@ -8174,16 +8158,16 @@ export default () => {
 							);
 						},
 						selectTarget: -1,
-						filterTarget: function (card, player, target) {
+						filterTarget(card, player, target) {
 							return target != player && target.hasSkill("gzbolan");
 						},
-						contentAfter: function () {
+						contentAfter() {
 							player.loseHp();
 						},
 						ai: {
 							order: 10,
 							result: {
-								player: function (player, target) {
+								player(player, target) {
 									if (get.effect(player, { name: "losehp" }, player, player) > 0) return 3;
 									if (player.isHealthy()) return 1;
 									return -1;
@@ -8197,7 +8181,7 @@ export default () => {
 			gzchoufa: {
 				audio: "choufa",
 				inherit: "choufa",
-				content: function () {
+				content() {
 					"step 0";
 					player.choosePlayerCard(target, "h", true);
 					"step 1";
@@ -8216,17 +8200,17 @@ export default () => {
 			gzhuishi: {
 				audio: 2,
 				trigger: { player: "phaseDrawBegin1" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return ui.discardPile.childNodes.length > 0;
 				},
 				preHidden: true,
-				prompt: function () {
+				prompt() {
 					return get.prompt("huishi") + "（可观看牌数：" + lib.skill.gzhuishi.getNum() + "）";
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return lib.skill.gzhuishi.getNum() > 3;
 				},
-				getNum: function () {
+				getNum() {
 					var list = [];
 					list.push(ui.discardPile.lastChild);
 					if (list[0].previousSibling) list.push(list[0].previousSibling);
@@ -8238,7 +8222,7 @@ export default () => {
 					}
 					return num;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					trigger.changeToZero();
 					var cards = game.cardsGotoOrdering(get.cards(lib.skill.gzhuishi.getNum())).cards;
@@ -8272,11 +8256,11 @@ export default () => {
 				trigger: { global: "phaseEnd" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var target = event.player;
 					return target != player && target.isIn() && target.isUnseen(2) && player.countCards("he") > 0 && player.canUse({ name: "sha", nature: "ice" }, target, false);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCard("he", get.prompt("gzqingleng", trigger.player), "将一张牌当做冰【杀】对其使用", function (card, player) {
@@ -8302,7 +8286,7 @@ export default () => {
 				audio: "quanbian",
 				preHidden: true,
 				trigger: { player: ["useCard", "respond"] },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.hasSkill("gzquanbian_blocker")) return false;
 					var phase = event.getParent("phaseUse");
 					if (!phase || phase.player != player) return false;
@@ -8318,7 +8302,7 @@ export default () => {
 						0
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var cards = get.cards(player.maxHp);
 					for (var i = cards.length - 1; i >= 0; i--) {
@@ -8390,10 +8374,10 @@ export default () => {
 				audio: "dcmingfa",
 				enable: "phaseUse",
 				usable: 1,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return player != target && target.isEnemyOf(player);
 				},
-				content: function () {
+				content() {
 					player.markAuto("gzmingfa", targets);
 					game.delayx();
 				},
@@ -8408,11 +8392,11 @@ export default () => {
 						audio: "dcmingfa",
 						trigger: { global: "phaseEnd" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzmingfa").includes(event.player);
 						},
 						logTarget: "player",
-						content: function () {
+						content() {
 							var target = trigger.player;
 							player.unmarkAuto("gzmingfa", [target]);
 							if (target.isIn()) {
@@ -8441,7 +8425,7 @@ export default () => {
 			gzjilei: {
 				inherit: "jilei",
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseControl("basic", "trick", "equip", "cancel2", function () {
@@ -8481,10 +8465,10 @@ export default () => {
 				trigger: { global: "judge" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("hes") > 0 && event.player.isFriendOf(player);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCard(get.translation(trigger.player) + "的" + (trigger.judgestr || "") + "判定为" + get.translation(trigger.player.judging[0]) + "，" + get.prompt("gzhuanshi"), "hes", function (card) {
@@ -8545,22 +8529,22 @@ export default () => {
 				audio: "hongyuan",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hasCard(function (card) {
 						return lib.skill.gzhongyuan.filterCard(card);
 					}, "h");
 				},
-				filterCard: function (card) {
+				filterCard(card) {
 					return !card.hasTag("lianheng") && !card.hasGaintag("_lianheng");
 				},
 				position: "h",
 				discard: false,
 				lose: false,
-				content: function () {
+				content() {
 					cards[0].addGaintag("_lianheng");
 					player.addTempSkill("gzhongyuan_clear");
 				},
-				check: function (card) {
+				check(card) {
 					return 4.5 - get.value(card);
 				},
 				group: "gzhongyuan_draw",
@@ -8569,7 +8553,7 @@ export default () => {
 				subSkill: {
 					clear: {
 						charlotte: true,
-						onremove: function (player) {
+						onremove(player) {
 							player.removeGaintag("_lianheng");
 						},
 					},
@@ -8577,7 +8561,7 @@ export default () => {
 						audio: "hongyuan",
 						trigger: { player: "drawBefore" },
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								event.getParent().name == "_lianheng" &&
 								game.hasPlayer(function (current) {
@@ -8585,7 +8569,7 @@ export default () => {
 								})
 							);
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget(get.prompt("gzhongyuan"), "将摸牌（" + get.cnNumber(trigger.num) + "张）转移给一名同势力角色", function (card, player, target) {
@@ -8610,7 +8594,7 @@ export default () => {
 					player: ["loseAfter", "useCard", "respond"],
 					global: ["equipAfter", "addJudgeAfter", "gainAfter", "loseAsyncAfter", "addToExpansionAfter"],
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player == _status.currentPhase) return false;
 					if (event.name == "useCard" || event.name == "respond") {
 						return (
@@ -8629,7 +8613,7 @@ export default () => {
 				},
 				frequent: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					player.draw();
 				},
 			},
@@ -8640,7 +8624,7 @@ export default () => {
 				preHidden: true,
 				audio: "dangxian",
 				audioname: ["guansuo"],
-				content: function () {
+				content() {
 					var next = player.phaseUse();
 					event.next.remove(next);
 					trigger.next.push(next);
@@ -8651,14 +8635,14 @@ export default () => {
 						audio: "dangxian",
 						trigger: { player: "showCharacterAfter" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								event.toShow.some(name => {
 									return get.character(name, 3).includes("gzdangxian");
 								}) && !player.storage.gzdangxian_draw
 							);
 						},
-						content: function () {
+						content() {
 							player.storage.gzdangxian_draw = true;
 							player.addMark("xianqu_mark", 1);
 						},
@@ -8672,10 +8656,10 @@ export default () => {
 				trigger: { player: "phaseDrawEnd" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("he") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseToDiscard("he", get.prompt2("gzluoyi"))
@@ -8700,10 +8684,10 @@ export default () => {
 						charlotte: true,
 						forced: true,
 						trigger: { source: "damageBegin1" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.card && (event.card.name == "sha" || event.card.name == "juedou") && event.getParent().type == "card";
 						},
-						content: function () {
+						content() {
 							trigger.num++;
 						},
 					},
@@ -8713,7 +8697,7 @@ export default () => {
 			gzqiangxi: {
 				audio: "qiangxi",
 				inherit: "qiangxi",
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player;
 				},
 			},
@@ -8725,27 +8709,27 @@ export default () => {
 				direct: true,
 				preHidden: true,
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("h", function (card) {
 							return _status.connectMode || get.suit(card, player) == "heart";
 						}) > 0 && event.num > 0
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCardTarget({
-							filterCard: function (card, player) {
+							filterCard(card, player) {
 								return get.suit(card) == "heart" && lib.filter.cardDiscardable(card, player);
 							},
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								return player != target;
 							},
-							ai1: function (card) {
+							ai1(card) {
 								return 10 - get.value(card);
 							},
-							ai2: function (target) {
+							ai2(target) {
 								var att = get.attitude(_status.event.player, target);
 								var trigger = _status.event.getTrigger();
 								var da = 0;
@@ -8812,7 +8796,7 @@ export default () => {
 				ai: {
 					maixie_defend: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (player.hasSkillTag("jueqing", false, target)) return;
 							if (get.tag(card, "damage") && target.countCards("he") > 1) return 0.7;
 						},
@@ -8821,10 +8805,10 @@ export default () => {
 			},
 			gzhongyan: {
 				mod: {
-					suit: function (card, suit) {
+					suit(card, suit) {
 						if (suit == "spade") return "heart";
 					},
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						if (
 							player.hasCard(function (card) {
 								return get.suit(card, player) == "heart";
@@ -8840,20 +8824,20 @@ export default () => {
 				audioname2: { gz_jun_liubei: "shouyue_liegong" },
 				locked: false,
 				mod: {
-					targetInRange: function (card, player, target) {
+					targetInRange(card, player, target) {
 						if (card.name == "sha" && target.countCards("h") < player.countCards("h")) return true;
 					},
-					attackRange: function (player, distance) {
+					attackRange(player, distance) {
 						if (get.zhu(player, "shouyue")) return distance + 1;
 					},
 				},
 				trigger: { player: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.name == "sha" && player.hp <= event.target.hp;
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var str = get.translation(trigger.target),
 						card = get.translation(trigger.card);
@@ -8900,10 +8884,10 @@ export default () => {
 				trigger: { player: "useCardToPlayered" },
 				preHidden: true,
 				logTarget: "target",
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.name == "sha" && player.isPhaseUsing() && !player.hasSkill("gzkuangfu_extra") && event.target.countGainableCards(player, "e") > 0;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					if (
 						get.attitude(player, event.target) > 0 ||
 						!event.target.hasCard(function (card) {
@@ -8913,7 +8897,7 @@ export default () => {
 						return false;
 					return true;
 				},
-				content: function () {
+				content() {
 					trigger.getParent()._gzkuangfued = true;
 					player.gainPlayerCard(trigger.target, "e", true);
 					player.addTempSkill("gzkuangfu_extra", "phaseUseAfter");
@@ -8923,7 +8907,7 @@ export default () => {
 						trigger: { player: "useCardAfter" },
 						charlotte: true,
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								event._gzkuangfued &&
 								!player.hasHistory("sourceDamage", function (evt) {
@@ -8932,7 +8916,7 @@ export default () => {
 								player.countCards("h") > 0
 							);
 						},
-						content: function () {
+						content() {
 							player.chooseToDiscard("h", 2, true);
 						},
 					},
@@ -8948,7 +8932,7 @@ export default () => {
 				preHidden: ["wushuang1", "wushuang2", "gzwushuang"],
 				trigger: { player: "useCard1" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.card.name != "juedou" || !event.card.isCard) return false;
 					if (event.targets) {
 						if (
@@ -8961,7 +8945,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var num = game.countPlayer(function (current) {
 						return !trigger.targets.includes(current) && lib.filter.targetEnabled2(trigger.card, player, current);
@@ -8996,10 +8980,10 @@ export default () => {
 				preHidden: ["gzshensu_1", "gzshensu_2", "gzshensu"],
 				trigger: { player: "phaseDiscardBegin" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hp > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt("gzshensu"), "失去1点体力并跳过弃牌阶段，视为对一名其他角色使用一张无距离限制的【杀】", function (card, player, target) {
@@ -9037,7 +9021,7 @@ export default () => {
 			gzshenwei: {
 				audio: "llqshenwei",
 				mainSkill: true,
-				init: function (player) {
+				init(player) {
 					if (player.checkMainSkill("gzshenwei")) {
 						player.removeMaxHp();
 					}
@@ -9047,7 +9031,7 @@ export default () => {
 				locked: false,
 				filter: (event, player) => !event.numFixed && player.isMaxHandcard(),
 				preHidden: true,
-				content: function () {
+				content() {
 					trigger.num += 2;
 				},
 				mod: {
@@ -9058,7 +9042,7 @@ export default () => {
 				audio: "zhuangrong",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						!player.hasSkill("gzwushuang") &&
 						player.hasCard(function (card) {
@@ -9066,10 +9050,10 @@ export default () => {
 						}, "h")
 					);
 				},
-				filterCard: function (card, player) {
+				filterCard(card, player) {
 					return get.type2(card, player) == "trick";
 				},
-				content: function () {
+				content() {
 					player.addTempSkill("gzwushuang", "phaseUseEnd");
 				},
 				derivation: "gzwushuang",
@@ -9081,7 +9065,7 @@ export default () => {
 				derivation: "gzfenglve_zongheng",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("h") > 0 &&
 						!player.hasSkillTag("noCompareSource") &&
@@ -9090,10 +9074,10 @@ export default () => {
 						})
 					);
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && target.countCards("h") > 0 && !target.hasSkillTag("noCompareTarget");
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseToCompare(target);
 					"step 1";
@@ -9132,7 +9116,7 @@ export default () => {
 				ai: {
 					order: 8,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (
 								!player.hasCard(function (card) {
 									if (get.position(card) != "h") return false;
@@ -9155,7 +9139,7 @@ export default () => {
 			},
 			gzfenglve_zongheng: {
 				inherit: "gzfenglve",
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseToCompare(target);
 					"step 1";
@@ -9182,7 +9166,7 @@ export default () => {
 				ai: {
 					order: 8,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (
 								!player.hasCard(function (card) {
 									if (get.position(card) != "h") return false;
@@ -9207,10 +9191,10 @@ export default () => {
 				audio: "anyong",
 				trigger: { global: "damageBegin1" },
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.source && event.player != event.source && event.source.isFriendOf(player) && event.player.isIn();
 				},
-				check: function (event, player) {
+				check(event, player) {
 					if (get.attitude(player, event.player) > 0) return false;
 					if (
 						event.player.hasSkillTag("filterDamage", null, {
@@ -9225,7 +9209,7 @@ export default () => {
 				},
 				logTarget: "player",
 				preHidden: true,
-				content: function () {
+				content() {
 					trigger.num *= 2;
 					if (!trigger.player.isUnseen(2)) {
 						player.loseHp();
@@ -9240,7 +9224,7 @@ export default () => {
 				audio: "zhukou",
 				trigger: { source: "damageSource" },
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!player.getHistory("useCard").length) return false;
 					var evt = event.getParent("phaseUse");
 					if (!evt || !evt.player) return false;
@@ -9253,7 +9237,7 @@ export default () => {
 					);
 				},
 				frequent: true,
-				content: function () {
+				content() {
 					player.draw(Math.min(player.getHistory("useCard").length, 5));
 				},
 			},
@@ -9261,7 +9245,7 @@ export default () => {
 				audio: 2,
 				trigger: { player: "phaseUseEnd" },
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("h") > 0 &&
 						!player.hasCard(function (card) {
@@ -9269,14 +9253,14 @@ export default () => {
 						}, "h")
 					);
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return (
 						player.countCards("h", function (card) {
 							return get.value(card) >= 6;
 						}) <= Math.max(1, player.countCards("h") / 2)
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var cards = player.getCards("h", function (card) {
 						return lib.filter.cardDiscardable(card, player, "gzduannian");
@@ -9294,7 +9278,7 @@ export default () => {
 				forceDie: true,
 				skillAnimation: true,
 				animationColor: "fire",
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(lib.filter.notMe, get.prompt("gzlianyou"), "令一名其他角色获得〖兴火〗")
@@ -9315,10 +9299,10 @@ export default () => {
 			gzxinghuo: {
 				trigger: { source: "damageBegin1" },
 				forced: true,
-				filter: function (event) {
+				filter(event) {
 					return event.hasNature("fire");
 				},
-				content: function () {
+				content() {
 					trigger.num++;
 				},
 			},
@@ -9327,10 +9311,10 @@ export default () => {
 				audio: "gongxiu",
 				trigger: { player: "phaseDrawBegin2" },
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return !event.numFixed && event.num > 0 && player.maxHp > 0;
 				},
-				content: function () {
+				content() {
 					trigger.num--;
 					player.addTempSkill("gzgongxiu2", "phaseDrawAfter");
 				},
@@ -9340,7 +9324,7 @@ export default () => {
 				forced: true,
 				charlotte: true,
 				popup: false,
-				content: function () {
+				content() {
 					"step 0";
 					var str = "令至多" + get.cnNumber(player.maxHp) + "名角色";
 					if (typeof player.storage.gzgongxiu != "number") {
@@ -9374,21 +9358,21 @@ export default () => {
 			gzjinghe: {
 				audio: "jinghe",
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.maxHp > 0 && player.countCards("h") > 0 && !player.hasSkill("gzjinghe_clear");
 				},
-				selectCard: function () {
+				selectCard() {
 					var max = _status.event.player.maxHp;
 					if (ui.selected.targets.length) return [ui.selected.targets.length, max];
 					return [1, max];
 				},
-				selectTarget: function () {
+				selectTarget() {
 					return ui.selected.cards.length;
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return !target.isUnseen();
 				},
-				filterCard: function (card) {
+				filterCard(card) {
 					if (ui.selected.cards.length) {
 						var name = get.name(card);
 						for (var i of ui.selected.cards) {
@@ -9398,7 +9382,7 @@ export default () => {
 					return true;
 				},
 				position: "h",
-				check: function (card) {
+				check(card) {
 					var player = _status.event.player;
 					if (
 						game.countPlayer(function (current) {
@@ -9414,7 +9398,7 @@ export default () => {
 				delay: false,
 				multitarget: true,
 				multiline: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.showCards(cards, get.translation(player) + "发动了【经合】");
 					event.skills = lib.skill.gzjinghe.derivation.randomGets(targets.length);
@@ -9454,7 +9438,7 @@ export default () => {
 				derivation: ["leiji", "nhyinbing", "nhhuoqi", "nhguizhu", "nhxianshou", "nhlundao", "nhguanyue", "nhyanzheng"],
 				subSkill: {
 					clear: {
-						onremove: function (player) {
+						onremove(player) {
 							game.countPlayer(function (current) {
 								current.removeAdditionalSkills("gzjinghe_" + player.playerid);
 							});
@@ -9467,11 +9451,11 @@ export default () => {
 				audio: "zyshilu",
 				preHidden: true,
 				trigger: { global: "dieAfter" },
-				prompt2: function (event, player) {
+				prompt2(event, player) {
 					return "将其的所有武将牌" + (player == event.source ? "及武将牌库里的两张随机武将牌" : "") + "置于武将牌上作为“戮”";
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					var list = [],
 						target = trigger.player;
 					if (target.name1 && target.name1.indexOf("gz_shibing") != 0 && _status.characterlist.includes(target.name1)) list.push(target.name1);
@@ -9503,13 +9487,13 @@ export default () => {
 				marktext: "戮",
 				intro: {
 					content: "character",
-					onunmark: function (storage, player) {
+					onunmark(storage, player) {
 						if (storage && storage.length) {
 							_status.characterlist.addArray(storage);
 							storage.length = 0;
 						}
 					},
-					mark: function (dialog, storage, player) {
+					mark(dialog, storage, player) {
 						if (storage && storage.length) {
 							dialog.addSmall([storage, "character"]);
 						} else {
@@ -9525,11 +9509,11 @@ export default () => {
 					zhiheng: {
 						audio: "gzshilu",
 						trigger: { player: "phaseZhunbeiBegin" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzshilu").length > 0 && player.countCards("he") > 0;
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							var num = Math.min(player.getStorage("gzshilu").length, player.countCards("he"));
 							player.chooseToDiscard("he", get.prompt("gzshilu"), "弃置至多" + get.cnNumber(num) + "张牌并摸等量的牌", [1, num]).logSkill = "gzshilu";
@@ -9543,10 +9527,10 @@ export default () => {
 				audio: "zyxiongnve",
 				trigger: { player: "phaseUseBegin" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.getStorage("gzshilu").length > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseButton([get.prompt("gzxiongnve"), [player.storage.gzshilu, "character"]])
@@ -9602,7 +9586,7 @@ export default () => {
 					game.log(player, "本回合对" + get.translation(event.group) + "势力的角色", "#g" + lib.skill[skill].promptx);
 				},
 				group: "gzxiongnve_end",
-				throwCharacter: function (player, list) {
+				throwCharacter(player, list) {
 					player.unmarkAuto("gzshilu", list);
 					_status.characterlist.addArray(list);
 					game.log(player, "从", "#y“戮”", "中移去了", "#g" + get.translation(list));
@@ -9635,11 +9619,11 @@ export default () => {
 						},
 						trigger: { source: "damageBegin1" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzxiongnve_effect0").includes(event.player.identity);
 						},
 						logTarget: "player",
-						content: function () {
+						content() {
 							trigger.num++;
 						},
 					},
@@ -9653,11 +9637,11 @@ export default () => {
 						},
 						trigger: { source: "damageEnd" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzxiongnve_effect1").includes(event.player.identity) && event.player.countGainableCards(player, "he") > 0;
 						},
 						logTarget: "player",
-						content: function () {
+						content() {
 							player.gainPlayerCard(trigger.player, true, "he");
 						},
 					},
@@ -9669,7 +9653,7 @@ export default () => {
 							content: "对$势力的角色使用牌没有次数限制",
 						},
 						mod: {
-							cardUsableTarget: function (card, player, target) {
+							cardUsableTarget(card, player, target) {
 								if (player.getStorage("gzxiongnve_effect2").includes(target.identity)) return true;
 							},
 						},
@@ -9682,17 +9666,17 @@ export default () => {
 							content: "其他角色对你造成伤害时，此伤害-1",
 						},
 						trigger: { player: "damageBegin3" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.source && event.source != player;
 						},
 						forced: true,
 						logTarget: "source",
-						content: function () {
+						content() {
 							trigger.num--;
 						},
 						ai: {
 							effect: {
-								target: function (card, player, target) {
+								target(card, player, target) {
 									if (target == player) return;
 									if (player.hasSkillTag("jueqing", false, target)) return;
 									var num = get.tag(card, "damage");
@@ -9707,10 +9691,10 @@ export default () => {
 					end: {
 						trigger: { player: "phaseUseEnd" },
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getStorage("gzshilu").length > 1;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player.chooseButton(["是否移去两张“戮”获得减伤？", [player.storage.gzshilu, "character"]], 2).set("ai", function (button) {
 								var name = button.link,
@@ -9743,10 +9727,10 @@ export default () => {
 				trigger: { player: "phaseDrawBegin2" },
 				frequent: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.isMinHandcard();
 				},
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					var isFriend;
 					if (player.identity == "unknown") {
 						var group = "shu";
@@ -9760,7 +9744,7 @@ export default () => {
 						};
 					return game.filterPlayer(isFriend);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var list = game.filterPlayer(function (current) {
 						return current.isFriendOf(player);
@@ -9777,10 +9761,10 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				usable: 1,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && target.countGainableCards(player, "h") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.gainPlayerCard(target, "h", true, event.name == "gzweimeng" ? [1, player.hp] : 1);
 					"step 1";
@@ -9831,7 +9815,7 @@ export default () => {
 						gain: 1,
 					},
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							return -Math.pow(Math.min(player.hp, target.countCards("h")), 2) / 4;
 						},
 					},
@@ -9844,11 +9828,11 @@ export default () => {
 				global: "huoshui_mingzhi",
 				trigger: { player: "useCardToTargeted" },
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (event.card.name == "sha" || event.card.name == "wanjian") && event.target.isUnseen(2) && event.target.isEnemyOf(player);
 				},
 				logTarget: "target",
-				content: function () {
+				content() {
 					var target = trigger.target;
 					target.addTempSkill("huoshui_norespond");
 					target.markAuto("huoshui_norespond", [trigger.card]);
@@ -9862,18 +9846,18 @@ export default () => {
 				popup: false,
 				silent: true,
 				firstDo: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.getStorage("huoshui_norespond").includes(event.card);
 				},
-				content: function () {
+				content() {
 					player.unmarkAuto("huoshui_norespond", [trigger.card]);
 					if (!player.storage.huoshui_norespond.length) player.removeSkill("huoshui_norespond");
 				},
 				mod: {
-					cardEnabled: function (card) {
+					cardEnabled(card) {
 						if (card.name == "shan") return false;
 					},
-					cardRespondable: function (card) {
+					cardRespondable(card) {
 						if (card.name == "shan") return false;
 					},
 				},
@@ -9881,7 +9865,7 @@ export default () => {
 			huoshui_mingzhi: {
 				ai: {
 					nomingzhi: true,
-					skillTagFilter: function (player) {
+					skillTagFilter(player) {
 						if (_status.currentPhase && _status.currentPhase != player && _status.currentPhase.hasSkill("huoshui")) {
 							return true;
 						}
@@ -9895,7 +9879,7 @@ export default () => {
 			qingcheng_ai: {
 				ai: {
 					effect: {
-						target: function (card) {
+						target(card) {
 							if (get.tag(card, "damage")) return 2;
 						},
 					},
@@ -9905,7 +9889,7 @@ export default () => {
 			gzjuejue: {
 				audio: 2,
 				trigger: { player: "phaseDiscardBegin" },
-				check: function (event, player) {
+				check(event, player) {
 					return (
 						player.hp > 2 &&
 						player.needsToDiscard() > 0 &&
@@ -9916,7 +9900,7 @@ export default () => {
 					);
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					player.addTempSkill("gzjuejue_effect");
 					player.loseHp();
 				},
@@ -9926,14 +9910,14 @@ export default () => {
 						forced: true,
 						charlotte: true,
 						popup: false,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								player.getHistory("lose", function (evt) {
 									return evt.type == "discard" && evt.cards2 && evt.cards2.length > 0 && evt.getParent("phaseDiscard") == event;
 								}).length > 0
 							);
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var num = 0;
 							player.getHistory("lose", function (evt) {
@@ -9972,7 +9956,7 @@ export default () => {
 				},
 				ai: {
 					noDieAfter2: true,
-					skillTagFilter: function (player, tag, target) {
+					skillTagFilter(player, tag, target) {
 						return target.isFriendOf(player);
 					},
 				},
@@ -9983,7 +9967,7 @@ export default () => {
 				zhenfa: "siege",
 				direct: true,
 				locked: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						game.countPlayer() > 4 &&
 						game.hasPlayer(function (current) {
@@ -9992,7 +9976,7 @@ export default () => {
 					);
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var list = game.filterPlayer(function (current) {
 						return player.sieged(current) && player.canUse("sha", current, false);
@@ -10034,7 +10018,7 @@ export default () => {
 				subSkill: {
 					siege: {
 						mod: {
-							maxHandcard: function (player, num) {
+							maxHandcard(player, num) {
 								if (game.countPlayer() < 4) return;
 								var next = player.getNext(),
 									prev = player.getPrevious(),
@@ -10063,7 +10047,7 @@ export default () => {
 				trigger: { global: "phaseUseBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (
 						!player.isFriendOf(event.player) ||
 						!game.hasPlayer(function (current) {
@@ -10076,16 +10060,16 @@ export default () => {
 						return get.type2(card, player) == "trick";
 					});
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCardTarget({
 							prompt: get.prompt("daming"),
 							prompt2: "弃置一张锦囊牌并选择要横置的角色",
-							filterCard: function (card, player) {
+							filterCard(card, player) {
 								return get.type2(card, player) == "trick" && lib.filter.cardDiscardable(card, player, "daming");
 							},
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								return !target.isLinked();
 							},
 							goon: (function () {
@@ -10100,11 +10084,11 @@ export default () => {
 									return true;
 								return false;
 							})(),
-							ai1: function (card) {
+							ai1(card) {
 								if (_status.event.goon) return 7 - get.value(card);
 								return 0;
 							},
-							ai2: function (target) {
+							ai2(target) {
 								var player = _status.event.player;
 								return (
 									(target.identity != "unknown" &&
@@ -10201,7 +10185,7 @@ export default () => {
 					target: "useCardToTargeted",
 				},
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var type = get.type2(event.card);
 					if (type != "basic" && type != "trick") return false;
 					var list = game.filterPlayer(function (current) {
@@ -10216,7 +10200,7 @@ export default () => {
 				},
 				check: () => false,
 				preHidden: true,
-				content: function () {
+				content() {
 					if (trigger.name == "useCard") trigger.directHit.addArray(game.players);
 					else trigger.directHit.add(player);
 				},
@@ -10224,7 +10208,7 @@ export default () => {
 				ai: {
 					halfneg: true,
 					directHit_ai: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (!arg.card) return false;
 						var type = get.type2(arg.card);
 						if (type != "basic" && type != "trick") return false;
@@ -10249,7 +10233,7 @@ export default () => {
 					ai: {
 						ai: {
 							directHit_ai: true,
-							skillTagFilter: function (playerx, tag, arg) {
+							skillTagFilter(playerx, tag, arg) {
 								if (!arg.card) return false;
 								var type = get.type2(arg.card);
 								if (type != "basic" && type != "trick") return false;
@@ -10282,7 +10266,7 @@ export default () => {
 				trigger: { global: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if ((player != event.player && !player.hasSkill("gztongduo")) || !event.player.isFriendOf(player)) return false;
 					return (
 						event.player.getHistory("lose", function (evt) {
@@ -10290,7 +10274,7 @@ export default () => {
 						}).length > 0
 					);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var num = 0;
 					trigger.player.getHistory("lose", function (evt) {
@@ -10312,7 +10296,7 @@ export default () => {
 				enable: "phaseUse",
 				limited: true,
 				delay: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					var isFriend;
 					if (player.identity == "unknown") {
 						var group = "shu";
@@ -10329,7 +10313,7 @@ export default () => {
 					});
 				},
 				selectTarget: -1,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (player == target) return true;
 					if (player.identity == "unknown") {
 						var group = "shu";
@@ -10344,7 +10328,7 @@ export default () => {
 				multiline: true,
 				skillAnimation: true,
 				animationColor: "orange",
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("qingyin");
 					event.num = 0;
@@ -10359,7 +10343,7 @@ export default () => {
 					if (lib.character[player.name2][3].includes("qingyin")) player.removeCharacter(1);
 				},
 				ai: {
-					order: function (item, player) {
+					order(item, player) {
 						var isFriend;
 						if (player.identity == "unknown") {
 							var group = "shu";
@@ -10394,7 +10378,7 @@ export default () => {
 				trigger: { global: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player != event.player && !player.hasSkill("gzlianpian")) return false;
 					var num = 0;
 					game.getGlobalHistory("cardMove", function (evt) {
@@ -10407,7 +10391,7 @@ export default () => {
 						});
 					return player.countDiscardableCards(event.player, "he") > 0 || player.isDamaged();
 				},
-				content: function () {
+				content() {
 					"step 0";
 					if (player == trigger.player) {
 						player
@@ -10469,11 +10453,11 @@ export default () => {
 			gzyusui: {
 				audio: "yusui",
 				trigger: { target: "useCardToTargeted" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player != player && event.player.isIn() && event.player.isEnemyOf(player) && get.color(event.card) == "black";
 				},
 				logTarget: "player",
-				check: function (event, player) {
+				check(event, player) {
 					var target = event.player;
 					if (player.hp < 3 || get.attitude(player, target) > -3) return false;
 					if (player.hp < target.hp) return true;
@@ -10482,7 +10466,7 @@ export default () => {
 				},
 				usable: 1,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.loseHp();
 					event.target = trigger.player;
@@ -10513,13 +10497,13 @@ export default () => {
 				audio: "boyan",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(target => lib.skill.gzboyan.filterTarget(null, player, target));
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && target.countCards("h") < target.maxHp;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					target.draw(Math.min(5, target.maxHp - target.countCards("h")));
 					"step 1";
@@ -10543,13 +10527,13 @@ export default () => {
 						enable: "phaseUse",
 						usable: 1,
 						filterTarget: lib.filter.notMe,
-						content: function () {
+						content() {
 							target.addTempSkill("gzboyan_block");
 						},
 						ai: {
 							order: 4,
 							result: {
-								target: function (player, target) {
+								target(player, target) {
 									if (
 										target.countCards("h", "shan") &&
 										!target.hasSkillTag("respondShan", true, null, true) &&
@@ -10568,7 +10552,7 @@ export default () => {
 						intro: { content: "不能使用或打出手牌" },
 						charlotte: true,
 						mod: {
-							cardEnabled2: function (card) {
+							cardEnabled2(card) {
 								if (get.position(card) == "h") return false;
 							},
 						},
@@ -10586,7 +10570,7 @@ export default () => {
 						return 10;
 					},
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (get.attitude(player, target) > 0) return Math.min(5, target.maxHp - target.countCards("h"));
 							if (
 								target.maxHp - target.countCards("h") == 1 &&
@@ -10606,7 +10590,7 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("he") > 0 &&
 						game.hasPlayer(function (current) {
@@ -10616,13 +10600,13 @@ export default () => {
 				},
 				filterCard: true,
 				position: "he",
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && target.countCards("he") > 0;
 				},
-				check: function (card) {
+				check(card) {
 					return 6 - get.value(card);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					target
 						.chooseCard("he", "交给" + get.translation(player) + "一张装备牌，或令其获得你的一张牌", { type: "equip" })
@@ -10642,7 +10626,7 @@ export default () => {
 				ai: {
 					order: 6,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							if (
 								target.countCards("e", function (card) {
 									return get.suit(card) == "spade" && get.value(card) < 8;
@@ -10652,7 +10636,7 @@ export default () => {
 								return get.effect(player, { name: "sha" }, target, player);
 							return 0;
 						},
-						target: function (player, target) {
+						target(player, target) {
 							var es = target.getCards("e").sort(function (a, b) {
 								return get.value(b, target) - get.value(a, target);
 							});
@@ -10668,7 +10652,7 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				delay: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					var isEnemy;
 					if (player.identity == "unknown") {
 						if (!player.wontYe("wu"))
@@ -10687,7 +10671,7 @@ export default () => {
 						return isEnemy(current) && player.inRange(current);
 					});
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (player == target || !player.inRange(target)) return false;
 					if (player.identity == "unknown") {
 						if (!player.wontYe("wu")) return true;
@@ -10700,7 +10684,7 @@ export default () => {
 				selectCard: [0, 1],
 				multitarget: true,
 				multiline: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("gzduwu");
 					player.addSkill("gzduwu_count");
@@ -10746,7 +10730,7 @@ export default () => {
 				ai: {
 					order: 2,
 					result: {
-						player: function (player) {
+						player(player) {
 							if (
 								game.countPlayer(function (current) {
 									return !current.isFriendOf(player) && !player.inRange(current);
@@ -10764,10 +10748,10 @@ export default () => {
 						trigger: { global: "dyingBegin" },
 						silent: true,
 						charlotte: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.getParent("gzduwu").player == player;
 						},
-						content: function () {
+						content() {
 							player.markAuto("gzduwu_count", [trigger.player]);
 						},
 					},
@@ -10779,10 +10763,10 @@ export default () => {
 				trigger: { global: "phaseZhunbeiBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player != player && event.player.isIn() && player.countCards("e") > 0 && player.canUse("sha", event.player, false);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCard("e", get.prompt("gzxishe", trigger.player), "将装备区内的一张牌当做" + (player.hp > trigger.player.hp ? "不可响应的" : "") + "【杀】对其使用", function (card, player) {
@@ -10828,7 +10812,7 @@ export default () => {
 				},
 				ai: {
 					directHit_ai: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (_status.event.getParent().name == "gzxishe" && arg.card && arg.card.name == "sha" && arg.target && arg.target == _status.event.target && player.hp > arg.target.hp) return true;
 						return false;
 					},
@@ -10840,10 +10824,10 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				delay: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.showHandcards();
 					"step 1";
@@ -10902,7 +10886,7 @@ export default () => {
 				ai: {
 					order: 10,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							var num = player.maxHp - player.getExpansions("gzhuaiyi").length;
 							if (player.countCards("h", { color: "red" }) <= num) return 1;
 							if (player.countCards("h", { color: "black" }) <= num) return 1;
@@ -10912,7 +10896,7 @@ export default () => {
 				},
 				marktext: "异",
 				intro: { content: "expansion", markcount: "expansion" },
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
@@ -10921,10 +10905,10 @@ export default () => {
 				audio: 2,
 				trigger: { player: "phaseDrawBegin2" },
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return !event.numFixed && player.getExpansions("gzhuaiyi").length > 0;
 				},
-				content: function () {
+				content() {
 					trigger.num += player.getExpansions("gzhuaiyi").length;
 				},
 				group: "gzzisui_die",
@@ -10933,10 +10917,10 @@ export default () => {
 						audio: "gzzisui",
 						trigger: { player: "phaseJieshuBegin" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getExpansions("gzhuaiyi").length > player.maxHp;
 						},
-						content: function () {
+						content() {
 							player.die();
 						},
 					},
@@ -10947,14 +10931,14 @@ export default () => {
 				audio: 2,
 				trigger: { player: "phaseZhunbeiBegin" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return current != player && current.isUnseen();
 					});
 				},
 				preHidden: "gzcongcha_draw",
 				prompt2: "选择一名武将牌均暗置的其他角色",
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt2("gzcongcha"), function (card, player, target) {
@@ -10981,7 +10965,7 @@ export default () => {
 						audio: "gzcongcha",
 						trigger: { player: "phaseDrawBegin2" },
 						frequent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								!event.numFixed &&
 								!game.hasPlayer(function (current) {
@@ -10990,7 +10974,7 @@ export default () => {
 							);
 						},
 						prompt: "是否发动【聪察】多摸两张牌？",
-						content: function () {
+						content() {
 							trigger.num += 2;
 						},
 					},
@@ -11001,7 +10985,7 @@ export default () => {
 				ai: {
 					mingzhi_yes: true,
 					mingzhi_no: true,
-					skillTagFilter: function (player, tag) {
+					skillTagFilter(player, tag) {
 						if (_status.brawl) return false;
 						var group = lib.character[player.name1][1];
 						if (tag == "mingzhi_yes") {
@@ -11027,11 +11011,11 @@ export default () => {
 				forced: true,
 				charlotte: true,
 				onremove: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player == player.storage.gzcongcha2;
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					"step 0";
 					player.removeSkill("gzcongcha2");
 					trigger.player.removeSkill("gzcongcha_ai");
@@ -11047,12 +11031,12 @@ export default () => {
 			gzzhaoxin: {
 				audio: 2,
 				trigger: { player: "damageEnd" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") > 0;
 				},
 				check: () => false,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.showHandcards();
 					"step 1";
@@ -11078,16 +11062,16 @@ export default () => {
 				audio: 2,
 				derivation: "gzfankui",
 				mod: {
-					targetInRange: function (card, player, target) {
+					targetInRange(card, player, target) {
 						if (player == _status.currentPhase && player.countMark("gzsuzhi_count") < 3 && get.type2(card) == "trick") return true;
 					},
 				},
 				trigger: { player: "phaseJieshuBegin" },
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countMark("gzsuzhi_count") < 3;
 				},
-				content: function () {
+				content() {
 					player.addTempSkills("gzfankui", { player: "phaseBegin" });
 				},
 				group: ["gzsuzhi_damage", "gzsuzhi_draw", "gzsuzhi_gain"],
@@ -11097,10 +11081,10 @@ export default () => {
 						audio: "gzsuzhi",
 						trigger: { source: "damageBegin1" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player == _status.currentPhase && player.countMark("gzsuzhi_count") < 3 && event.card && (event.card.name == "sha" || event.card.name == "juedou") && event.getParent().type == "card";
 						},
-						content: function () {
+						content() {
 							trigger.num++;
 							player.addTempSkill("gzsuzhi_count");
 							player.addMark("gzsuzhi_count", 1, false);
@@ -11110,10 +11094,10 @@ export default () => {
 						audio: "gzsuzhi",
 						trigger: { player: "useCard" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player == _status.currentPhase && player.countMark("gzsuzhi_count") < 3 && event.card.isCard && get.type2(event.card) == "trick";
 						},
-						content: function () {
+						content() {
 							player.draw();
 							player.addTempSkill("gzsuzhi_count");
 							player.addMark("gzsuzhi_count", 1, false);
@@ -11123,12 +11107,12 @@ export default () => {
 						audio: "gzsuzhi",
 						trigger: { global: "loseAfter" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (player != _status.currentPhase || event.type != "discard" || player == event.player || player.countMark("gzsuzhi_count") >= 3) return false;
 							return event.player.countGainableCards(player, "he") > 0;
 						},
 						logTarget: "player",
-						content: function () {
+						content() {
 							"step 0";
 							player.addTempSkill("gzsuzhi_count");
 							player.addMark("gzsuzhi_count", 1, false);
@@ -11150,28 +11134,28 @@ export default () => {
 			gzbaolie: {
 				audio: 2,
 				mod: {
-					targetInRange: function (card, player, target) {
+					targetInRange(card, player, target) {
 						if (card.name == "sha" && target.hp >= player.hp) return true;
 					},
-					cardUsableTarget: function (card, player, target) {
+					cardUsableTarget(card, player, target) {
 						if (card.name == "sha" && target.hp >= player.hp) return true;
 					},
 				},
 				trigger: { player: "phaseUseBegin" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return current.isEnemyOf(player) && player.inRangeOf(current);
 					});
 				},
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					return game.filterPlayer(function (current) {
 						return current.isEnemyOf(player) && player.inRangeOf(current);
 					});
 				},
 				check: () => false,
-				content: function () {
+				content() {
 					"step 0";
 					event.targets = game
 						.filterPlayer(function (current) {
@@ -11210,15 +11194,15 @@ export default () => {
 			gzchenglve: {
 				audio: 2,
 				trigger: { global: "useCardAfter" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.targets.length > 1 && event.player.isIn() && event.player.isFriendOf(player);
 				},
 				logTarget: "player",
-				check: function (event, player) {
+				check(event, player) {
 					return get.attitude(player, event.player) > 0;
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					trigger.player.draw();
 					if (
@@ -11263,13 +11247,13 @@ export default () => {
 				trigger: { player: "damageEnd" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.num == 1 || player.countCards("he") > 0;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return event.num == 1;
 				},
-				content: function () {
+				content() {
 					if (trigger.num == 1) player.draw();
 					else player.chooseToDiscard(true, "he", 2);
 				},
@@ -11278,41 +11262,41 @@ export default () => {
 				audio: "zhuosheng",
 				trigger: { global: "damageEnd" },
 				logTarget: "player",
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isFriendOf(player);
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					var target = trigger.player;
 					target.addTempSkill("gzzhuosheng2", { player: "phaseJieshuBegin" });
 					target.draw().gaintag = ["gzzhuosheng2"];
 				},
 			},
 			gzzhuosheng2: {
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					player.removeGaintag(skill);
 				},
 				mod: {
-					targetInRange: function (card, player, target) {
+					targetInRange(card, player, target) {
 						if (!card.cards || get.type(card) != "basic") return;
 						for (var i of card.cards) {
 							if (i.hasGaintag("gzzhuosheng2")) return game.online ? player == _status.currentPhase : player.isPhaseUsing();
 						}
 					},
-					cardUsable: function (card, player, target) {
+					cardUsable(card, player, target) {
 						if (!card.cards || get.type(card) != "basic" || !(game.online ? player == _status.currentPhase : player.isPhaseUsing())) return;
 						for (var i of card.cards) {
 							if (i.hasGaintag("gzzhuosheng2")) return Infinity;
 						}
 					},
-					aiOrder: function (player, card, num) {
+					aiOrder(player, card, num) {
 						if (get.itemtype(card) == "card" && card.hasGaintag("gzzhuosheng2") && get.type(card) == "basic") return num - 0.1;
 					},
 				},
 				audio: "zhuosheng",
 				trigger: { player: "useCard2" },
 				direct: true,
-				filterx: function (event, player) {
+				filterx(event, player) {
 					if (!player.isPhaseUsing()) return false;
 					return (
 						player.getHistory("lose", function (evt) {
@@ -11324,7 +11308,7 @@ export default () => {
 						}).length > 0
 					);
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!lib.skill.gzzhuosheng2.filterx(event, player)) return false;
 					if (get.type(event.card) != "trick") return false;
 					if (event.targets && event.targets.length > 0) return true;
@@ -11341,7 +11325,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var prompt2 = "为" + get.translation(trigger.card) + "增加或减少一个目标";
 					player
@@ -11377,11 +11361,11 @@ export default () => {
 					equip: {
 						audio: "zhuosheng",
 						trigger: { player: "useCard" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return get.type(event.card) == "equip" && lib.skill.gzzhuosheng2.filterx(event, player);
 						},
 						prompt: "是否发动【擢升】摸一张牌？",
-						content: function () {
+						content() {
 							player.draw();
 						},
 					},
@@ -11391,10 +11375,10 @@ export default () => {
 						},
 						silent: true,
 						firstDo: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return get.type(event.card) == "basic" && lib.skill.gzzhuosheng2.filterx(event, player) && event.addCount !== false;
 						},
-						content: function () {
+						content() {
 							trigger.addCount = false;
 							var stat = player.getStat();
 							if (stat && stat.card && stat.card[trigger.card.name]) stat.card[trigger.card.name]--;
@@ -11408,10 +11392,10 @@ export default () => {
 				trigger: { global: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isAlive() && event.player.getStat("damage") && lib.filter.targetEnabled({ name: "sha" }, player, event.player) && (player.hasSha() || (_status.connectMode && player.countCards("h") > 0));
 				},
-				content: function () {
+				content() {
 					var next = player
 						.chooseToUse(
 							function (card, player, event) {
@@ -11446,7 +11430,7 @@ export default () => {
 				},
 				ai: {
 					unequip_ai: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						var evt = _status.event.getParent();
 						if (evt.name != "gzzhuhai" || !arg || !arg.target) return false;
 						if (
@@ -11463,16 +11447,16 @@ export default () => {
 				trigger: { player: "shaMiss" },
 				forced: true,
 				popup: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.gzzhuhai_tag == true && event.target.countCards("he") > 0;
 				},
-				content: function () {
+				content() {
 					player.line(trigger.target);
 					trigger.target.chooseToDiscard("he", true);
 				},
 				ai: {
 					unequip: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (!arg || !arg.card || !arg.card.gzzhuhai_tag) return false;
 					},
 				},
@@ -11481,7 +11465,7 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				usable: 1,
-				onChooseToUse: function (event) {
+				onChooseToUse(event) {
 					if (!game.online) {
 						event.set(
 							"quanjin_list",
@@ -11489,17 +11473,17 @@ export default () => {
 						);
 					}
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.quanjin_list && event.quanjin_list.length > 0 && player.countCards("h") > 0;
 				},
 				filterCard: true,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return _status.event.quanjin_list.includes(target);
 				},
 				discard: false,
 				lose: false,
 				delay: false,
-				check: function (card) {
+				check(card) {
 					var evt = _status.event;
 					if (
 						evt.quanjin_list.filter(function (target) {
@@ -11509,7 +11493,7 @@ export default () => {
 						return 8 - get.value(card);
 					return 6.5 - get.value(card);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.give(cards, target);
 					"step 1";
@@ -11558,7 +11542,7 @@ export default () => {
 				ai: {
 					order: 1,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							if (get.attitude(player, target) > 0) return 3.3;
 							var num = 0;
 							game.countPlayer(function (current) {
@@ -11580,7 +11564,7 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					var num = player.countCards("h");
 					return game.hasPlayer(function (current) {
 						if (current.isEnemyOf(player)) {
@@ -11589,7 +11573,7 @@ export default () => {
 						}
 					});
 				},
-				selectCard: function () {
+				selectCard() {
 					var list = [],
 						player = _status.event.player;
 					if (ui.selected.targets.length) return get.distance(player, ui.selected.targets[0]) - 1;
@@ -11603,10 +11587,10 @@ export default () => {
 					return [list[0], list[list.length - 1]];
 				},
 				filterCard: true,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target.isEnemyOf(player) && get.distance(player, target) == ui.selected.cards.length + 1;
 				},
-				check: function (card) {
+				check(card) {
 					var player = _status.event.player;
 					if (
 						ui.selected.cards.length &&
@@ -11617,7 +11601,7 @@ export default () => {
 						return 0;
 					return 7 - ui.selected.cards.length * 2 - get.value(card);
 				},
-				content: function () {
+				content() {
 					target.damage("nocard");
 					if (!player.storage.zaoyun2) player.storage.zaoyun2 = [];
 					player.storage.zaoyun2.push(target);
@@ -11626,7 +11610,7 @@ export default () => {
 				ai: {
 					order: 5,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							return get.damageEffect(target, player, target);
 						},
 					},
@@ -11636,7 +11620,7 @@ export default () => {
 				onremove: true,
 				charlotte: true,
 				mod: {
-					globalFrom: function (player, target) {
+					globalFrom(player, target) {
 						if (player.getStorage("zaoyun2").includes(target)) return -Infinity;
 					},
 				},
@@ -11646,7 +11630,7 @@ export default () => {
 				trigger: { player: "phaseUseBegin" },
 				forced: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseTarget("请选择【雉盗】的目标", "本回合内只能对自己和该角色使用牌，且第一次对其造成伤害时摸一张牌", lib.filter.notMe, true).set("ai", function (target) {
 						var player = _status.event.player;
@@ -11664,10 +11648,10 @@ export default () => {
 			},
 			gzzhidao2: {
 				mod: {
-					playerEnabled: function (card, player, target) {
+					playerEnabled(card, player, target) {
 						if (target != player && target != player.storage.gzzhidao2) return false;
 					},
-					globalFrom: function (from, to) {
+					globalFrom(from, to) {
 						if (to == from.storage.gzzhidao2) return -Infinity;
 					},
 				},
@@ -11675,7 +11659,7 @@ export default () => {
 				trigger: { source: "damageSource" },
 				forced: true,
 				charlotte: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						event.player == player.storage.gzzhidao2 &&
 						player
@@ -11687,7 +11671,7 @@ export default () => {
 					);
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					player.gainPlayerCard(trigger.player, "hej", true);
 				},
 			},
@@ -11696,15 +11680,15 @@ export default () => {
 				forced: true,
 				preHidden: ["gzyjili_remove"],
 				trigger: { target: "useCardToTargeted" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (get.color(event.card) != "red" || event.targets.length != 1) return false;
 					var type = get.type(event.card);
 					return type == "basic" || type == "trick";
 				},
-				check: function () {
+				check() {
 					return false;
 				},
-				content: function () {
+				content() {
 					player.addTempSkill("gzyjili2");
 					var evt = trigger.getParent();
 					if (!evt.gzyjili) evt.gzyjili = [];
@@ -11716,7 +11700,7 @@ export default () => {
 						audio: "gzyjili",
 						trigger: { player: "damageBegin2" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							var evt = false;
 							for (var i of lib.phaseName) {
 								evt = event.getParent(i);
@@ -11730,7 +11714,7 @@ export default () => {
 								}).length == 1
 							);
 						},
-						content: function () {
+						content() {
 							trigger.cancel();
 							player.removeCharacter(get.character(player.name1, 3).includes("gzyjili") ? 0 : 1);
 						},
@@ -11742,7 +11726,7 @@ export default () => {
 				charlotte: true,
 				popup: false,
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						event.gzyjili &&
 						event.gzyjili.includes(player) &&
@@ -11759,7 +11743,7 @@ export default () => {
 						)
 					);
 				},
-				content: function () {
+				content() {
 					trigger.player.useCard(
 						{
 							name: trigger.card.name,
@@ -11775,15 +11759,15 @@ export default () => {
 				audio: 2,
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return lib.skill.donggui.filterTarget(null, player, current);
 					});
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && !target.isUnseen(2) && player.canUse("diaohulishan", target);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseButton(["暗置" + get.translation(target) + "的一张武将牌", [[target.name1, target.name2], "character"]], true).set("filterButton", function (button) {
 						return !get.is.jun(button.link);
@@ -11811,7 +11795,7 @@ export default () => {
 				ai: {
 					order: 2,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							var target1 = target.getNext();
 							var target2 = target.getPrevious();
 							if (target1 == target2 || target.inline(target1) || target.inline(target2) || target1.inline(target2) || !target1.isFriendOf(target2)) return 0;
@@ -11828,7 +11812,7 @@ export default () => {
 				audio: 2,
 				zhenfa: "inline",
 				trigger: { player: "phaseJieshuBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					var bool = player.hasSkill("fengyang");
 					return (
 						game.hasPlayer(function (current) {
@@ -11841,7 +11825,7 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					event.list = game
 						.filterPlayer(function (current) {
@@ -11873,7 +11857,7 @@ export default () => {
 				subSkill: {
 					nogain: {
 						mod: {
-							canBeDiscarded: function (card, player, target) {
+							canBeDiscarded(card, player, target) {
 								if (
 									get.position(card) == "e" &&
 									player.identity != target.identity &&
@@ -11883,7 +11867,7 @@ export default () => {
 								)
 									return false;
 							},
-							canBeGained: function (card, player, target) {
+							canBeGained(card, player, target) {
 								if (
 									get.position(card) == "e" &&
 									player.identity != target.identity &&
@@ -11902,20 +11886,20 @@ export default () => {
 				forced: true,
 				preHidden: true,
 				trigger: { player: "phaseDiscardBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return !player.getHistory("useCard").length || !player.getHistory("sourceDamage").length;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return !player.getHistory("useCard").length;
 				},
-				content: function () {
+				content() {
 					lib.skill.rekuangcai.change(player, player.getHistory("useCard").length ? -1 : 1);
 				},
 				mod: {
-					targetInRange: function (card, player) {
+					targetInRange(card, player) {
 						if (player == _status.currentPhase) return true;
 					},
-					cardUsable: function (card, player) {
+					cardUsable(card, player) {
 						if (player == _status.currentPhase) return Infinity;
 					},
 				},
@@ -11927,23 +11911,23 @@ export default () => {
 				firstDo: true,
 				noHidden: true,
 				preHidden: ["gzkuangcai_discard"],
-				filter: function (event, player) {
+				filter(event, player) {
 					return player == _status.currentPhase && get.type(event.card) == "trick";
 				},
-				content: function () {
+				content() {
 					trigger.nowuxie = true;
 				},
 				mod: {
-					targetInRange: function (card, player) {
+					targetInRange(card, player) {
 						if (player == _status.currentPhase) return true;
 					},
-					cardUsable: function (card, player) {
+					cardUsable(card, player) {
 						if (player == _status.currentPhase) return Infinity;
 					},
 				},
 				ai: {
 					unequip: true,
-					skillTagFilter: function (player) {
+					skillTagFilter(player) {
 						return player == _status.currentPhase;
 					},
 				},
@@ -11953,20 +11937,20 @@ export default () => {
 						audio: "gzkuangcai",
 						trigger: { player: "phaseDiscardBegin" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							var use = player.getHistory("useCard").length;
 							var damage = player.getStat("damage") || 0;
 							if (use && !damage) return true;
 							if (damage >= use) return true;
 							return false;
 						},
-						check: function (event, player) {
+						check(event, player) {
 							var use = player.getHistory("useCard").length;
 							var damage = player.getStat("damage") || 0;
 							if (use && !damage) return false;
 							return true;
 						},
-						content: function () {
+						content() {
 							var use = player.getHistory("useCard").length;
 							var damage = player.getStat("damage") || 0;
 							if (use && !damage) player.addTempSkill("gzkuangcai_less");
@@ -11978,7 +11962,7 @@ export default () => {
 					},
 					more: {
 						mod: {
-							maxHandcard: function (player, num) {
+							maxHandcard(player, num) {
 								return num + 2;
 							},
 						},
@@ -11986,7 +11970,7 @@ export default () => {
 					},
 					less: {
 						mod: {
-							maxHandcard: function (player, num) {
+							maxHandcard(player, num) {
 								return num - 2;
 							},
 						},
@@ -11998,14 +11982,14 @@ export default () => {
 				audio: 2,
 				preHidden: true,
 				trigger: { target: "useCardToTargeted" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player == event.player || event.targets.length != 1 || !event.player.isIn()) return false;
 					if (!event.player.countCards("he") && _status.event.dying) return false;
 					var hs = player.getCards("h");
 					if (hs.length == 0) return false;
 					return hs.every(i => lib.filter.cardDiscardable(i, player, "gzshejian"));
 				},
-				check: function (event, player) {
+				check(event, player) {
 					var target = event.player;
 					if (get.damageEffect(target, player, player) <= 0) return false;
 					if (
@@ -12042,7 +12026,7 @@ export default () => {
 					return false;
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					"step 0";
 					var cards = player.getCards("h");
 					event.num = cards.length;
@@ -12069,13 +12053,13 @@ export default () => {
 				trigger: { global: "phaseBegin" },
 				limited: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player != event.player;
 				},
 				logTarget: "player",
 				skillAnimation: true,
 				animationColor: "orange",
-				check: function (event, player) {
+				check(event, player) {
 					var target = event.player;
 					if (get.attitude(player, target) >= -3) return false;
 					if (
@@ -12097,7 +12081,7 @@ export default () => {
 						});
 					return num >= Math.max(2, target.hp);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("gzpozhen");
 					var target = trigger.player;
@@ -12118,10 +12102,10 @@ export default () => {
 			},
 			gzpozhen2: {
 				mod: {
-					cardEnabled2: function (card) {
+					cardEnabled2(card) {
 						if (get.position(card) == "h") return false;
 					},
-					cardRecastable: function (card) {
+					cardRecastable(card) {
 						if (get.position(card) == "h") return false;
 					},
 				},
@@ -12131,13 +12115,13 @@ export default () => {
 				viceSkill: true,
 				trigger: { global: "damageBegin4" },
 				preHidden: true,
-				init: function (player, skill) {
+				init(player, skill) {
 					if (player.checkViceSkill(skill) && !player.viceChanged) player.removeMaxHp();
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isFriendOf(player) && event.num >= event.player.hp;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					if (get.attitude(player, event.player) < 3) return false;
 					if (event.num >= 1 || player.storage.gzpozhen) return true;
 					if (
@@ -12158,7 +12142,7 @@ export default () => {
 				logTarget: "player",
 				skillAnimation: true,
 				animationColor: "orange",
-				content: function () {
+				content() {
 					trigger.cancel();
 					player.changeVice();
 				},
@@ -12169,13 +12153,13 @@ export default () => {
 						logTarget: "player",
 						forced: true,
 						locked: false,
-						prompt: function (event, player) {
+						prompt(event, player) {
 							return get.translation(event.player) + "即将变更副将，是否发动【荐才】，令其此次变更副将时增加两张可选武将牌？";
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.player.isFriendOf(player);
 						},
-						content: function () {
+						content() {
 							trigger.num += 2;
 						},
 					},
@@ -12183,7 +12167,7 @@ export default () => {
 			},
 			gzxingzhao: {
 				audio: 2,
-				getNum: function () {
+				getNum() {
 					var list = [],
 						players = game.filterPlayer();
 					for (var target of players) {
@@ -12200,7 +12184,7 @@ export default () => {
 					return list.length;
 				},
 				mod: {
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						return num + (lib.skill.gzxingzhao.getNum() > 2 ? 4 : 0);
 					},
 				},
@@ -12213,10 +12197,10 @@ export default () => {
 						name: "恂恂",
 						description: "摸牌阶段，你可以观看牌堆顶的四张牌，然后将其中的两张牌置于牌堆顶，并将其余的牌以任意顺序置于牌堆底。",
 						trigger: { player: "phaseDrawBegin1" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return lib.skill.gzxingzhao.getNum() > 0;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var cards = get.cards(4);
 							game.cardsGotoOrdering(cards);
@@ -12255,11 +12239,11 @@ export default () => {
 							player: ["useCard", "damageEnd"],
 						},
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (event.name == "damage" || get.type(event.card) == "equip") && lib.skill.gzxingzhao.getNum() > 1 && !player.isMaxHandcard();
 						},
 						frequent: true,
-						content: function () {
+						content() {
 							player.draw();
 						},
 					},
@@ -12267,17 +12251,17 @@ export default () => {
 						audio: "gzxingzhao",
 						trigger: { player: "damageEnd" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return lib.skill.gzxingzhao.getNum() > 1 && event.source && event.source.isAlive() && event.source.countCards("h") != player.countCards("h");
 						},
-						logTarget: function (event, player) {
+						logTarget(event, player) {
 							var target = event.source;
 							return target.countCards("h") > player.countCards("h") ? player : target;
 						},
-						check: function (event, player) {
+						check(event, player) {
 							return get.attitude(player, lib.skill.gzxingzhao_draw.logTarget(event, player)) > 0;
 						},
-						content: function () {
+						content() {
 							lib.skill.gzxingzhao_draw.logTarget(trigger, player).draw();
 						},
 					},
@@ -12285,10 +12269,10 @@ export default () => {
 						audio: "gzxingzhao",
 						trigger: { player: "phaseDiscardBefore" },
 						forced: true,
-						filter: function () {
+						filter() {
 							return lib.skill.gzxingzhao.getNum() > 2;
 						},
-						content: function () {
+						content() {
 							trigger.cancel();
 							game.log(player, "跳过了", "#y弃牌阶段");
 						},
@@ -12299,12 +12283,12 @@ export default () => {
 							player: "loseAfter",
 							global: ["equipAfter", "addJudgeAfter", "gainAfter", "loseAsyncAfter", "addToExpansionAfter"],
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							var evt = event.getl(player);
 							return evt && evt.player == player && evt.es && evt.es.length > 0 && lib.skill.gzxingzhao.getNum() > 3;
 						},
 						forced: true,
-						content: function () {
+						content() {
 							player.draw();
 						},
 					},
@@ -12312,12 +12296,12 @@ export default () => {
 				ai: {
 					threaten: 3,
 					effect: {
-						target_use: function (card, player, target, current) {
+						target_use(card, player, target, current) {
 							if (lib.skill.gzxingzhao.getNum() > 3 && get.type(card) == "equip" && !get.cardtag(card, "gifts")) return [1, 2];
 						},
 					},
 					reverseEquip: true,
-					skillTagFilter: function () {
+					skillTagFilter() {
 						return lib.skill.gzxingzhao.getNum() > 3;
 					},
 				},
@@ -12326,13 +12310,13 @@ export default () => {
 				audio: 2,
 				trigger: { player: "phaseUseBegin" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						return current != player && current.countCards("he");
 					});
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt2("gzwenji"), function (card, player, target) {
@@ -12386,17 +12370,17 @@ export default () => {
 				},
 				subSkill: {
 					respond: {
-						onremove: function (player) {
+						onremove(player) {
 							player.removeGaintag("gzwenji");
 						},
 						mod: {
-							targetInRange: function (card, player, target) {
+							targetInRange(card, player, target) {
 								if (!card.cards) return;
 								for (var i of card.cards) {
 									if (i.hasGaintag("gzwenji")) return true;
 								}
 							},
-							cardUsable: function (card, player, target) {
+							cardUsable(card, player, target) {
 								if (!card.cards) return;
 								for (var i of card.cards) {
 									if (i.hasGaintag("gzwenji")) return Infinity;
@@ -12407,7 +12391,7 @@ export default () => {
 						forced: true,
 						charlotte: true,
 						audio: "gzwenji",
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								player.getHistory("lose", function (evt) {
 									if (evt.getParent() != event) return false;
@@ -12418,7 +12402,7 @@ export default () => {
 								}).length > 0
 							);
 						},
-						content: function () {
+						content() {
 							trigger.directHit.addArray(
 								game.filterPlayer(function (current) {
 									return current != player;
@@ -12432,7 +12416,7 @@ export default () => {
 						},
 						ai: {
 							directHit_ai: true,
-							skillTagFilter: function (player, tag, arg) {
+							skillTagFilter(player, tag, arg) {
 								return arg.card && arg.card.cards && arg.card.cards.filter(card => card.hasGaintag("gzwenji")).length > 0;
 							},
 						},
@@ -12444,7 +12428,7 @@ export default () => {
 				trigger: { player: "phaseJieshuBegin" },
 				frequent: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (
 						!player.getHistory("useCard", function (evt) {
 							return evt.isPhaseUsing();
@@ -12462,7 +12446,7 @@ export default () => {
 						}).length == 0
 					);
 				},
-				content: function () {
+				content() {
 					player.draw(game.countGroup());
 				},
 			},
@@ -12471,7 +12455,7 @@ export default () => {
 				trigger: { player: "damageEnd" },
 				frequent: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					event.count = trigger.num;
 					"step 1";
@@ -12490,10 +12474,10 @@ export default () => {
 						trigger: { source: "damageSource" },
 						direct: true,
 						noHidden: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.player.isEnemyOf(player) && event.player.isIn();
 						},
-						content: function () {
+						content() {
 							"step 0";
 							trigger.player.chooseBool("是否对" + get.translation(player) + "发动【布施】？", "你摸一张牌，然后其摸一张牌");
 							"step 1";
@@ -12514,16 +12498,16 @@ export default () => {
 					source: "damageSource",
 				},
 				forced: true,
-				filter: function (event, player, name) {
+				filter(event, player, name) {
 					if (name == "damageSource" && player == event.player) return false;
 					return game.hasPlayer(function (current) {
 						return current.isFriendOf(event.player);
 					});
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return player.isFriendOf(event.player);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					event.count = trigger.num;
 					if (event.triggername == "damageSource") event.count = 1;
@@ -12556,12 +12540,12 @@ export default () => {
 				trigger: { global: "useCardToPlayered" },
 				direct: true,
 				//noHidden:true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var target = event.player;
 					return event.isFirstTarget && target.isFriendOf(player) && target.isPhaseUsing() && (target == player || player.hasSkill("gzmidao")) && ["basic", "trick"].includes(get.type(event.card)) && get.tag(event.card, "damage") > 0 && event.cards && event.cards.length && !target.hasSkill("gzmidao2");
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var next = trigger.player.chooseBool("是否对" + get.translation(player) + "发动【米道】？", "令该角色修改" + get.translation(trigger.card) + "的花色和伤害属性");
 					next.set("ai", () => false);
@@ -12715,10 +12699,10 @@ export default () => {
 				firstDo: true,
 				popup: false,
 				onremove: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.storage.gzmidao2 && event.card == player.storage.gzmidao2[0];
 				},
-				content: function () {
+				content() {
 					var nature = player.storage.gzmidao2[1];
 					if (nature == "普通") delete trigger.nature;
 					else trigger.nature = nature;
@@ -12727,7 +12711,7 @@ export default () => {
 			gzbiluan: {
 				audio: 2,
 				mod: {
-					globalTo: function (from, to, distance) {
+					globalTo(from, to, distance) {
 						return distance + to.countCards("e");
 					},
 				},
@@ -12737,11 +12721,11 @@ export default () => {
 				trigger: { global: "phaseZhunbeiBegin" },
 				noHidden: true,
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player != event.player && !event.player.isFriendOf(player) && !player.inRangeOf(event.player);
 				},
 				logTarget: "player",
-				content: function () {
+				content() {
 					"step 0";
 					var target = trigger.player;
 					event.target = target;
@@ -12782,10 +12766,10 @@ export default () => {
 				trigger: { global: "phaseZhunbeiBegin" },
 				noHidden: true,
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player != event.player && !event.player.isFriendOf(player) && player.countDiscardableCards(event.player, "e") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					trigger.player.chooseBool("是否对" + get.translation(player) + "发动【礼下】？", "弃置其装备区内的一张牌，然后选择一项：①弃置两张牌。②失去1点体力。③令其摸两张牌。").set("ai", function () {
 						var player = _status.event.player;
@@ -12858,12 +12842,12 @@ export default () => {
 
 			yigui: {
 				audio: 2,
-				hiddenCard: function (player, name) {
+				hiddenCard(player, name) {
 					var storage = player.storage.yigui;
 					if (name == "shan" || name == "wuxie" || !storage || !storage.character.length || storage.used.includes(name) || !lib.inpile.includes(name)) return false;
 					return true;
 				},
-				init: function (player, skill) {
+				init(player, skill) {
 					if (!player.storage.skill)
 						player.storage[skill] = {
 							character: [],
@@ -12871,7 +12855,7 @@ export default () => {
 						};
 				},
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.type == "wuxie" || event.type == "respondShan") return false;
 					var storage = player.storage.yigui;
 					if (!storage || !storage.character.length) return false;
@@ -12890,7 +12874,7 @@ export default () => {
 				},
 				chooseButton: {
 					select: 2,
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var dialog = ui.create.dialog("役鬼", "hidden");
 						dialog.add([player.storage.yigui.character, "character"]);
 						var list = lib.inpile;
@@ -12912,7 +12896,7 @@ export default () => {
 						dialog.add([list2, "vcard"]);
 						return dialog;
 					},
-					check: function (button) {
+					check(button) {
 						if (ui.selected.buttons.length) {
 							var evt = _status.event.getParent("chooseToUse");
 							var name = button.link[2];
@@ -12939,7 +12923,7 @@ export default () => {
 						}
 						return 1 + Math.random();
 					},
-					filter: function (button, player) {
+					filter(button, player) {
 						var evt = _status.event.getParent("chooseToUse");
 						if (!ui.selected.buttons.length) {
 							if (typeof button.link != "string") return false;
@@ -12988,7 +12972,7 @@ export default () => {
 								});
 						}
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						var name = links[1][2];
 						var nature = links[1][3] || null;
 						var character = links[0];
@@ -12996,12 +12980,12 @@ export default () => {
 						var next = {
 							character: character,
 							group: group,
-							filterCard: function () {
+							filterCard() {
 								return false;
 							},
 							selectCard: -1,
 							complexCard: true,
-							check: function () {
+							check() {
 								return 1;
 							},
 							popname: true,
@@ -13011,7 +12995,7 @@ export default () => {
 								nature: nature,
 								isCard: true,
 							},
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								var xx = lib.skill.yigui_backup;
 								var evt = _status.event;
 								var group = xx.group;
@@ -13029,7 +13013,7 @@ export default () => {
 								if (evt._backup && evt._backup.filterTarget) return evt._backup.filterTarget(card, player, target);
 								return lib.filter.filterTarget(card, player, target);
 							},
-							onuse: function (result, player) {
+							onuse(result, player) {
 								player.logSkill("yigui");
 								var character = lib.skill.yigui_backup.character;
 								player.flashAvatar("yigui", character);
@@ -13043,7 +13027,7 @@ export default () => {
 						};
 						return next;
 					},
-					prompt: function (links, player) {
+					prompt(links, player) {
 						var name = links[1][2];
 						var character = links[0];
 						var nature = links[1][3];
@@ -13052,7 +13036,7 @@ export default () => {
 				},
 				group: ["yigui_init", "yigui_refrain"],
 				ai: {
-					order: function () {
+					order() {
 						return 1 + 10 * Math.random();
 					},
 					result: {
@@ -13062,11 +13046,11 @@ export default () => {
 				mark: true,
 				marktext: "魂",
 				intro: {
-					onunmark: function (storage, player) {
+					onunmark(storage, player) {
 						_status.characterlist.addArray(storage.character);
 						storage.character = [];
 					},
-					mark: function (dialog, storage, player) {
+					mark(dialog, storage, player) {
 						if (storage && storage.character.length) {
 							if (player.isUnderControl(true)) {
 								dialog.addSmall([storage.character, "character"]);
@@ -13077,10 +13061,10 @@ export default () => {
 							return "没有魂";
 						}
 					},
-					content: function (storage, player) {
+					content(storage, player) {
 						return "共有" + get.cnNumber(storage.character.length) + "张“魂”";
 					},
-					markcount: function (storage, player) {
+					markcount(storage, player) {
 						if (storage && storage.character) return storage.character.length;
 						return 0;
 					},
@@ -13092,14 +13076,14 @@ export default () => {
 					player: "showCharacterAfter",
 				},
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						event.toShow.some(name => {
 							return get.character(name, 3).includes("yigui");
 						}) && !player.storage.yigui_init
 					);
 				},
-				content: function () {
+				content() {
 					player.storage.yigui_init = true;
 					var list = _status.characterlist.randomGets(2);
 					if (list.length) {
@@ -13117,25 +13101,25 @@ export default () => {
 				forced: true,
 				silent: true,
 				popup: false,
-				content: function () {
+				content() {
 					player.storage.yigui.used = [];
 				},
 			},
 			yigui_shan: {
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.type != "respondShan") return false;
 					var storage = player.storage.yigui;
 					if (!storage || !storage.character.length || storage.used.includes("shan")) return false;
 					return event.filterCard({ name: "shan" }, player, event);
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var dialog = ui.create.dialog("役鬼", "hidden");
 						dialog.add([player.storage.yigui.character, "character"]);
 						return dialog;
 					},
-					check: function (button) {
+					check(button) {
 						return (
 							1 /
 							(1 +
@@ -13144,16 +13128,16 @@ export default () => {
 								}))
 						);
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						var character = links[0];
 						var next = {
 							character: character,
-							filterCard: function () {
+							filterCard() {
 								return false;
 							},
 							selectCard: -1,
 							complexCard: true,
-							check: function () {
+							check() {
 								return 1;
 							},
 							popname: true,
@@ -13162,7 +13146,7 @@ export default () => {
 								name: "shan",
 								isCard: true,
 							},
-							onuse: function (result, player) {
+							onuse(result, player) {
 								player.logSkill("yigui");
 								var character = lib.skill.yigui_shan_backup.character;
 								player.flashAvatar("yigui", character);
@@ -13179,7 +13163,7 @@ export default () => {
 				},
 				ai: {
 					respondShan: true,
-					skillTagFilter: function (player) {
+					skillTagFilter(player) {
 						var storage = player.storage.yigui;
 						if (!storage || !storage.character.length || storage.used.includes("shan")) return false;
 					},
@@ -13191,19 +13175,19 @@ export default () => {
 			},
 			yigui_wuxie: {
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.type != "wuxie") return false;
 					var storage = player.storage.yigui;
 					if (!storage || !storage.character.length || storage.used.includes("wuxie")) return false;
 					return event.filterCard({ name: "wuxie" }, player, event);
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var dialog = ui.create.dialog("役鬼", "hidden");
 						dialog.add([player.storage.yigui.character, "character"]);
 						return dialog;
 					},
-					check: function (button) {
+					check(button) {
 						return (
 							1 /
 							(1 +
@@ -13212,16 +13196,16 @@ export default () => {
 								}))
 						);
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						var character = links[0];
 						var next = {
 							character: character,
-							filterCard: function () {
+							filterCard() {
 								return false;
 							},
 							selectCard: -1,
 							complexCard: true,
-							check: function () {
+							check() {
 								return 1;
 							},
 							popname: true,
@@ -13230,7 +13214,7 @@ export default () => {
 								name: "wuxie",
 								isCard: true,
 							},
-							onuse: function (result, player) {
+							onuse(result, player) {
 								player.logSkill("yigui");
 								var character = lib.skill.yigui_wuxie_backup.character;
 								player.flashAvatar("yigui", character);
@@ -13254,7 +13238,7 @@ export default () => {
 			},
 			yigui_gzshan: {
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.type != "respondShan" || !event.filterCard({ name: "shan" }, player, event) || !lib.inpile.includes("shan")) return false;
 					var storage = player.storage.yigui,
 						target = event.getParent().player;
@@ -13271,12 +13255,12 @@ export default () => {
 					);
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var dialog = ui.create.dialog("役鬼", "hidden");
 						dialog.add([player.storage.yigui.character, "character"]);
 						return dialog;
 					},
-					filter: function (button, player) {
+					filter(button, player) {
 						var evt = _status.event.getParent("chooseToUse");
 						var target = evt.getParent().player,
 							identity = target.identity;
@@ -13286,7 +13270,7 @@ export default () => {
 						var groups = double ? double : [lib.character[button.link][1]];
 						return groups.includes(identity);
 					},
-					check: function (button) {
+					check(button) {
 						return (
 							1 /
 							(1 +
@@ -13295,7 +13279,7 @@ export default () => {
 								}))
 						);
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						var character = links[0];
 						var next = {
 							character: character,
@@ -13306,7 +13290,7 @@ export default () => {
 							popname: true,
 							audio: "yigui",
 							viewAs: { name: "shan", isCard: true },
-							onuse: function (result, player) {
+							onuse(result, player) {
 								player.logSkill("yigui");
 								var character = lib.skill.yigui_gzshan_backup.character;
 								player.flashAvatar("yigui", character);
@@ -13323,7 +13307,7 @@ export default () => {
 				},
 				ai: {
 					respondShan: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (arg == "respond" || !lib.inpile.includes("shan")) return false;
 						var storage = player.storage.yigui;
 						if (!storage || !storage.character.length || storage.used.includes("shan")) return false;
@@ -13423,10 +13407,10 @@ export default () => {
 				audio: 2,
 				frequent: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.name == "damage" || (event.player.isAlive() && !event.player.isFriendOf(player));
 				},
-				content: function () {
+				content() {
 					var list = _status.characterlist.randomGets(1);
 					if (list.length) {
 						_status.characterlist.removeArray(list);
@@ -13441,16 +13425,16 @@ export default () => {
 			gzbuyi: {
 				trigger: { global: "dyingAfter" },
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!(event.player && event.player.isAlive() && event.source && event.source.isAlive())) return false;
 					return event.player.isFriendOf(player) && event.reason && event.reason.name == "damage";
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return get.attitude(player, event.player) > 0;
 				},
 				logTarget: "source",
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseJunlingFor(trigger.source);
 					"step 1";
@@ -13476,12 +13460,12 @@ export default () => {
 			keshou: {
 				audio: 2,
 				trigger: { player: "damageBegin3" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.num > 0;
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var check = player.countCards("h", { color: "red" }) > 1 || player.countCards("h", { color: "black" }) > 1;
 					player
@@ -13534,7 +13518,7 @@ export default () => {
 			zhuwei: {
 				audio: 2,
 				trigger: { player: "judgeEnd" },
-				filter: function (event) {
+				filter(event) {
 					if (get.owner(event.result.card)) return false;
 					if (event.nogain && event.nogain(event.result.card)) return false;
 					return true;
@@ -13542,7 +13526,7 @@ export default () => {
 				},
 				frequent: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.gain(trigger.result.card, "gain2");
 					player.chooseBool("是否令" + get.translation(_status.currentPhase) + "本回合的手牌上限和使用【杀】的次数上限+1？").ai = function () {
@@ -13562,17 +13546,17 @@ export default () => {
 					eff: {
 						sub: true,
 						mod: {
-							cardUsable: function (card, player, num) {
+							cardUsable(card, player, num) {
 								if (card.name == "sha") return num + player.storage.zhuwei_eff;
 							},
-							maxHandcard: function (player, num) {
+							maxHandcard(player, num) {
 								return num + player.storage.zhuwei_eff;
 							},
 						},
 						mark: true,
 						charlotte: true,
 						intro: {
-							content: function (storage) {
+							content(storage) {
 								if (storage) return "使用【杀】的次数上限+" + storage + "，手牌上限+" + storage;
 							},
 						},
@@ -13580,18 +13564,18 @@ export default () => {
 				},
 			},
 			gzweidi: {
-				init: function (player) {
+				init(player) {
 					player.storage.gzweidi = [];
 				},
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.storage.gzweidi.length > 0;
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target != player && player.storage.gzweidi.includes(target);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseJunlingFor(target);
 					"step 1";
@@ -13634,7 +13618,7 @@ export default () => {
 						sub: true,
 						trigger: { global: "gainBefore" },
 						silent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (player == event.player || player.storage.gzweidi.includes(event.player) || _status.currentPhase != player) return false;
 							if (event.cards.length) {
 								if (event.getParent().name == "draw") return true;
@@ -13642,7 +13626,7 @@ export default () => {
 							}
 							return false;
 						},
-						content: function () {
+						content() {
 							player.storage.gzweidi.push(trigger.player);
 						},
 					},
@@ -13650,10 +13634,10 @@ export default () => {
 						sub: true,
 						trigger: { global: "phaseAfter" },
 						silent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.player == player;
 						},
-						content: function () {
+						content() {
 							player.storage.gzweidi = [];
 						},
 					},
@@ -13665,7 +13649,7 @@ export default () => {
 				group: ["gzyongsi_eff1", "gzyongsi_eff2", "gzyongsi_eff3"],
 				preHidden: ["gzyongsi_eff3"],
 				ai: {
-					threaten: function (player, target) {
+					threaten(player, target) {
 						if (
 							game.hasPlayer(function (current) {
 								return current != target && current.getEquip("yuxi");
@@ -13675,7 +13659,7 @@ export default () => {
 						return 2;
 					},
 					forceMajor: true,
-					skillTagFilter: function () {
+					skillTagFilter() {
 						return !game.hasPlayer(function (current) {
 							return current.getEquip("yuxi");
 						});
@@ -13689,13 +13673,13 @@ export default () => {
 						trigger: { player: "phaseDrawBegin2" },
 						//priority:8,
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.numFixed || player.isDisabled(5)) return false;
 							return !game.hasPlayer(function (current) {
 								return current.getEquips("yuxi").length > 0;
 							});
 						},
-						content: function () {
+						content() {
 							trigger.num++;
 						},
 						audio: ["yongsi1", 2],
@@ -13707,7 +13691,7 @@ export default () => {
 						forced: true,
 						noHidden: true,
 						equipSkill: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (player.isDisabled(5)) return false;
 							return (
 								game.hasPlayer(function (current) {
@@ -13718,7 +13702,7 @@ export default () => {
 								})
 							);
 						},
-						content: function () {
+						content() {
 							player.chooseUseTarget("玉玺（庸肆）：选择知己知彼的目标", { name: "zhibi" });
 						},
 						audio: ["yongsi1", 2],
@@ -13728,13 +13712,13 @@ export default () => {
 						trigger: { global: "useCardToTargeted" },
 						//priority:16,
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.target && event.target == player && event.card && event.card.name == "zhibi";
 						},
-						check: function () {
+						check() {
 							return false;
 						},
-						content: function () {
+						content() {
 							player.showHandcards();
 						},
 					},
@@ -13745,10 +13729,10 @@ export default () => {
 				direct: true,
 				preHidden: true,
 				audio: 2,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.source && event.source.isAlive() && event.source != player && event.player == player && player.countCards("h") && event.num > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var players = game.filterPlayer(function (current) {
 						return (
@@ -13809,7 +13793,7 @@ export default () => {
 					maixie: true,
 					maixie_defend: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (get.tag(card, "damage") && target.hp > 1) {
 								if (player.hasSkillTag("jueqing", false, target)) return [1, -2];
 								if (!target.countCards("h")) return [1, -1];
@@ -13832,16 +13816,16 @@ export default () => {
 				forced: true,
 				preHidden: true,
 				audio: "drlt_congjian",
-				filter: function (event, player, name) {
+				filter(event, player, name) {
 					if (event.num <= 0) return false;
 					if (name == "damageBegin1" && _status.currentPhase != player) return true;
 					if (name == "damageBegin3" && _status.currentPhase == player) return true;
 					return false;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return _status.currentPhase != player;
 				},
-				content: function () {
+				content() {
 					trigger.num++;
 				},
 			},
@@ -13862,17 +13846,17 @@ export default () => {
 				},
 				audio: "wuziliangjiangdao",
 				forceaudio: true,
-				filter: function (event, player, name) {
+				filter(event, player, name) {
 					if (name != "phaseZhunbeiBegin") return get.is.jun(player) && player.identity == "wei";
 					return this.filter2.apply(this, arguments);
 				},
-				filter2: function (event, player) {
+				filter2(event, player) {
 					if (!get.zhu(player, "jianan")) return false;
 					if (!player.countCards("he")) return false;
 					return !player.isUnseen();
 				},
 				direct: true,
-				content: function () {
+				content() {
 					"step 0";
 					if (event.triggername != "phaseZhunbeiBegin") {
 						event.trigger("jiananUpdate");
@@ -13996,7 +13980,7 @@ export default () => {
 				enable: "phaseUse",
 				audio: 2,
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						game.countPlayer(function (current) {
 							return current.identity == "wei";
@@ -14006,14 +13990,14 @@ export default () => {
 						})
 					);
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (ui.selected.targets.length) return target.isDamaged() && target.identity == "wei";
 					return target.identity == "wei";
 				},
 				selectTarget: 2,
 				multitarget: true,
 				targetprompt: ["受到伤害</br>然后摸牌", "回复体力"],
-				content: function () {
+				content() {
 					"step 0";
 					targets[0].damage(player);
 					"step 1";
@@ -14024,7 +14008,7 @@ export default () => {
 					threaten: 1.2,
 					order: 9,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (ui.selected.targets.length) return 1;
 							if (get.damageEffect(target, player, player) > 0) return 2;
 							if (target.hp > 2) return 1;
@@ -14048,15 +14032,15 @@ export default () => {
 					others: {
 						trigger: { global: "equipAfter" },
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.player == player || !player.countCards("e", { subtype: ["equip3", "equip4"] })) return false;
 							return event.card.name == "liulongcanjia";
 						},
-						check: function (event, player) {
+						check(event, player) {
 							if (get.attitude(player, target) <= 0) return player.countCards("e", { subtype: ["equip4", "equip4"] }) < 2;
 							return true;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player.chooseBool("是否发动【总御】，与" + get.translation(trigger.player) + "交换装备区内坐骑牌？");
 							"step 1";
@@ -14078,7 +14062,7 @@ export default () => {
 						forceaudio: true,
 						trigger: { player: "equipAfter" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							// if (!player.hasSkill("gzzongyu")) return false;
 							// 村规
 							if (!player.hasSkill("gzzongyu", null, null, false)) return false;
@@ -14090,7 +14074,7 @@ export default () => {
 								return current != player && current.countCards("ej", "liulongcanjia");
 							});
 						},
-						content: function () {
+						content() {
 							var list = [];
 							for (var i = 0; i < ui.discardPile.childElementCount; i++) {
 								if (ui.discardPile.childNodes[i].name == "liulongcanjia") {
@@ -14125,7 +14109,7 @@ export default () => {
 				forceunique: true,
 				mark: true,
 				intro: {
-					content: function () {
+					content() {
 						return get.translation("wuziliangjiangdao_info");
 					},
 				},
@@ -14134,7 +14118,7 @@ export default () => {
 			gzzhengbi: {
 				audio: "zhengbi",
 				trigger: { player: "phaseUseBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					//if(event.player!=player) return false;
 					return (
 						game.hasPlayer(function (current) {
@@ -14142,7 +14126,7 @@ export default () => {
 						}) || player.countCards("h", { type: "basic" })
 					);
 				},
-				check: function (event, player) {
+				check(event, player) {
 					if (
 						player.countCards("h", function (card) {
 							return get.value(card) < 7;
@@ -14153,7 +14137,7 @@ export default () => {
 					}
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var choices = [];
 					if (
@@ -14220,16 +14204,16 @@ export default () => {
 							.chooseCardTarget({
 								prompt: "请将一张基本牌交给一名已确定势力的其他角色",
 								position: "h",
-								filterCard: function (card) {
+								filterCard(card) {
 									return get.type(card) == "basic";
 								},
-								filterTarget: function (card, player, target) {
+								filterTarget(card, player, target) {
 									return target != player && target.identity != "unknown";
 								},
-								ai1: function (card) {
+								ai1(card) {
 									return 5 - get.value(card);
 								},
-								ai2: function (target) {
+								ai2(target) {
 									var player = _status.event.player;
 									var att = get.attitude(player, target);
 									if (att > 0) return 0;
@@ -14291,14 +14275,14 @@ export default () => {
 						trigger: { player: "phaseUseEnd" },
 						forced: true,
 						charlotte: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							var target = player.storage.gzzhengbi_eff1;
 							return target && !target.isUnseen() && target.countGainableCards(player, "he") > 0;
 						},
-						logTarget: function (event, player) {
+						logTarget(event, player) {
 							return player.storage.gzzhengbi_eff1;
 						},
-						content: function () {
+						content() {
 							var num = 0;
 							var target = player.storage.gzzhengbi_eff1;
 							if (target.countGainableCards(player, "h")) num++;
@@ -14322,16 +14306,16 @@ export default () => {
 				position: "h",
 				filterCard: true,
 				selectCard: -1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return !player.storage.gzfengying && player.countCards("h") > 0;
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target == player;
 				},
 				selectTarget: -1,
 				discard: false,
 				lose: false,
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("gzfengying");
 					player.storage.gzfengying = true;
@@ -14351,7 +14335,7 @@ export default () => {
 				ai: {
 					order: 0.1,
 					result: {
-						player: function (player) {
+						player(player) {
 							var value = 0;
 							var cards = player.getCards("h");
 							if (cards.length >= 4) return 0;
@@ -14375,7 +14359,7 @@ export default () => {
 
 			junling4_eff: {
 				mod: {
-					cardEnabled2: function (card) {
+					cardEnabled2(card) {
 						if (get.position(card) == "h") return false;
 					},
 				},
@@ -14391,7 +14375,7 @@ export default () => {
 				forced: true,
 				silent: true,
 				popup: false,
-				content: function () {
+				content() {
 					trigger.cancel();
 				},
 				mark: true,
@@ -14401,7 +14385,7 @@ export default () => {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (get.tag(card, "recover")) return "zeroplayertarget";
 						},
 					},
@@ -14410,7 +14394,7 @@ export default () => {
 
 			gzjieyue: {
 				trigger: { player: "phaseZhunbeiBegin" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("h") &&
 						game.hasPlayer(function (current) {
@@ -14420,21 +14404,21 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCardTarget({
 							prompt: get.prompt2("gzjieyue"),
 							position: "h",
 							filterCard: true,
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								return target.identity != "wei" && target != player;
 							},
-							ai1: function (card, player, target) {
+							ai1(card, player, target) {
 								if (get.attitude(player, target) > 0) return 11 - get.value(card);
 								return 7 - get.value(card);
 							},
-							ai2: function (target) {
+							ai2(target) {
 								var att = get.attitude(get.event().player, target);
 								if (att < 0) return -att;
 								return 1;
@@ -14473,12 +14457,12 @@ export default () => {
 					eff: {
 						sub: true,
 						trigger: { player: "phaseDrawBegin2" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return !event.numFixed;
 						},
 						forced: true,
 						popup: false,
-						content: function () {
+						content() {
 							trigger.num += 3;
 						},
 					},
@@ -14491,13 +14475,13 @@ export default () => {
 				limited: true,
 				audio: 2,
 				enable: "phaseUse",
-				prepare: function (cards, player) {
+				prepare(cards, player) {
 					var targets = game.filterPlayer(function (current) {
 						return current.isFriendOf(player) || current.isUnseen();
 					});
 					player.line(targets, "fire");
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("jianglue");
 					player.addTempSkill("jianglue_count");
@@ -14589,7 +14573,7 @@ export default () => {
 				ai: {
 					order: 10,
 					result: {
-						player: function (player) {
+						player(player) {
 							if (player.isUnseen() && player.wontYe()) {
 								if (get.population(player.group) >= game.players.length / 4) return 1;
 								return Math.random() > 0.7 ? 1 : 0;
@@ -14602,10 +14586,10 @@ export default () => {
 						sub: true,
 						trigger: { global: "recoverAfter" },
 						silent: true,
-						filter: function (event) {
+						filter(event) {
 							return event.getParent("jianglue");
 						},
-						content: function () {
+						content() {
 							player.storage.jianglue_count++;
 						},
 					},
@@ -14616,7 +14600,7 @@ export default () => {
 				global: "gzxuanhuo_others",
 				derivation: ["fz_wusheng", "fz_new_paoxiao", "fz_new_longdan", "fz_new_tieji", "fz_liegong", "fz_xinkuanggu"],
 				ai: {
-					threaten: function (player, target) {
+					threaten(player, target) {
 						if (
 							game.hasPlayer(function (current) {
 								return current != target && current.isFriendOf(target);
@@ -14632,7 +14616,7 @@ export default () => {
 						forceaudio: true,
 						enable: "phaseUse",
 						usable: 1,
-						filter: function (event, player) {
+						filter(event, player) {
 							return (
 								!player.isUnseen() &&
 								player.countCards("h") > 0 &&
@@ -14644,7 +14628,7 @@ export default () => {
 						prompt: "弃置一张手牌，然后获得以下技能中的一个：〖武圣〗〖咆哮〗〖龙胆〗〖铁骑〗〖烈弓〗〖狂骨〗",
 						position: "h",
 						filterCard: true,
-						check: function (card) {
+						check(card) {
 							let player = _status.event.player,
 								shas = player.countCards("h", cardx => {
 									return cardx != card && cardx.name == "sha" && player.hasUseTarget(cardx);
@@ -14654,7 +14638,7 @@ export default () => {
 							if (!shas || count - shas > 1) return (player.needsToDiscard() ? 7 : 1) - val;
 							return 7 - val;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var list = ["new_rewusheng", "gzpaoxiao", "new_longdan", "new_tieji", "liegong", "xinkuanggu"];
 							player
@@ -14732,11 +14716,11 @@ export default () => {
 							player: "useCard",
 						},
 						//priority:1,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill == "fz_new_longdan_shan" && event.getParent(2).name == "sha";
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget("是否发动【龙胆】令一名其他角色回复1点体力？", function (card, player, target) {
@@ -14760,10 +14744,10 @@ export default () => {
 							player: "shaMiss",
 						},
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill == "fz_new_longdan_sha";
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget("是否发动【龙胆】对一名其他角色造成1点伤害？", function (card, player, target) {
@@ -14787,11 +14771,11 @@ export default () => {
 						audio: "fz_new_longdan",
 						forced: true,
 						locked: false,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (!get.zhu(player, "shouyue")) return false;
 							return event.skill == "fz_new_longdan_sha" || event.skill == "fz_new_longdan_shan";
 						},
-						content: function () {
+						content() {
 							player.draw();
 							//player.storage.fanghun2++;
 						},
@@ -14806,25 +14790,25 @@ export default () => {
 						viewAs: {
 							name: "sha",
 						},
-						viewAsFilter: function (player) {
+						viewAsFilter(player) {
 							if (!player.countCards("hs", "shan")) return false;
 						},
 						prompt: "将一张闪当杀使用或打出",
 						position: "hs",
-						check: function () {
+						check() {
 							return 1;
 						},
 						ai: {
 							effect: {
-								target: function (card, player, target, current) {
+								target(card, player, target, current) {
 									if (get.tag(card, "respondSha") && current < 0) return 0.6;
 								},
 							},
 							respondSha: true,
-							skillTagFilter: function (player) {
+							skillTagFilter(player) {
 								if (!player.countCards("hs", "shan")) return false;
 							},
-							order: function () {
+							order() {
 								return get.order({ name: "sha" }) + 0.1;
 							},
 						},
@@ -14841,19 +14825,19 @@ export default () => {
 						},
 						position: "hs",
 						prompt: "将一张杀当闪使用或打出",
-						check: function () {
+						check() {
 							return 1;
 						},
-						viewAsFilter: function (player) {
+						viewAsFilter(player) {
 							if (!player.countCards("hs", "sha")) return false;
 						},
 						ai: {
 							respondShan: true,
-							skillTagFilter: function (player) {
+							skillTagFilter(player) {
 								if (!player.countCards("hs", "sha")) return false;
 							},
 							effect: {
-								target: function (card, player, target, current) {
+								target(card, player, target, current) {
 									if (get.tag(card, "respondShan") && current < 0) return 0.6;
 								},
 							},
@@ -14870,7 +14854,7 @@ export default () => {
 				ai: {
 					maixie_defend: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (player.hasSkillTag("jueqing", false, target)) return [1, -1.5];
 							if (!target.hasFriend()) return;
 							if (get.tag(card, "damage")) return [1, 0, 0, -0.7];
@@ -14882,11 +14866,11 @@ export default () => {
 						audio: "xinenyuan",
 						trigger: { target: "useCardToTargeted" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.card.name == "tao" && event.player != player;
 						},
 						logTarget: "player",
-						content: function () {
+						content() {
 							trigger.player.draw();
 						},
 					},
@@ -14894,10 +14878,10 @@ export default () => {
 						audio: "xinenyuan",
 						trigger: { player: "damageEnd" },
 						forced: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.source && event.source != player && event.num > 0;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player.logSkill("enyuan_damage", trigger.source);
 							trigger.source.chooseCard("交给" + get.translation(player) + "一张手牌，或失去1点体力", "h").set("ai", function (card) {
@@ -14919,7 +14903,7 @@ export default () => {
 					player: "phaseJieshuBegin",
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var list = [],
 						players = game.filterPlayer();
@@ -14964,7 +14948,7 @@ export default () => {
 					},
 				},
 				mod: {
-					targetInRange: function (card, player, target) {
+					targetInRange(card, player, target) {
 						if (card.name == "bingliang") {
 							return true;
 						}
@@ -14974,11 +14958,11 @@ export default () => {
 				audio: "duanliang1",
 				audioname2: { gz_jun_caocao: "jianan_duanliang" },
 				enable: "chooseToUse",
-				filterCard: function (card) {
+				filterCard(card) {
 					if (get.type(card) != "basic" && get.type(card) != "equip") return false;
 					return get.color(card) == "black";
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.hasSkill("new_duanliang_off")) return false;
 					return player.countCards("hes", { type: ["basic", "equip"], color: "black" });
 				},
@@ -14986,11 +14970,11 @@ export default () => {
 				viewAs: {
 					name: "bingliang",
 				},
-				onuse: function (result, player) {
+				onuse(result, player) {
 					if (get.distance(player, result.targets[0]) > 2) player.addTempSkill("new_duanliang_off");
 				},
 				prompt: "将一黑色的基本牌或装备牌当兵粮寸断使用",
-				check: function (card) {
+				check(card) {
 					return 6 - get.value(card);
 				},
 				ai: {
@@ -15001,7 +14985,7 @@ export default () => {
 						value: 4,
 					},
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (target.hasJudge("caomu")) return 0;
 							return -1.5 / Math.sqrt(target.countCards("h") + 1);
 						},
@@ -15018,7 +15002,7 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					event.num = trigger.num || 1;
 					"step 1";
@@ -15051,20 +15035,20 @@ export default () => {
 				viewAs: {
 					name: "wanjian",
 				},
-				filterCard: function (card, player) {
+				filterCard(card, player) {
 					if (!player.storage.new_luanji) return true;
 					return !player.storage.new_luanji.includes(get.suit(card));
 				},
 				selectCard: 2,
 				position: "hs",
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("hs", function (card) {
 							return !player.storage.new_luanji || !player.storage.new_luanji.includes(get.suit(card));
 						}) > 1
 					);
 				},
-				check: function (card) {
+				check(card) {
 					var player = _status.event.player;
 					var targets = game.filterPlayer(function (current) {
 						return player.canUse("wanjian", current);
@@ -15093,10 +15077,10 @@ export default () => {
 							player: "phaseAfter",
 						},
 						silent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.storage.new_luanji ? true : false;
 						},
-						content: function () {
+						content() {
 							delete player.storage.new_luanji;
 						},
 						sub: true,
@@ -15108,10 +15092,10 @@ export default () => {
 							player: "useCard",
 						},
 						silent: true,
-						filter: function (event) {
+						filter(event) {
 							return event.skill == "new_luanji";
 						},
-						content: function () {
+						content() {
 							if (!player.storage.new_luanji) {
 								player.storage.new_luanji = [];
 							}
@@ -15128,11 +15112,11 @@ export default () => {
 							global: "respond",
 						},
 						silent: true,
-						filter: function (event) {
+						filter(event) {
 							if (event.player.isUnseen()) return false;
 							return event.getParent(2).skill == "new_luanji" && event.player.isFriendOf(_status.currentPhase);
 						},
-						content: function () {
+						content() {
 							trigger.player.draw();
 						},
 						sub: true,
@@ -15144,7 +15128,7 @@ export default () => {
 			new_qingcheng: {
 				audio: "qingcheng",
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					return (
 						player.countCards("he", { color: "black" }) &&
 						game.hasPlayer(function (current) {
@@ -15156,14 +15140,14 @@ export default () => {
 					color: "black",
 				},
 				position: "he",
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (target == player) return false;
 					return !target.isUnseen(2);
 				},
-				check: function (card) {
+				check(card) {
 					return 6 - get.value(card, _status.event.player);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					event.target = target;
 					event.done = false;
@@ -15219,7 +15203,7 @@ export default () => {
 				ai: {
 					order: 8,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (target.hp <= 0) return -5;
 							if (player.getStat().skill.new_qingcheng) return 0;
 							if (!target.hasSkillTag("maixie")) return 0;
@@ -15245,10 +15229,10 @@ export default () => {
 						trigger: {
 							player: "gainBefore",
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.source && event.source != player && player != _status.currentPhase && !event.bySelf && player.countCards("h") == 0;
 						},
-						content: function () {
+						content() {
 							trigger.name = "addToExpansion";
 							trigger.setContent("addToExpansion");
 							trigger.gaintag = ["new_kongcheng"];
@@ -15262,10 +15246,10 @@ export default () => {
 						trigger: {
 							player: "phaseDrawBegin1",
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getExpansions("new_kongcheng").length > 0;
 						},
-						content: function () {
+						content() {
 							player.gain(player.getExpansions("new_kongcheng"), "draw");
 						},
 						sub: true,
@@ -15277,25 +15261,25 @@ export default () => {
 					target: "useCardToTarget",
 				},
 				forced: true,
-				check: function (event, player) {
+				check(event, player) {
 					return get.effect(event.target, event.card, event.player, player) < 0;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") == 0 && (event.card.name == "sha" || event.card.name == "juedou");
 				},
-				content: function () {
+				content() {
 					trigger.getParent().targets.remove(player);
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (target.countCards("h") == 0 && (card.name == "sha" || card.name == "juedou")) return "zeroplayertarget";
 						},
 					},
 				},
 				intro: {
 					markcount: "expansion",
-					mark: function (dialog, content, player) {
+					mark(dialog, content, player) {
 						var content = player.getExpansions("new_kongcheng");
 						if (content && content.length) {
 							if (player == game.me || player.isUnderControl()) {
@@ -15305,7 +15289,7 @@ export default () => {
 							}
 						}
 					},
-					content: function (content, player) {
+					content(content, player) {
 						var content = player.getExpansions("new_kongcheng");
 						if (content && content.length) {
 							if (player == game.me || player.isUnderControl()) {
@@ -15315,7 +15299,7 @@ export default () => {
 						}
 					},
 				},
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
@@ -15326,7 +15310,7 @@ export default () => {
 				trigger: {
 					player: "phaseDiscardBegin",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					var list = [];
 					player.getHistory("useCard", function (evt) {
 						if (evt.isPhaseUsing(player)) {
@@ -15336,17 +15320,17 @@ export default () => {
 					});
 					return list.length <= 1;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return player.needsToDiscard();
 				},
-				content: function () {
+				content() {
 					player.addTempSkill("keji_add", "phaseAfter");
 				},
 			},
 			keji_add: {
 				charlotte: true,
 				mod: {
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						return num + 4;
 					},
 				},
@@ -15357,7 +15341,7 @@ export default () => {
 				},
 				//priority:2,
 				audio: "botu",
-				filter: function (event, player) {
+				filter(event, player) {
 					var history = player.getHistory("useCard");
 					var suits = [];
 					var types = [];
@@ -15368,10 +15352,10 @@ export default () => {
 					}
 					return suits.length >= 4 || types.length >= 3;
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return player.canMoveCard(true);
 				},
-				content: function () {
+				content() {
 					player.moveCard();
 				},
 			},
@@ -15388,11 +15372,11 @@ export default () => {
 							player: "useCard",
 						},
 						//priority:1,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill == "new_longdan_shan" && event.getParent(2).name == "sha";
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget("是否发动【龙胆】令一名其他角色回复1点体力？", function (card, player, target) {
@@ -15417,10 +15401,10 @@ export default () => {
 							player: "shaMiss",
 						},
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill == "new_longdan_sha";
 						},
-						content: function () {
+						content() {
 							"step 0";
 							player
 								.chooseTarget("是否发动【龙胆】对一名其他角色造成1点伤害？", function (card, player, target) {
@@ -15445,11 +15429,11 @@ export default () => {
 						audioname2: { gz_jun_liubei: "shouyue_longdan" },
 						forced: true,
 						locked: false,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (!get.zhu(player, "shouyue")) return false;
 							return event.skill == "new_longdan_sha" || event.skill == "new_longdan_shan";
 						},
-						content: function () {
+						content() {
 							player.draw();
 							//player.storage.fanghun2++;
 						},
@@ -15466,24 +15450,24 @@ export default () => {
 							name: "sha",
 						},
 						position: "hs",
-						viewAsFilter: function (player) {
+						viewAsFilter(player) {
 							if (!player.countCards("hs", "shan")) return false;
 						},
 						prompt: "将一张闪当杀使用或打出",
-						check: function () {
+						check() {
 							return 1;
 						},
 						ai: {
 							effect: {
-								target: function (card, player, target, current) {
+								target(card, player, target, current) {
 									if (get.tag(card, "respondSha") && current < 0) return 0.6;
 								},
 							},
 							respondSha: true,
-							skillTagFilter: function (player) {
+							skillTagFilter(player) {
 								if (!player.countCards("hs", "shan")) return false;
 							},
-							order: function () {
+							order() {
 								return get.order({ name: "sha" }) + 0.1;
 							},
 						},
@@ -15501,19 +15485,19 @@ export default () => {
 						},
 						position: "hs",
 						prompt: "将一张杀当闪使用或打出",
-						check: function () {
+						check() {
 							return 1;
 						},
-						viewAsFilter: function (player) {
+						viewAsFilter(player) {
 							if (!player.countCards("hs", "sha")) return false;
 						},
 						ai: {
 							respondShan: true,
-							skillTagFilter: function (player) {
+							skillTagFilter(player) {
 								if (!player.countCards("hs", "sha")) return false;
 							},
 							effect: {
-								target: function (card, player, target, current) {
+								target(card, player, target, current) {
 									if (get.tag(card, "respondShan") && current < 0) return 0.6;
 								},
 							},
@@ -15528,7 +15512,7 @@ export default () => {
 				trigger: {
 					player: "useCard",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (_status.currentPhase != player) return false;
 					if (event.card.name != "sha") return false;
 					var history = player.getHistory("useCard", function (evt) {
@@ -15538,17 +15522,17 @@ export default () => {
 				},
 				forced: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					player.draw();
 				},
 				mod: {
-					cardUsable: function (card, player, num) {
+					cardUsable(card, player, num) {
 						if (card.name == "sha") return Infinity;
 					},
 				},
 				ai: {
 					unequip: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (!get.zhu(player, "shouyue")) return false;
 						if (arg && arg.name == "sha") return true;
 						return false;
@@ -15560,11 +15544,11 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				filterCard: true,
-				check: function (card) {
+				check(card) {
 					return 8 - get.value(card);
 				},
 				position: "he",
-				content: function () {
+				content() {
 					player.loseHp();
 					player.draw(3);
 					player.addTempSkill("kurou_effect", "phaseAfter");
@@ -15572,7 +15556,7 @@ export default () => {
 				ai: {
 					order: 8,
 					result: {
-						player: function (player) {
+						player(player) {
 							if (player.hp <= 2) return player.countCards("h") == 0 ? 1 : 0;
 							if (player.countCards("h", { name: "sha", color: "red" })) return 1;
 							return player.countCards("h") <= player.hp ? 1 : 0;
@@ -15582,7 +15566,7 @@ export default () => {
 			},
 			kurou_effect: {
 				mod: {
-					cardUsable: function (card, player, num) {
+					cardUsable(card, player, num) {
 						if (card.name == "sha") return num + 1;
 					},
 				},
@@ -15591,29 +15575,29 @@ export default () => {
 				audio: "chulao",
 				enable: "phaseUse",
 				usable: 1,
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (player == target) return false;
 					for (var i = 0; i < ui.selected.targets.length; i++) {
 						if (ui.selected.targets[i].isFriendOf(target)) return false;
 					}
 					return target.countCards("he") > 0;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("he") > 0;
 				},
 				filterCard: true,
 				position: "he",
 				selectTarget: [1, 3],
-				check: function (card) {
+				check(card) {
 					if (get.suit(card) == "spade") return 8 - get.value(card);
 					return 5 - get.value(card);
 				},
-				contentBefore: function () {
+				contentBefore() {
 					var evt = event.getParent();
 					evt.draw = [];
 					if (get.suit(cards[0]) == "spade") evt.draw.push(player);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.discardPlayerCard(target, "he", true);
 					"step 1";
@@ -15621,7 +15605,7 @@ export default () => {
 						if (get.suit(result.cards[0]) == "spade") event.getParent().draw.push(target);
 					}
 				},
-				contentAfter: function () {
+				contentAfter() {
 					"step 0";
 					var list = event.getParent().draw;
 					if (!list.length) event.finish();
@@ -15649,7 +15633,7 @@ export default () => {
 				preHidden: true,
 				derivation: ["baka_yingzi", "baka_yinghun"],
 				viceSkill: true,
-				init: function (player) {
+				init(player) {
 					if (player.checkViceSkill("baka_hunshang") && !player.viceChanged) {
 						player.removeMaxHp();
 					}
@@ -15657,23 +15641,23 @@ export default () => {
 				trigger: {
 					player: "phaseZhunbeiBegin",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hp <= 1;
 				},
 				forced: true,
 				locked: false,
 				//priority:3,
-				content: function () {
+				content() {
 					player.addTempSkills(["baka_yingzi", "baka_yinghun"]);
 				},
 				ai: {
-					threaten: function (player, target) {
+					threaten(player, target) {
 						if (target.hp == 1) return 2;
 						return 0.5;
 					},
 					maixie: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (!target.hasFriend()) return;
 							if (get.tag(card, "damage") == 1 && target.hp == 2 && !target.isTurnedOver() && _status.currentPhase != target && get.distance(_status.currentPhase, target, "absolute") <= 3) return [0.5, 1];
 						},
@@ -15686,7 +15670,7 @@ export default () => {
 			},
 			baka_yingzi: {
 				mod: {
-					maxHandcardBase: function (player, num) {
+					maxHandcardBase(player, num) {
 						return player.maxHp;
 					},
 				},
@@ -15695,10 +15679,10 @@ export default () => {
 					player: "phaseDrawBegin2",
 				},
 				frequent: true,
-				filter: function (event) {
+				filter(event) {
 					return !event.numFixed;
 				},
-				content: function () {
+				content() {
 					trigger.num++;
 				},
 				ai: {
@@ -15712,7 +15696,7 @@ export default () => {
 				},
 				frequent: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					event.cards = game.cardsGotoOrdering(get.cards(2)).cards;
 					"step 1";
@@ -15781,7 +15765,7 @@ export default () => {
 					maixie: true,
 					maixie_hp: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (get.tag(card, "damage")) {
 								if (player.hasSkillTag("jueqing", false, target)) return [1, -2];
 								if (!target.hasFriend()) return;
@@ -15808,7 +15792,7 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt("gzjieming"), "令一名角色将手牌补至X张（X为其体力上限且至多为5）", function (card, player, target) {
@@ -15835,7 +15819,7 @@ export default () => {
 					maixie: true,
 					maixie_hp: true,
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.tag(card, "damage") && target.hp > 1) {
 								if (player.hasSkillTag("jueqing", false, target)) return [1, -2];
 								var max = 0;
@@ -15868,7 +15852,7 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt2("gzfangzhu"), function (card, player, target) {
@@ -15917,7 +15901,7 @@ export default () => {
 					maixie: true,
 					maixie_hp: true,
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (get.tag(card, "damage")) {
 								if (player.hasSkillTag("jueqing", false, target)) return [1, -2];
 								if (target.hp <= 1) return;
@@ -15943,20 +15927,20 @@ export default () => {
 				},
 			},
 			fengyin_main: {
-				init: function (player, skill) {
+				init(player, skill) {
 					player.addSkillBlocker(skill);
 				},
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					player.removeSkillBlocker(skill);
 				},
 				charlotte: true,
-				skillBlocker: function (skill, player) {
+				skillBlocker(skill, player) {
 					return lib.character[player.name1][3].includes(skill) && !lib.skill[skill].charlotte && !get.is.locked(skill, player);
 				},
 				mark: true,
 				marktext: "主",
 				intro: {
-					content: function (storage, player, skill) {
+					content(storage, player, skill) {
 						var list = player.getSkills(null, null, false).filter(function (i) {
 							return lib.skill.fengyin_main.skillBlocker(i, player);
 						});
@@ -15966,20 +15950,20 @@ export default () => {
 				},
 			},
 			fengyin_vice: {
-				init: function (player, skill) {
+				init(player, skill) {
 					player.addSkillBlocker(skill);
 				},
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					player.removeSkillBlocker(skill);
 				},
 				charlotte: true,
-				skillBlocker: function (skill, player) {
+				skillBlocker(skill, player) {
 					return lib.character[player.name2][3].includes(skill) && !lib.skill[skill].charlotte && !get.is.locked(skill, player);
 				},
 				mark: true,
 				marktext: "副",
 				intro: {
-					content: function (storage, player, skill) {
+					content(storage, player, skill) {
 						var list = player.getSkills(null, null, false).filter(function (i) {
 							return lib.skill.fengyin_vice.skillBlocker(i, player);
 						});
@@ -15994,14 +15978,14 @@ export default () => {
 				trigger: {
 					player: "useCardToPlayered",
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return get.attitude(player, event.target) < 0;
 				},
-				filter: function (event) {
+				filter(event) {
 					return event.card.name == "sha";
 				},
 				logTarget: "target",
-				content: function () {
+				content() {
 					"step 0";
 					var target = trigger.target;
 					var controls = [];
@@ -16072,21 +16056,21 @@ export default () => {
 				},
 				forced: true,
 				preHidden: true,
-				check: function (event, player) {
+				check(event, player) {
 					return true;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.num <= 0 || !event.source) return false;
 					var n1 = player.getNext();
 					var p1 = player.getPrevious();
 					if (event.source != n1 && event.source != p1) return true;
 				},
-				content: function () {
+				content() {
 					trigger.cancel();
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (player.hasSkillTag("jueqing", false, target)) return;
 							if (player == target.getNext() || player == target.getPrevious()) return;
 							if (get.tag(card, "damage")) return "zeroplayertarget";
@@ -16097,27 +16081,27 @@ export default () => {
 			hmkguishu: {
 				audio: "bmcanshi",
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("hs", { suit: "spade" }) > 0;
 				},
-				init: function (player) {
+				init(player) {
 					if (!player.storage.hmkguishu) player.storage.hmkguishu = 0;
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var list = ["yuanjiao", "zhibi"];
 						for (var i = 0; i < list.length; i++) {
 							list[i] = ["锦囊", "", list[i]];
 						}
 						return ui.create.dialog("鬼术", [list, "vcard"]);
 					},
-					filter: function (button, player) {
+					filter(button, player) {
 						var name = button.link[2];
 						if (player.storage.hmkguishu == 1 && name == "yuanjiao") return false;
 						if (player.storage.hmkguishu == 2 && name == "zhibi") return false;
 						return lib.filter.filterCard({ name: name }, player, _status.event.getParent());
 					},
-					check: function (button) {
+					check(button) {
 						var player = _status.event.player;
 						if (button.link == "yuanjiao") {
 							return 3;
@@ -16127,34 +16111,34 @@ export default () => {
 							return 0;
 						}
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						return {
 							audio: "bmcanshi",
-							filterCard: function (card, player) {
+							filterCard(card, player) {
 								return get.suit(card) == "spade";
 							},
 							position: "hs",
 							selectCard: 1,
 							popname: true,
-							ai: function (card) {
+							ai(card) {
 								return 6 - ai.get.value(card);
 							},
 							viewAs: { name: links[0][2] },
-							onuse: function (result, player) {
+							onuse(result, player) {
 								player.logSkill("hmkguishu");
 								if (result.card.name == "yuanjiao") player.storage.hmkguishu = 1;
 								else player.storage.hmkguishu = 2;
 							},
 						};
 					},
-					prompt: function (links, player) {
+					prompt(links, player) {
 						return "将一张手牌当作" + get.translation(links[0][2]) + "使用";
 					},
 				},
 				ai: {
 					order: 4,
 					result: {
-						player: function (player) {
+						player(player) {
 							return 2;
 						},
 					},
@@ -16164,7 +16148,7 @@ export default () => {
 			_mingzhisuodingji: {
 				mode: ["guozhan"],
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.hasSkillTag("nomingzhi", false, null, true)) return false;
 					var bool = false;
 					var skillm = lib.character[player.name1][3];
@@ -16186,7 +16170,7 @@ export default () => {
 					return bool;
 				},
 				popup: false,
-				content: function () {
+				content() {
 					"step 0";
 					var choice = [];
 					var skillm = lib.character[player.name1][3];
@@ -16239,12 +16223,12 @@ export default () => {
 				silent: true,
 				popup: false,
 				forced: true,
-				filter: function () {
+				filter() {
 					if (_status.connectMode && !lib.configOL.viewnext) return false;
 					else if (!_status.connectMode && !get.config("viewnext")) return false;
 					return game.players.length > 1;
 				},
-				content: function () {
+				content() {
 					var target = player.getNext();
 					player.viewCharacter(target, 1);
 				},
@@ -16255,7 +16239,7 @@ export default () => {
 				},
 				forced: true,
 				priority: 22,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (get.mode() != "guozhan") return false;
 					if (_status.connectMode && !lib.configOL.aozhan) return false;
 					else if (!_status.connectMode && !get.config("aozhan")) return false;
@@ -16269,7 +16253,7 @@ export default () => {
 					}
 					return true;
 				},
-				content: function () {
+				content() {
 					var color = get.groupnature(player.group, "raw");
 					if (player.isUnseen()) color = "fire";
 					player.$fullscreenpop("鏖战模式", color);
@@ -16310,14 +16294,14 @@ export default () => {
 			_guozhan_marks: {
 				ruleSkill: true,
 				enable: "phaseUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hasMark("yexinjia_mark") || player.hasMark("xianqu_mark") || player.hasMark("yinyang_mark") || player.hasMark("zhulianbihe_mark");
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						return ui.create.dialog("###国战标记###弃置一枚对应的标记，发动其对应的效果");
 					},
-					chooseControl: function (event, player) {
+					chooseControl(event, player) {
 						var list = [],
 							bool = player.hasMark("yexinjia_mark");
 						if (bool || player.hasMark("xianqu_mark")) list.push("先驱");
@@ -16329,7 +16313,7 @@ export default () => {
 						list.push("cancel2");
 						return list;
 					},
-					check: function () {
+					check() {
 						var player = _status.event.player,
 							bool = player.hasMark("yexinjia_mark");
 						if ((bool || player.hasMark("xianqu_mark")) && 4 - player.countCards("h") > 1) return "先驱";
@@ -16346,20 +16330,20 @@ export default () => {
 						if (player.hasMark("yinyang_mark") && player.getHandcardLimit() - player.countCards("h") > 0) return "阴阳鱼";
 						return "cancel2";
 					},
-					backup: function (result, player) {
+					backup(result, player) {
 						switch (result.control) {
 							case "珠联(桃)":
 								return get.copy(lib.skill._zhulianbihe_mark_tao);
 							case "珠联(摸牌)":
 								return {
-									content: function () {
+									content() {
 										player.draw(2);
 										player.removeMark(player.hasMark("zhulianbihe_mark") ? "zhulianbihe_mark" : "yexinjia_mark", 1);
 									},
 								};
 							case "阴阳鱼":
 								return {
-									content: function () {
+									content() {
 										player.draw();
 										player.removeMark(player.hasMark("yinyang_mark") ? "yinyang_mark" : "yexinjia_mark", 1);
 									},
@@ -16380,7 +16364,7 @@ export default () => {
 				intro: {
 					content: "◇出牌阶段，你可以弃置此标记，然后将手牌摸至四张并观看一名其他角色的一张武将牌。",
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.removeMark(player.hasMark("xianqu_mark") ? "xianqu_mark" : "yexinjia_mark", 1);
 					var num = 4 - player.countCards("h");
@@ -16446,21 +16430,21 @@ export default () => {
 			_zhulianbihe_mark_tao: {
 				ruleSkill: true,
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.type != "phase" && (player.hasMark("zhulianbihe_mark") || player.hasMark("yexinjia_mark"));
 				},
-				viewAsFilter: function (player) {
+				viewAsFilter(player) {
 					return player.hasMark("zhulianbihe_mark") || player.hasMark("yexinjia_mark");
 				},
 				viewAs: {
 					name: "tao",
 					isCard: true,
 				},
-				filterCard: function () {
+				filterCard() {
 					return false;
 				},
 				selectCard: -1,
-				precontent: function () {
+				precontent() {
 					player.removeMark(player.hasMark("zhulianbihe_mark") ? "zhulianbihe_mark" : "yexinjia_mark", 1);
 				},
 			},
@@ -16469,20 +16453,20 @@ export default () => {
 				trigger: {
 					player: "phaseDiscardBegin",
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return (player.hasMark("yinyang_mark") || player.hasMark("yexinjia_mark")) && player.needsToDiscard();
 				},
-				prompt: function (event, player) {
+				prompt(event, player) {
 					return "是否弃置一枚【" + (player.hasMark("yinyang_mark") ? "阴阳鱼" : "野心家") + "】标记，使本回合的手牌上限+2？";
 				},
-				content: function () {
+				content() {
 					player.addTempSkill("yinyang_add", "phaseAfter");
 					player.removeMark(player.hasMark("yinyang_mark") ? "yinyang_mark" : "yexinjia_mark", 1);
 				},
 			},
 			yinyang_add: {
 				mod: {
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						return num + 2;
 					},
 				},
@@ -16505,20 +16489,20 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				prompt: "将至多三张可合纵的牌交给一名与你势力不同的角色，或未确定势力的角色，若你交给与你势力不同的角色，则你摸等量的牌",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hasCard(function (card) {
 						return card.hasTag("lianheng") || card.hasGaintag("_lianheng");
 					}, "h");
 				},
-				filterCard: function (card) {
+				filterCard(card) {
 					return card.hasTag("lianheng") || card.hasGaintag("_lianheng");
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					if (target == player) return false;
 					if (player.isUnseen()) return target.isUnseen();
 					return !target.isFriendOf(player);
 				},
-				check: function (card) {
+				check(card) {
 					if (card.name == "tao") return 0;
 					return 7 - get.value(card);
 				},
@@ -16526,7 +16510,7 @@ export default () => {
 				discard: false,
 				lose: false,
 				delay: false,
-				content: function () {
+				content() {
 					"step 0";
 					player.give(cards, target);
 					"step 1";
@@ -16539,7 +16523,7 @@ export default () => {
 						order: 8,
 					},
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							var huoshao = false;
 							for (var i = 0; i < ui.selected.cards.length; i++) {
 								if (ui.selected.cards[i].name == "huoshaolianying") {
@@ -16556,7 +16540,7 @@ export default () => {
 							if (!player.isMajor() && huoshao && !target.isMajor() && target.getNext().isMajor()) return 1.5;
 							return 1;
 						},
-						target: function (player, target) {
+						target(player, target) {
 							if (target.isUnseen()) return 0;
 							return 1;
 						},
@@ -16569,7 +16553,7 @@ export default () => {
 					content: "expansion",
 					markcount: "expansion",
 				},
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
@@ -16581,7 +16565,7 @@ export default () => {
 				subSkill: {
 					add: {
 						trigger: { global: "damageEnd" },
-						filter: function (event, player) {
+						filter(event, player) {
 							var suits = [],
 								cards = player.getExpansions("qianhuan");
 							for (var i = 0; i < cards.length; i++) {
@@ -16597,7 +16581,7 @@ export default () => {
 							);
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							var suits = [],
 								cards = player.getExpansions("qianhuan");
@@ -16623,12 +16607,12 @@ export default () => {
 					},
 					use: {
 						trigger: { global: "useCardToTarget" },
-						filter: function (event, player) {
+						filter(event, player) {
 							if (!["basic", "trick"].includes(get.type(event.card, "trick"))) return false;
 							return event.target && player.isFriendOf(event.target) && event.targets.length == 1 && player.getExpansions("qianhuan").length;
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							var goon = get.effect(trigger.target, trigger.card, trigger.player, player) < 0;
 							if (goon) {
@@ -16681,7 +16665,7 @@ export default () => {
 			gzsanyao: {
 				audio: "sanyao",
 				inherit: "sanyao",
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target.hp > player.hp || target.countCards("h") > player.countCards("h");
 				},
 			},
@@ -16689,7 +16673,7 @@ export default () => {
 				audio: "zhiman",
 				inherit: "zhiman",
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					if (trigger.player.countGainableCards(player, "ej")) {
 						player.gainPlayerCard(trigger.player, "ej", true);
@@ -16704,7 +16688,7 @@ export default () => {
 			gzdiancai: {
 				audio: "diancai",
 				trigger: { global: "phaseUseEnd" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (_status.currentPhase == player) return false;
 					var num = 0;
 					player.getHistory("lose", function (evt) {
@@ -16713,7 +16697,7 @@ export default () => {
 					return num >= player.hp;
 				},
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var num = player.maxHp - player.countCards("h");
 					if (num > 0) {
@@ -16730,11 +16714,11 @@ export default () => {
 				},
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var evt = event.getl(player);
 					return evt && evt.es && evt.es.length > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseTarget(get.prompt("xuanlve"), "弃置一名其他角色的一张牌", function (card, player, target) {
@@ -16755,7 +16739,7 @@ export default () => {
 					noe: true,
 					reverseEquip: true,
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.type(card) == "equip") return [1, 1];
 						},
 					},
@@ -16767,7 +16751,7 @@ export default () => {
 				audio: 2,
 				derivation: "gzzhiheng",
 				filterCard: true,
-				check: function (card) {
+				check(card) {
 					if (get.type(card) == "equip") return 0;
 					var player = _status.event.player;
 					var num =
@@ -16787,7 +16771,7 @@ export default () => {
 					}
 					return 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var num =
 						game.countPlayer(function (current) {
@@ -16830,7 +16814,7 @@ export default () => {
 			},
 			jubao: {
 				mod: {
-					canBeGained: function (card, source, player) {
+					canBeGained(card, source, player) {
 						if (source != player && get.position(card) == "e" && get.subtype(card) == "equip5") return false;
 					},
 				},
@@ -16839,7 +16823,7 @@ export default () => {
 				derivation: "dinglanyemingzhu",
 				forced: true,
 				unique: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (
 						game.hasPlayer(function (current) {
 							return current.countCards("ej", function (card) {
@@ -16856,7 +16840,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.draw();
 					"step 1";
@@ -16892,10 +16876,10 @@ export default () => {
 				},
 				trigger: { player: "damageEnd" },
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card && (event.card.name == "sha" || get.type(event.card, "trick") == "trick") && player.getExpansions("yuanjiangfenghuotu").length > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseCardButton("将一张“烽火”置入弃牌堆", player.getExpansions("yuanjiangfenghuotu"), true);
 					"step 1";
@@ -16909,7 +16893,7 @@ export default () => {
 				enable: "phaseUse",
 				audio: ["yuanjiangfenghuotu", 2],
 				forceaudio: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var zhu = get.zhu(player, "jiahe");
 					if (zhu) {
 						return player.countCards("he", { type: "equip" }) > 0;
@@ -16919,7 +16903,7 @@ export default () => {
 				filterCard: { type: "equip" },
 				position: "he",
 				usable: 1,
-				check: function (card) {
+				check(card) {
 					var zhu = get.zhu(_status.event.player, "jiahe");
 					if (!zhu) return 0;
 					var num = 7 - get.value(card);
@@ -16947,16 +16931,16 @@ export default () => {
 				discard: false,
 				lose: false,
 				delay: false,
-				prepare: function (cards, player) {
+				prepare(cards, player) {
 					var zhu = get.zhu(player, "jiahe");
 					player.line(zhu);
 				},
-				content: function () {
+				content() {
 					var zhu = get.zhu(player, "jiahe");
 					zhu.addToExpansion(cards, player, "give").gaintag.add("yuanjiangfenghuotu");
 				},
 				ai: {
-					order: function (item, player) {
+					order(item, player) {
 						if (
 							player.hasSkillTag("noe") ||
 							!player.countCards("h", function (card) {
@@ -16976,14 +16960,14 @@ export default () => {
 				direct: true,
 				audio: "jiahe_put",
 				forceaudio: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					var zhu = get.zhu(player, "jiahe");
 					if (zhu && zhu.getExpansions("yuanjiangfenghuotu").length) {
 						return true;
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var zhu = get.zhu(player, "jiahe");
 					event.num = zhu.getExpansions("yuanjiangfenghuotu").length;
@@ -17090,14 +17074,14 @@ export default () => {
 				forceunique: true,
 				nopop: true,
 				mark: true,
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
 				intro: {
 					content: "expansion",
 					markcount: "expansion",
-					mark: function (dialog, content, player) {
+					mark(dialog, content, player) {
 						var content = player.getExpansions("yuanjiangfenghuotu");
 						if (content && content.length) {
 							dialog.addSmall(content);
@@ -17110,7 +17094,7 @@ export default () => {
 				enable: "phaseUse",
 				usable: 1,
 				audio: "qice",
-				filter: function (event, player) {
+				filter(event, player) {
 					var hs = player.getCards("h");
 					if (!hs.length) return false;
 					for (var i = 0; i < hs.length; i++) {
@@ -17123,11 +17107,11 @@ export default () => {
 				subSkill: {
 					change: {
 						trigger: { player: "useCardAfter" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill == "gzqice_backup";
 						},
 						silent: true,
-						content: function () {
+						content() {
 							player.mayChangeVice();
 							event.skill = "gzqice";
 							event.trigger("skillAfter");
@@ -17135,7 +17119,7 @@ export default () => {
 					},
 				},
 				chooseButton: {
-					dialog: function () {
+					dialog() {
 						var list = lib.inpile;
 						var list2 = [];
 						for (var i = 0; i < list.length; i++) {
@@ -17143,7 +17127,7 @@ export default () => {
 						}
 						return ui.create.dialog(get.translation("gzqice"), [list2, "vcard"]);
 					},
-					filter: function (button, player) {
+					filter(button, player) {
 						var card = { name: button.link[2] };
 						var info = get.info(card);
 						var num = player.countCards("h");
@@ -17175,17 +17159,17 @@ export default () => {
 						}
 						return lib.filter.filterCard(card, player, _status.event.getParent());
 					},
-					check: function (button) {
+					check(button) {
 						if (["chiling", "xietianzi", "tiesuo", "lulitongxin", "diaohulishan", "jiedao"].includes(button.link[2])) return 0;
 						return _status.event.player.getUseValue(button.link[2]);
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						return {
 							filterCard: true,
 							audio: "qice",
 							selectCard: -1,
 							position: "h",
-							selectTarget: function () {
+							selectTarget() {
 								var select = get.select(get.info(get.card()).selectTarget);
 								var nh = _status.event.player.countCards("h");
 								if (select[1] > nh) {
@@ -17193,7 +17177,7 @@ export default () => {
 								}
 								return select;
 							},
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								var info = get.info(card);
 								if (info.changeTarget) {
 									var targets = [target];
@@ -17206,19 +17190,19 @@ export default () => {
 							},
 							popname: true,
 							viewAs: { name: links[0][2] },
-							ai1: function () {
+							ai1() {
 								return 1;
 							},
 						};
 					},
-					prompt: function (links, player) {
+					prompt(links, player) {
 						return "将全部手牌当作" + get.translation(links[0][2]) + "使用";
 					},
 				},
 				ai: {
 					order: 1,
 					result: {
-						player: function (player) {
+						player(player) {
 							var num = 0;
 							var cards = player.getCards("h");
 							if (cards.length >= 3 && player.hp >= 3) return 0;
@@ -17235,7 +17219,7 @@ export default () => {
 				trigger: { global: "phaseDiscardBegin" },
 				audio: "yuejian",
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.isFriendOf(event.player)) {
 						return (
 							event.player.getHistory("useCard", function (evt) {
@@ -17250,7 +17234,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					trigger.player.addTempSkill("gzyuejian_num");
 				},
 				logTarget: "player",
@@ -17258,7 +17242,7 @@ export default () => {
 				subSkill: {
 					num: {
 						mod: {
-							maxHandcardBase: function (player, num) {
+							maxHandcardBase(player, num) {
 								return player.maxHp;
 							},
 						},
@@ -17268,7 +17252,7 @@ export default () => {
 			gzxinsheng: {
 				trigger: { player: "damageEnd" },
 				// frequent:true,
-				content: function () {
+				content() {
 					game.log(player, "获得了一张", "#g化身");
 					lib.skill.gzhuashen.addCharacter(player, _status.characterlist.randomGet(), true);
 					game.delayx();
@@ -17277,13 +17261,13 @@ export default () => {
 			gzhuashen: {
 				unique: true,
 				group: ["gzhuashen_add", "gzhuashen_swap", "gzhuashen_remove", "gzhuashen_disallow", "gzhuashen_flash"],
-				init: function (player) {
+				init(player) {
 					player.storage.gzhuashen = [];
 					player.storage.gzhuashen_removing = [];
 					player.storage.gzhuashen_trigger = [];
 					player.storage.gzhuashen_map = {};
 				},
-				onremove: function (player) {
+				onremove(player) {
 					delete player.storage.gzhuashen;
 					delete player.storage.gzhuashen_removing;
 					delete player.storage.gzhuashen_trigger;
@@ -17292,7 +17276,7 @@ export default () => {
 				ondisable: true,
 				mark: true,
 				intro: {
-					mark: function (dialog, storage, player) {
+					mark(dialog, storage, player) {
 						if (storage && storage.length) {
 							if (player.isUnderControl(true)) {
 								dialog.addSmall([storage, "character"]);
@@ -17308,7 +17292,7 @@ export default () => {
 							return "没有化身";
 						}
 					},
-					content: function (storage, player) {
+					content(storage, player) {
 						if (player.isUnderControl(true)) {
 							var skills = [];
 							for (var i in player.storage.gzhuashen_map) {
@@ -17320,7 +17304,7 @@ export default () => {
 						}
 					},
 				},
-				filterSkill: function (name) {
+				filterSkill(name) {
 					var skills = lib.character[name][3].slice(0);
 					for (var i = 0; i < skills.length; i++) {
 						var info = lib.skill[skills[i]];
@@ -17330,7 +17314,7 @@ export default () => {
 					}
 					return skills;
 				},
-				addCharacter: function (player, name, show) {
+				addCharacter(player, name, show) {
 					var skills = lib.skill.gzhuashen.filterSkill(name);
 					if (skills.length) {
 						player.storage.gzhuashen_map[name] = skills;
@@ -17345,7 +17329,7 @@ export default () => {
 						lib.skill.gzhuashen.drawCharacter(player, [name]);
 					}
 				},
-				drawCharacter: function (player, list) {
+				drawCharacter(player, list) {
 					game.broadcastAll(
 						function (player, list) {
 							if (player.isUnderControl(true)) {
@@ -17366,7 +17350,7 @@ export default () => {
 						list
 					);
 				},
-				removeCharacter: function (player, name) {
+				removeCharacter(player, name) {
 					var skills = lib.skill.gzhuashen.filterSkill(name);
 					if (skills.length) {
 						delete player.storage.gzhuashen_map[name];
@@ -17388,7 +17372,7 @@ export default () => {
 					player.updateMarks("gzhuashen");
 					_status.characterlist.add(name);
 				},
-				getSkillSources: function (player, skill) {
+				getSkillSources(player, skill) {
 					if (player.getStockSkills().includes(skill)) return [];
 					var sources = [];
 					for (var i in player.storage.gzhuashen_map) {
@@ -17401,10 +17385,10 @@ export default () => {
 					add: {
 						trigger: { player: "phaseBeginStart" },
 						frequent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.storage.gzhuashen.length < 2;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var list = _status.characterlist.randomGets(5);
 							if (!list.length) {
@@ -17432,11 +17416,11 @@ export default () => {
 					swap: {
 						trigger: { player: "phaseBeginStart" },
 						direct: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							if (player.hasSkill("gzhuashen_triggered")) return false;
 							return player.storage.gzhuashen.length >= 2;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							var list = player.storage.gzhuashen.slice(0);
 							if (!list.length) {
@@ -17462,7 +17446,7 @@ export default () => {
 					triggered: {},
 					flash: {
 						hookTrigger: {
-							log: function (player, skill) {
+							log(player, skill) {
 								var sources = lib.skill.gzhuashen.getSkillSources(player, skill);
 								if (sources.length) {
 									player.flashAvatar("gzhuashen", sources.randomGet());
@@ -17472,23 +17456,23 @@ export default () => {
 						},
 						trigger: { player: ["useSkillBegin", "useCard", "respond"] },
 						silent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill && lib.skill.gzhuashen.getSkillSources(player, event.skill).length > 0;
 						},
-						content: function () {
+						content() {
 							lib.skill.gzhuashen_flash.hookTrigger.log(player, trigger.skill);
 						},
 					},
 					clear: {
 						trigger: { player: "phaseAfter" },
 						silent: true,
-						content: function () {
+						content() {
 							player.storage.gzhuashen_trigger.length = 0;
 						},
 					},
 					disallow: {
 						hookTrigger: {
-							block: function (event, player, name, skill) {
+							block(event, player, name, skill) {
 								for (var i = 0; i < player.storage.gzhuashen_trigger.length; i++) {
 									var info = player.storage.gzhuashen_trigger[i];
 									if (info[0] == event && info[1] == name && lib.skill.gzhuashen.getSkillSources(player, skill).length > 0) {
@@ -17504,17 +17488,17 @@ export default () => {
 							player: ["useSkillAfter", "useCardAfter", "respondAfter", "triggerAfter", "skillAfter"],
 						},
 						hookTrigger: {
-							after: function (event, player) {
+							after(event, player) {
 								if (event._direct && !player.storage.gzhuashen_removing.includes(event.skill)) return false;
 								if (lib.skill[event.skill].silent) return false;
 								return lib.skill.gzhuashen.getSkillSources(player, event.skill).length > 0;
 							},
 						},
 						silent: true,
-						filter: function (event, player) {
+						filter(event, player) {
 							return event.skill && lib.skill.gzhuashen.getSkillSources(player, event.skill).length > 0;
 						},
-						content: function () {
+						content() {
 							"step 0";
 							if (trigger.name == "trigger") {
 								player.storage.gzhuashen_trigger.push([trigger._trigger, trigger.triggername]);
@@ -17537,7 +17521,7 @@ export default () => {
 				},
 				ai: {
 					nofrequent: true,
-					skillTagFilter: function (player, tag, arg) {
+					skillTagFilter(player, tag, arg) {
 						if (arg && player.storage.gzhuashen) {
 							if (lib.skill.gzhuashen.getSkillSources(player, arg).length > 0) {
 								return true;
@@ -17552,16 +17536,16 @@ export default () => {
 				audio: "xiongsuan",
 				enable: "phaseUse",
 				filterCard: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h");
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return target.isFriendOf(player);
 				},
-				check: function (card) {
+				check(card) {
 					return 7 - get.value(card);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("gzxiongsuan");
 					target.damage("nocard");
@@ -17594,7 +17578,7 @@ export default () => {
 						popup: false,
 						charlotte: true,
 						onremove: true,
-						content: function () {
+						content() {
 							player.restoreSkill(player.storage.gzxiongsuan_restore);
 						},
 					},
@@ -17603,7 +17587,7 @@ export default () => {
 					order: 4,
 					damage: true,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (target.hp > 1) {
 								var skills = target.getOriginalSkills();
 								for (var i = 0; i < skills.length; i++) {
@@ -17636,13 +17620,13 @@ export default () => {
 				trigger: { global: "dying" },
 				forced: true,
 				logAudio: () => 1,
-				check: function () {
+				check() {
 					return false;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player != player && event.parent.name == "damage" && event.parent.source && event.parent.source.isFriendOf(player);
 				},
-				content: function () {
+				content() {
 					player.draw();
 				},
 				group: "gzsuishi2",
@@ -17652,10 +17636,10 @@ export default () => {
 				trigger: { global: "dieAfter" },
 				forced: true,
 				logAudio: () => 2,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isFriendOf(player);
 				},
-				content: function () {
+				content() {
 					player.loseHp();
 				},
 			},
@@ -17664,7 +17648,7 @@ export default () => {
 				forceaudio: true,
 				trigger: { player: "chooseToRespondBegin" },
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.responded) return false;
 					if (!event.filterCard({ name: "sha" })) return false;
 					var zhu = get.zhu(player, "hongfa");
@@ -17673,7 +17657,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var zhu = get.zhu(player, "hongfa");
 					player
@@ -17698,7 +17682,7 @@ export default () => {
 				audio: ["huangjintianbingfu", 2],
 				forceaudio: true,
 				enable: "chooseToUse",
-				filter: function (event, player) {
+				filter(event, player) {
 					if (!event.filterCard({ name: "sha" }, player)) return false;
 					var zhu = get.zhu(player, "hongfa");
 					if (zhu && zhu.getExpansions("huangjintianbingfu").length > 0) {
@@ -17707,43 +17691,43 @@ export default () => {
 					return false;
 				},
 				chooseButton: {
-					dialog: function (event, player) {
+					dialog(event, player) {
 						var zhu = get.zhu(player, "hongfa");
 						return ui.create.dialog("黄巾天兵符", zhu.getExpansions("huangjintianbingfu"), "hidden");
 					},
-					backup: function (links, player) {
+					backup(links, player) {
 						return {
-							filterCard: function () {
+							filterCard() {
 								return false;
 							},
 							selectCard: -1,
 							viewAs: { name: "sha", cards: links },
 							cards: links,
-							precontent: function () {
+							precontent() {
 								var cards = lib.skill.hongfa_use_backup.cards;
 								event.result.cards = cards;
 								player.logSkill("hongfa_use", result.targets);
 							},
 						};
 					},
-					prompt: function (links, player) {
+					prompt(links, player) {
 						return "选择杀的目标";
 					},
 				},
 				ai: {
 					respondSha: true,
-					skillTagFilter: function (player) {
+					skillTagFilter(player) {
 						var zhu = get.zhu(player, "hongfa");
 						if (zhu && zhu.getExpansions("huangjintianbingfu").length > 0) {
 							return true;
 						}
 						return false;
 					},
-					order: function () {
+					order() {
 						return get.order({ name: "sha" }) - 0.1;
 					},
 					result: {
-						player: function (player) {
+						player(player) {
 							if (player.countCards("h", "sha")) return 0;
 							return 1;
 						},
@@ -17762,10 +17746,10 @@ export default () => {
 				init(player) {
 					player.markSkill("huangjintianbingfu");
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.getExpansions("huangjintianbingfu").length == 0 && get.population("qun") > 0;
 				},
-				content: function () {
+				content() {
 					var cards = get.cards(get.population("qun"));
 					player.addToExpansion(cards, "gain2").gaintag.add("huangjintianbingfu");
 				},
@@ -17778,11 +17762,11 @@ export default () => {
 					hp: {
 						audio: "huangjintianbingfu3.mp3",
 						trigger: { player: "loseHpBefore" },
-						filter: function (event, player) {
+						filter(event, player) {
 							return player.getExpansions("huangjintianbingfu").length > 0;
 						},
 						direct: true,
-						content: function () {
+						content() {
 							"step 0";
 							player.chooseCardButton(get.prompt("hongfa"), player.getExpansions("huangjintianbingfu")).set("ai", function () {
 								return 1;
@@ -17804,14 +17788,14 @@ export default () => {
 				forceunique: true,
 				enable: "phaseUse",
 				usable: 1,
-				filterCard: function (card) {
+				filterCard(card) {
 					return get.name(card) != "taipingyaoshu" && get.color(card) == "red";
 				},
 				position: "he",
-				check: function (card) {
+				check(card) {
 					return 6 - get.value(card);
 				},
-				onChooseToUse: function (event) {
+				onChooseToUse(event) {
 					if (game.online) return;
 					event.set(
 						"wendao",
@@ -17825,10 +17809,10 @@ export default () => {
 						})()
 					);
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.wendao == true;
 				},
-				content: function () {
+				content() {
 					var list = [];
 					for (var i = 0; i < ui.discardPile.childElementCount; i++) {
 						if (ui.discardPile.childNodes[i].name == "taipingyaoshu") {
@@ -17865,14 +17849,14 @@ export default () => {
 				forceunique: true,
 				nopop: true,
 				mark: true,
-				onremove: function (player, skill) {
+				onremove(player, skill) {
 					var cards = player.getExpansions(skill);
 					if (cards.length) player.loseToDiscardpile(cards);
 				},
 				intro: {
 					content: "expansion",
 					markcount: "expansion",
-					mark: function (dialog, content, player) {
+					mark(dialog, content, player) {
 						var content = player.getExpansions("huangjintianbingfu");
 						if (content && content.length) {
 							dialog.addSmall(content);
@@ -17884,10 +17868,10 @@ export default () => {
 			wuxin: {
 				trigger: { player: "phaseDrawBegin1" },
 				audio: 2,
-				filter: function (event, player) {
+				filter(event, player) {
 					return get.population("qun") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var num = get.population("qun");
 					// if (player.hasSkill("hongfa")) {
@@ -17928,7 +17912,7 @@ export default () => {
 					global: ["loseAfter", "cardsDiscardAfter", "equipAfter"],
 				},
 				forced: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.name == "equip") {
 						if (player == event.player) return false;
 						if (event.card.name == "feilongduofeng" && event.player.getCards("e").includes(event.card)) return true;
@@ -17946,11 +17930,11 @@ export default () => {
 					}
 					return false;
 				},
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					if (event.name == "equip" && event.card.name == "feilongduofeng" && event.player.getCards("e").includes(event.card)) return event.player;
 					return [];
 				},
-				content: function () {
+				content() {
 					game.delayx();
 					var cards = [];
 					if (trigger.name == "equip") {
@@ -17980,7 +17964,7 @@ export default () => {
 							player: "loseEnd",
 							global: ["equipEnd", "addJudgeEnd", "gainEnd", "loseAsyncEnd", "addToExpansionEnd"],
 						},
-						filter: function (event, player) {
+						filter(event, player) {
 							if (event.name == "lose" && event.getParent().name == "useCard") return false;
 							var evt = event.getl(player);
 							return (
@@ -17992,7 +17976,7 @@ export default () => {
 							);
 						},
 						forced: true,
-						content: function () {
+						content() {
 							"step 0";
 							var cards = [],
 								evt = trigger.getl(player);
@@ -18050,10 +18034,10 @@ export default () => {
 				mark: true,
 				skillAnimation: true,
 				animationColor: "fire",
-				init: function (player) {
+				init(player) {
 					player.storage.jizhao = false;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.storage.jizhao) return false;
 					if (event.type == "dying") {
 						if (player != event.dying) return false;
@@ -18061,7 +18045,7 @@ export default () => {
 					}
 					return false;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.awakenSkill("jizhao");
 					player.storage.jizhao = true;
@@ -18079,7 +18063,7 @@ export default () => {
 				},
 				ai: {
 					order: 1,
-					skillTagFilter: function (player, arg, target) {
+					skillTagFilter(player, arg, target) {
 						if (player != target || player.storage.jizhao) return false;
 					},
 					save: true,
@@ -18095,14 +18079,14 @@ export default () => {
 				inherit: "shoucheng",
 				audio: "shoucheng",
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return game.hasPlayer(function (current) {
 						if (current == _status.currentPhase || !current.isFriendOf(player)) return false;
 						var evt = event.getl(current);
 						return evt && evt.hs && evt.hs.length && current.countCards("h") == 0;
 					});
 				},
-				content: function () {
+				content() {
 					"step 0";
 					event.list = game
 						.filterPlayer(function (current) {
@@ -18139,17 +18123,17 @@ export default () => {
 				preHidden: true,
 				//frequent:true,
 				direct: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.card.name != "sha") return false;
 					if (event.name == "useCardToPlayered" && !event.isFirstTarget) return false;
 					var target = lib.skill.gzyicheng.logTarget(event, player);
 					if (target == player) return true;
 					return target.inline(player) && target.isAlive() && player.hasSkill("gzyicheng");
 				},
-				logTarget: function (event, player) {
+				logTarget(event, player) {
 					return event.name == "useCardToPlayered" ? event.player : event.target;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					var target = lib.skill.gzyicheng.logTarget(trigger, player);
 					event.target = target;
@@ -18165,12 +18149,12 @@ export default () => {
 			yicheng: {
 				audio: 2,
 				trigger: { global: "useCardToTargeted" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.name == "sha" && event.target.isFriendOf(player);
 				},
 				preHidden: true,
 				logTarget: "target",
-				content: function () {
+				content() {
 					"step 0";
 					event.targets[0].draw();
 					"step 1";
@@ -18181,7 +18165,7 @@ export default () => {
 				inherit: "jixi",
 				audio: "jixi",
 				mainSkill: true,
-				init: function (player) {
+				init(player) {
 					if (player.checkMainSkill("gzjixi")) {
 						player.removeMaxHp();
 					}
@@ -18190,15 +18174,15 @@ export default () => {
 			ziliang: {
 				audio: 2,
 				trigger: { global: "damageEnd" },
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.player.isIn() && event.player.isFriendOf(player) && player.getExpansions("tuntian").length;
 				},
-				init: function (player) {
+				init(player) {
 					player.checkViceSkill("ziliang");
 				},
 				viceSkill: true,
 				direct: true,
-				content: function () {
+				content() {
 					"step 0";
 					player.chooseCardButton(get.prompt("ziliang", trigger.player), player.getExpansions("tuntian")).set("ai", function (button) {
 						return get.value(button.link);
@@ -18216,16 +18200,16 @@ export default () => {
 				trigger: { player: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("he") > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCardTarget({
 							filterCard: true,
 							position: "he",
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								if (player == target) return false;
 								var card = ui.selected.cards[0];
 								if (get.type(card) != "equip") return true;
@@ -18233,13 +18217,13 @@ export default () => {
 							},
 							prompt: get.prompt2("gzhuyuan"),
 							complexSelect: true,
-							ai1: function (card) {
+							ai1(card) {
 								if (!_status.event.goon) return false;
 								var player = _status.event.player;
 								if (get.type(card) != "equip") return 0;
 								return 7.5 - get.value(card);
 							},
-							ai2: function (target) {
+							ai2(target) {
 								if (!_status.event.goon) return false;
 								var player = _status.event.player,
 									card = ui.selected.cards[0];
@@ -18296,24 +18280,24 @@ export default () => {
 				trigger: { player: "phaseJieshuBegin" },
 				direct: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("he", { type: "equip" }) > 0;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseCardTarget({
-							filterCard: function (card) {
+							filterCard(card) {
 								return get.type(card) == "equip";
 							},
 							position: "he",
-							filterTarget: function (card, player, target) {
+							filterTarget(card, player, target) {
 								return target.canEquip(card);
 							},
-							ai1: function (card) {
+							ai1(card) {
 								return 6 - get.value(card);
 							},
-							ai2: function (target) {
+							ai2(target) {
 								return get.attitude(_status.event.player, target) - 3;
 							},
 							prompt: get.prompt2("huyuan"),
@@ -18355,7 +18339,7 @@ export default () => {
 			},
 			heyi_distance: {
 				mod: {
-					globalTo: function (from, to, distance) {
+					globalTo(from, to, distance) {
 						if (
 							game.hasPlayer(function (current) {
 								return current.hasSkill("heyi") && current.inline(to);
@@ -18367,25 +18351,25 @@ export default () => {
 				},
 			},
 			tianfu: {
-				init: function (player) {
+				init(player) {
 					player.checkMainSkill("tianfu");
 				},
 				mainSkill: true,
 				inherit: "kanpo",
 				zhenfa: "inline",
-				viewAsFilter: function (player) {
+				viewAsFilter(player) {
 					return _status.currentPhase && _status.currentPhase.inline(player) && !player.hasSkill("kanpo") && player.countCards("h", { color: "black" }) > 0;
 				},
 			},
 			yizhi: {
-				init: function (player) {
+				init(player) {
 					if (player.checkViceSkill("yizhi") && !player.viceChanged) {
 						player.removeMaxHp();
 					}
 				},
 				viceSkill: true,
 				inherit: "guanxing",
-				filter: function (event, player) {
+				filter(event, player) {
 					return !player.hasSkill("guanxing");
 				},
 			},
@@ -18393,13 +18377,13 @@ export default () => {
 				audio: "shangyi",
 				enable: "phaseUse",
 				usable: 1,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") > 0;
 				},
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return player != target && (target.countCards("h") || target.isUnseen(2));
 				},
-				content: function () {
+				content() {
 					"step 0";
 					target.viewHandcards(player);
 					"step 1";
@@ -18425,7 +18409,7 @@ export default () => {
 				ai: {
 					order: 11,
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							return -target.countCards("h");
 						},
 					},
@@ -18438,7 +18422,7 @@ export default () => {
 				global: "niaoxiang_sha",
 				preHidden: true,
 				trigger: { global: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.card.name != "sha") return false;
 					if (game.countPlayer() < 4) return false;
 					return player.siege(event.target) && event.player.siege(event.target);
@@ -18447,7 +18431,7 @@ export default () => {
 				locked: false,
 				forceaudio: true,
 				logTarget: "target",
-				content: function () {
+				content() {
 					var id = trigger.target.playerid;
 					var map = trigger.getParent().customArgs;
 					if (!map[id]) map[id] = {};
@@ -18462,12 +18446,12 @@ export default () => {
 				audio: "zfengshi",
 				zhenfa: "siege",
 				trigger: { global: "useCardToPlayered" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.card.name != "sha" || game.countPlayer() < 4) return false;
 					return player.siege(event.target) && event.player.siege(event.target) && event.target.countCards("e");
 				},
 				logTarget: "target",
-				content: function () {
+				content() {
 					trigger.target.chooseToDiscard("e", true);
 				},
 			},
@@ -18475,13 +18459,13 @@ export default () => {
 				unique: true,
 				audio: "guixiu",
 				trigger: { player: ["showCharacterAfter", "removeCharacterBefore"] },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.name == "removeCharacter" || event.name == "changeVice") return get.character(event.toRemove, 3).includes("gzguixiu") && player.isDamaged();
 					return event.toShow.some(name => {
 						return get.character(name, 3).includes("gzguixiu");
 					});
 				},
-				content: function () {
+				content() {
 					if (trigger.name == "showCharacter") {
 						player.draw(2);
 					} else {
@@ -18493,7 +18477,7 @@ export default () => {
 				derivation: "gzyongjue",
 				enable: "phaseUse",
 				audio: "cunsi",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.checkMainSkill("gzcunsi", false) || player.checkViceSkill("gzcunsi", false);
 				},
 				unique: true,
@@ -18501,7 +18485,7 @@ export default () => {
 				filterTarget: true,
 				skillAnimation: true,
 				animationColor: "orange",
-				content: function () {
+				content() {
 					"step 0";
 					if (player.checkMainSkill("gzcunsi", false)) {
 						player.removeCharacter(0);
@@ -18517,7 +18501,7 @@ export default () => {
 				ai: {
 					order: 9,
 					result: {
-						player: function (player, target) {
+						player(player, target) {
 							var num = 0;
 							if (player.isDamaged() && target.isFriendOf(player)) {
 								num++;
@@ -18538,7 +18522,7 @@ export default () => {
 			gzyongjue: {
 				audio: "yongjue",
 				trigger: { global: "useCardAfter" },
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event == event.player.getHistory("useCard")[0] && event.card.name == "sha" && _status.currentPhase == event.player && event.player.isFriendOf(player)) {
 						for (var i = 0; i < event.cards.length; i++) {
 							if (get.position(event.cards[i], true) == "o") {
@@ -18552,7 +18536,7 @@ export default () => {
 				intro: {
 					content: "若与你势力相同的一名角色于其回合内使用的第一张牌为【杀】，则该角色可以在此【杀】结算完成后获得之",
 				},
-				content: function () {
+				content() {
 					var cards = [];
 					for (var i = 0; i < trigger.cards.length; i++) {
 						if (get.position(trigger.cards[i], true) == "o") {
@@ -18566,7 +18550,7 @@ export default () => {
 			gzyongjue_ai: {
 				ai: {
 					presha: true,
-					skillTagFilter: function (player) {
+					skillTagFilter(player) {
 						if (
 							!game.hasPlayer(function (current) {
 								return current.isFriendOf(player) && current.hasSkill("gzyongjue");
@@ -18579,19 +18563,19 @@ export default () => {
 			},
 			baoling: {
 				trigger: { player: "phaseUseEnd" },
-				init: function (player) {
+				init(player) {
 					player.checkMainSkill("baoling");
 				},
 				mainSkill: true,
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hasViceCharacter();
 				},
-				check: function (event, player) {
+				check(event, player) {
 					return player.hp <= 1 || get.guozhanRank(player.name2, player) <= 3;
 				},
-				content: function () {
+				content() {
 					"step 0";
 					player.removeCharacter(1);
 					"step 1";
@@ -18608,15 +18592,15 @@ export default () => {
 				trigger: { player: "damageBegin3" },
 				forced: true,
 				preHidden: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.num > 0 && event.source && event.source.isUnseen(2);
 				},
-				content: function () {
+				content() {
 					trigger.num--;
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target) {
+						target(card, player, target) {
 							if (player.hasSkillTag("jueqing", false, target)) return;
 							if (!player.isUnseen(2)) return;
 							var num = get.tag(card, "damage");
@@ -18629,7 +18613,7 @@ export default () => {
 				},
 			},
 			hunshang: {
-				init: function (player) {
+				init(player) {
 					if (player.checkViceSkill("hunshang") && !player.viceChanged) {
 						player.removeMaxHp();
 					}
@@ -18642,26 +18626,26 @@ export default () => {
 			hunshang_yingzi: {
 				inherit: "yingzi",
 				audio: "reyingzi_sunce",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hp <= 1 && !player.hasSkill("yingzi");
 				},
 			},
 			hunshang_yinghun: {
 				inherit: "yinghun",
 				audio: "yinghun_sunce",
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.hp <= 1 && player.isDamaged() && !player.hasSkill("yinghun");
 				},
 			},
 			yingyang: {
 				audio: 2,
 				trigger: { player: "compare", target: "compare" },
-				filter: function (event) {
+				filter(event) {
 					return !event.iwhile;
 				},
 				direct: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					player
 						.chooseControl("点数+3", "点数-3", "cancel2")
@@ -18699,7 +18683,7 @@ export default () => {
 			gzqianxi: {
 				audio: "qianxi",
 				trigger: { player: "phaseZhunbeiBegin" },
-				content: function () {
+				content() {
 					"step 0";
 					player.judge();
 					"step 1";
@@ -18725,10 +18709,10 @@ export default () => {
 				trigger: { player: "die" },
 				forced: true,
 				forceDie: true,
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.source && event.source.isIn() && event.source != player && (event.source.hasMainCharacter() || event.source.hasViceCharacter());
 				},
-				content: function () {
+				content() {
 					"step 0";
 					if (!trigger.source.hasViceCharacter()) {
 						event._result = { control: "主将" };
@@ -18787,12 +18771,12 @@ export default () => {
 				},
 				logTarget: "source",
 				ai: {
-					threaten: function (player, target) {
+					threaten(player, target) {
 						if (target.hp == 1) return 0.2;
 						return 1.5;
 					},
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (!target.hasFriend()) return;
 							if (target.hp <= 1 && get.tag(card, "damage")) return [1, 0, 0, -2];
 						},
@@ -18805,14 +18789,14 @@ export default () => {
 				forced: true,
 				priority: 15,
 				preHidden: true,
-				check: function (event, player) {
+				check(event, player) {
 					return event.name == "addJudge" || (event.card.name != "chiling" && get.effect(event.target, event.card, event.player, player) < 0);
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (event.name == "addJudge") return get.color(event.card) == "black";
 					return get.type(event.card, null, false) == "trick" && get.color(event.card) == "black";
 				},
-				content: function () {
+				content() {
 					if (trigger.name == "addJudge") {
 						trigger.cancel();
 						var owner = get.owner(trigger.card);
@@ -18823,7 +18807,7 @@ export default () => {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (get.type(card, "trick") == "trick" && get.color(card) == "black") return "zeroplayertarget";
 						},
 					},
@@ -18838,13 +18822,13 @@ export default () => {
 				forced: true,
 				preHidden: true,
 				priority: 15,
-				check: function (event, player) {
+				check(event, player) {
 					return event.name == "addJudge" || get.effect(event.target, event.card, event.player, player) < 0;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return event.card.name == (event.name == "addJudge" ? "lebu" : "shunshou");
 				},
-				content: function () {
+				content() {
 					if (trigger.name == "addJudge") {
 						trigger.cancel();
 						var owner = get.owner(trigger.card);
@@ -18855,7 +18839,7 @@ export default () => {
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (card.name == "shunshou" || card.name == "lebu") return "zeroplayertarget";
 						},
 					},
@@ -18866,18 +18850,18 @@ export default () => {
 				trigger: { target: "useCardToTarget" },
 				forced: true,
 				priority: 15,
-				check: function (event, player) {
+				check(event, player) {
 					return get.effect(event.target, event.card, event.player, player) < 0;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.countCards("h") == 0 && (event.card.name == "sha" || event.card.name == "juedou");
 				},
-				content: function () {
+				content() {
 					trigger.getParent().targets.remove(player);
 				},
 				ai: {
 					effect: {
-						target: function (card, player, target, current) {
+						target(card, player, target, current) {
 							if (target.countCards("h") == 0 && (card.name == "sha" || card.name == "juedou")) return "zeroplayertarget";
 						},
 					},
@@ -18892,7 +18876,7 @@ export default () => {
 					if (evt && evt.player === player && evt.es && evt.es.length) return 1;
 					return false;
 				},
-				content: function () {
+				content() {
 					player.draw(player == _status.currentPhase ? 1 : 3);
 				},
 			},
@@ -18904,10 +18888,10 @@ export default () => {
 				selectCard: [1, Infinity],
 				discard: false,
 				prepare: "give",
-				filterTarget: function (card, player, target) {
+				filterTarget(card, player, target) {
 					return player != target;
 				},
-				check: function (card) {
+				check(card) {
 					if (ui.selected.cards.length > 2) return 0;
 					if (ui.selected.cards.length && ui.selected.cards[0].name == "du") return 0;
 					if (!ui.selected.cards.length && card.name == "du") return 20;
@@ -18928,7 +18912,7 @@ export default () => {
 					}
 					return 10 - get.value(card);
 				},
-				content: function () {
+				content() {
 					target.gain(cards, player);
 					if (typeof player.storage.gzrende != "number") {
 						player.storage.gzrende = 0;
@@ -18942,14 +18926,14 @@ export default () => {
 					}
 				},
 				ai: {
-					order: function (skill, player) {
+					order(skill, player) {
 						if (player.hp == player.maxHp || player.storage.gzrende < 0 || player.countCards("h") + player.storage.gzrende <= 2) {
 							return 1;
 						}
 						return 10;
 					},
 					result: {
-						target: function (player, target) {
+						target(player, target) {
 							if (ui.selected.cards.length && ui.selected.cards[0].name == "du") {
 								return -10;
 							}
@@ -18963,7 +18947,7 @@ export default () => {
 						},
 					},
 					effect: {
-						target_use: function (card, player, target) {
+						target_use(card, player, target) {
 							if (player == target && get.type(card) == "equip") {
 								if (player.countCards("e", { subtype: get.subtype(card) })) {
 									var players = game.filterPlayer();
@@ -18982,14 +18966,14 @@ export default () => {
 			gzrende1: {
 				trigger: { player: "phaseUseBegin" },
 				silent: true,
-				content: function () {
+				content() {
 					player.storage.gzrende = 0;
 				},
 			},
 			gzzhiheng: {
 				inherit: "zhiheng",
 				audio: "zhiheng",
-				selectCard: function () {
+				selectCard() {
 					var player = _status.event.player;
 					var range1 = [1, player.maxHp];
 					if (player.hasSkill("dinglanyemingzhu_skill")) {
@@ -19000,13 +18984,13 @@ export default () => {
 					}
 					return range1;
 				},
-				filterCard: function (card, player) {
+				filterCard(card, player) {
 					if (ui.selected.cards.length < player.maxHp || !player.hasSkill("dinglanyemingzhu_skill")) return true;
 					return card != player.getEquip("dinglanyemingzhu");
 				},
 				complexCard: true,
 				complexSelect: true,
-				prompt: function () {
+				prompt() {
 					var player = _status.event.player;
 					if (player.hasSkill("dinglanyemingzhu_skill")) return "出牌阶段限一次，你可以弃置任意张牌，然后摸等量的牌";
 					return "出牌阶段限一次，你可以弃置至多X张牌（X为你的体力上限），然后摸等量的牌";
@@ -19018,10 +19002,10 @@ export default () => {
 				usable: 4,
 				filterCard: { color: "red" },
 				position: "hs",
-				viewAsFilter: function (player) {
+				viewAsFilter(player) {
 					return player.countCards("hs", { color: "red" }) > 0;
 				},
-				check: function (card) {
+				check(card) {
 					return 5 - get.value(card);
 				},
 			},
@@ -19029,7 +19013,7 @@ export default () => {
 				inherit: "xiaoguo",
 				audio: "xiaoguo",
 				preHidden: true,
-				content: function () {
+				content() {
 					"step 0";
 					var nono = Math.abs(get.attitude(player, trigger.player)) < 3;
 					if (get.damageEffect(trigger.player, player, player) <= 0) {
@@ -19073,10 +19057,10 @@ export default () => {
 				ruleSkill: true,
 				forced: true,
 				popup: false,
-				filter: function (event, player) {
+				filter(event, player) {
 					return player.isUnseen(2) && !player.hasSkillTag("nomingzhi", false, null, true);
 				},
-				content: function () {
+				content() {
 					"step 0";
 					if (player.phaseNumber == 1 && player.isUnseen(0) && (_status.connectMode ? lib.configOL.junzhu : get.config("junzhu"))) {
 						var name = player.name1;
@@ -19195,7 +19179,7 @@ export default () => {
 				forceDie: true,
 				popup: false,
 				priority: 10,
-				content: function () {
+				content() {
 					"step 0";
 					if (get.info(trigger.skill).silent) {
 						event.finish();
@@ -19275,7 +19259,7 @@ export default () => {
 			_zhenfazhaohuan: {
 				enable: "phaseUse",
 				usable: 1,
-				getConfig: function (player, target) {
+				getConfig(player, target) {
 					if (target == player || !target.isUnseen()) return false;
 					var config = {};
 					var skills = player.getSkills();
@@ -19295,7 +19279,7 @@ export default () => {
 					}
 					return false;
 				},
-				filter: function (event, player) {
+				filter(event, player) {
 					if (player.identity == "ye" || player.identity == "unknown" || !player.wontYe(player.identity)) return false;
 					if (player.hasSkill("undist")) return false;
 					if (
@@ -19308,7 +19292,7 @@ export default () => {
 						return lib.skill._zhenfazhaohuan.getConfig(player, current);
 					});
 				},
-				content: function () {
+				content() {
 					"step 0";
 					event.list = game
 						.filterPlayer(function (current) {
@@ -19359,12 +19343,12 @@ export default () => {
 				},
 				frequent: true,
 				preHidden: true,
-				filter: function (event, player, name) {
+				filter(event, player, name) {
 					if (name == "useCardAfter") return get.type(event.card) == "equip";
 					if (name == "damageEnd") return true;
 					return event.getParent().name == "sha";
 				},
-				content: function () {
+				content() {
 					player.judge().set("callback", function () {
 						var card = event.judgeResult.card;
 						if (card && get.position(card, true) == "o") {
@@ -19378,7 +19362,7 @@ export default () => {
 				trigger: { player: "judgeEnd" },
 				forced: true,
 				preHidden: true,
-				content: function () {
+				content() {
 					player.addTempSkill("ushio_xilv2", { player: "phaseJieshu" });
 					player.addMark("ushio_xilv2", 1, false);
 				},
@@ -19387,7 +19371,7 @@ export default () => {
 				onremove: true,
 				charlotte: true,
 				mod: {
-					maxHandcard: function (player, num) {
+					maxHandcard(player, num) {
 						return num + player.countMark("ushio_xilv2");
 					},
 				},
@@ -19398,7 +19382,7 @@ export default () => {
 		},
 		game: {
 			canReplaceViewpoint: () => true,
-			showYexings: function () {
+			showYexings() {
 				if (_status.showYexings) return;
 				_status.showYexings = true;
 				var next = game.createEvent("showYexings", false);
@@ -19544,7 +19528,7 @@ export default () => {
 					}
 				});
 			},
-			getCharacterChoice: function (list, num) {
+			getCharacterChoice(list, num) {
 				var choice = list.splice(0, num).sort(function (a, b) {
 					return (get.is.double(a) ? 1 : -1) - (get.is.double(b) ? 1 : -1);
 				});
@@ -19625,7 +19609,7 @@ export default () => {
 				}
 				return choice.randomSort();
 			},
-			getState: function () {
+			getState() {
 				var state = {};
 				for (var i in lib.playerOL) {
 					var player = lib.playerOL[i];
@@ -19637,7 +19621,7 @@ export default () => {
 				}
 				return state;
 			},
-			updateState: function (state) {
+			updateState(state) {
 				for (var i in state) {
 					var player = lib.playerOL[i];
 					if (player) {
@@ -19647,7 +19631,7 @@ export default () => {
 					}
 				}
 			},
-			getRoomInfo: function (uiintro) {
+			getRoomInfo(uiintro) {
 				var num, last;
 				if (lib.configOL.initshow_draw == "off") {
 					num = "关闭";
@@ -19663,7 +19647,7 @@ export default () => {
 				last = uiintro.add('<div class="text chat">观看下家副将：' + (lib.configOL.viewnext ? "开启" : "关闭"));
 				last.style.paddingBottom = "8px";
 			},
-			addRecord: function (bool) {
+			addRecord(bool) {
 				if (typeof bool == "boolean") {
 					var data = lib.config.gameRecord.guozhan.data;
 					var identity = game.me.identity;
@@ -19687,7 +19671,7 @@ export default () => {
 					game.saveConfig("gameRecord", lib.config.gameRecord);
 				}
 			},
-			getIdentityList: function (player) {
+			getIdentityList(player) {
 				if (!player.isUnseen()) return;
 				if (player == game.me) return;
 				var list = {
@@ -19721,7 +19705,7 @@ export default () => {
 				}
 				return list;
 			},
-			getIdentityList2: function (list) {
+			getIdentityList2(list) {
 				for (var i in list) {
 					switch (i) {
 						case "unknown":
@@ -19744,7 +19728,7 @@ export default () => {
 					}
 				}
 			},
-			getVideoName: function () {
+			getVideoName() {
 				var str = get.translation(game.me.name1) + "/" + get.translation(game.me.name2);
 				var str2 = _status.separatism
 					? get.modetrans({
@@ -19758,13 +19742,13 @@ export default () => {
 				var name = [str, str2];
 				return name;
 			},
-			showIdentity: function (started) {
+			showIdentity(started) {
 				if (game.phaseNumber == 0 && !started) return;
 				for (var i = 0; i < game.players.length; i++) {
 					game.players[i].showCharacter(2, false);
 				}
 			},
-			tryResult: function () {
+			tryResult() {
 				var map = {},
 					sides = [],
 					pmap = _status.connectMode ? lib.playerOL : game.playerMap,
@@ -19839,7 +19823,7 @@ export default () => {
 					}
 				}
 			},
-			checkResult: function () {
+			checkResult() {
 				_status.overing = true;
 				var me = game.me._trueMe || game.me;
 				for (var i = 0; i < game.players.length; i++) {
@@ -19849,11 +19833,11 @@ export default () => {
 				game.over(winner && winner.isFriendOf(me) ? true : false);
 				game.showIdentity();
 			},
-			checkOnlineResult: function (player) {
+			checkOnlineResult(player) {
 				var winner = lib.playerOL[game.winner_id];
 				return winner && winner.isFriendOf(game.me);
 			},
-			chooseCharacter: function () {
+			chooseCharacter() {
 				var next = game.createEvent("chooseCharacter");
 				next.showConfig = true;
 				next.addPlayer = true;
@@ -20222,7 +20206,7 @@ export default () => {
 					}, 500);
 				});
 			},
-			chooseCharacterOL: function () {
+			chooseCharacterOL() {
 				var next = game.createEvent("chooseCharacter");
 				next.setContent(function () {
 					"step 0";
@@ -20507,7 +20491,7 @@ export default () => {
 			},
 		},
 		dynamicTranslate: {
-			gzzhaosong: function (player) {
+			gzzhaosong(player) {
 				var storage = player.getStorage("gzzhaosong");
 				var list1 = ["效果①", "效果②", "效果③"];
 				var str = "每局游戏每项限一次。";
@@ -20520,7 +20504,7 @@ export default () => {
 				}
 				return str;
 			},
-			gzshiyong: function (player) {
+			gzshiyong(player) {
 				return player.awakenedSkills.includes("gzyaowu") ? lib.translate.gzshiyongx_info : lib.translate.gzshiyong_info;
 			},
 			fakejuzhan(player) {
@@ -22065,7 +22049,7 @@ export default () => {
 		],
 		element: {
 			content: {
-				hideCharacter: function () {
+				hideCharacter() {
 					game.addVideo("hideCharacter", player, num);
 					var skills,
 						log = event.log;
@@ -22118,7 +22102,7 @@ export default () => {
 					}
 					player.checkConflict();
 				},
-				chooseJunlingFor: function () {
+				chooseJunlingFor() {
 					"step 0";
 					var list = ["junling1", "junling2", "junling3", "junling4", "junling5", "junling6"];
 					list = list.randomGets(event.num).sort();
@@ -22146,7 +22130,7 @@ export default () => {
 						event.result.targets = result.targets;
 					}
 				},
-				chooseJunlingControl: function () {
+				chooseJunlingControl() {
 					"step 0";
 					var dialog = [];
 					var str1 = source == player ? "（你）" : "";
@@ -22176,7 +22160,7 @@ export default () => {
 						control: result.control,
 					};
 				},
-				carryOutJunling: function () {
+				carryOutJunling() {
 					"step 0";
 					switch (event.junling) {
 						case "junling1": {
@@ -22252,10 +22236,10 @@ export default () => {
 						player.discard(cards);
 					}
 				},
-				doubleDraw: function () {
+				doubleDraw() {
 					if (!player.hasMark("yinyang_mark")) player.addMark("yinyang_mark", 1);
 				},
-				changeViceOnline: function () {
+				changeViceOnline() {
 					"step 0";
 					player.showCharacter(2);
 					var group = lib.character[player.name1][1];
@@ -22302,7 +22286,7 @@ export default () => {
 					player.viceChanged = true;
 					player.reinitCharacter(player.name2, name, false);
 				},
-				changeVice: function () {
+				changeVice() {
 					"step 0";
 					player.showCharacter(2);
 					if (!event.num) event.num = 3;
@@ -22362,7 +22346,7 @@ export default () => {
 					player.reinitCharacter(player.name2, name, false);
 				},
 				/*----分界线----*/
-				mayChangeVice: function () {
+				mayChangeVice() {
 					"step 0";
 					player.chooseBool("是否变更副将？").set("ai", function () {
 						var player = _status.event.player;
@@ -22377,13 +22361,13 @@ export default () => {
 						player.changeVice(event.hidden);
 					}
 				},
-				zhulian: function () {
+				zhulian() {
 					player.popup("珠联璧合");
 					if (!player.hasMark("zhulianbihe_mark")) player.addMark("zhulianbihe_mark", 1);
 				},
 			},
 			player: {
-				getGuozhanGroup: function (num) {
+				getGuozhanGroup(num) {
 					if (this.trueIdentity) {
 						if (lib.character[this.name1][1] != "ye" || num == 1) return this.trueIdentity;
 						return "ye";
@@ -22392,7 +22376,7 @@ export default () => {
 					if (num == 1) return lib.character[this.name2][1];
 					return lib.character[this.name1][1];
 				},
-				chooseJunlingFor: function (target) {
+				chooseJunlingFor(target) {
 					var next = game.createEvent("chooseJunlingFor");
 					next.player = this;
 					next.target = target;
@@ -22400,7 +22384,7 @@ export default () => {
 					next.setContent("chooseJunlingFor");
 					return next;
 				},
-				chooseJunlingControl: function (source, junling, targets) {
+				chooseJunlingControl(source, junling, targets) {
 					var next = game.createEvent("chooseJunlingControl");
 					next.player = this;
 					next.source = source;
@@ -22409,7 +22393,7 @@ export default () => {
 					next.setContent("chooseJunlingControl");
 					return next;
 				},
-				carryOutJunling: function (source, junling, targets) {
+				carryOutJunling(source, junling, targets) {
 					var next = game.createEvent("carryOutJunling");
 					next.source = source;
 					next.player = this;
@@ -22419,7 +22403,7 @@ export default () => {
 					return next;
 				},
 				/**/
-				mayChangeVice: function (repeat, hidden) {
+				mayChangeVice(repeat, hidden) {
 					if (!_status.changedSkills) _status.changedSkills = {};
 					var skill = _status.event.name;
 					if (repeat || !_status.changedSkills[this.playerid] || !_status.changedSkills[this.playerid].includes(skill)) {
@@ -22432,7 +22416,7 @@ export default () => {
 						return next;
 					}
 				},
-				differentIdentityFrom: function (target, self) {
+				differentIdentityFrom(target, self) {
 					if (this == target) return false;
 					if (this.getStorage("yexinjia_friend").includes(target)) return false;
 					if (target.getStorage("yexinjia_friend").includes(this)) return false;
@@ -22450,7 +22434,7 @@ export default () => {
 					}
 					return this.identity != target.identity;
 				},
-				sameIdentityAs: function (target, shown) {
+				sameIdentityAs(target, shown) {
 					if (this.getStorage("yexinjia_friend").includes(target)) return true;
 					if (target.getStorage("yexinjia_friend").includes(this)) return true;
 					if (shown) {
@@ -22466,13 +22450,13 @@ export default () => {
 					}
 					return this.identity == target.identity;
 				},
-				getModeState: function () {
+				getModeState() {
 					return {
 						unseen: this.isUnseen(0),
 						unseen2: this.isUnseen(1),
 					};
 				},
-				setModeState: function (info) {
+				setModeState(info) {
 					if (info.mode.unseen) this.classList.add("unseen");
 					if (info.mode.unseen2) this.classList.add("unseen2");
 					if (!info.name) return;
@@ -22494,7 +22478,7 @@ export default () => {
 						this.node.identity.classList.add("guessing");
 					}
 				},
-				dieAfter2: function (source) {
+				dieAfter2(source) {
 					var that = this;
 					if (that.hasSkillTag("noDieAfter", null, source)) return;
 					if (source && source.hasSkillTag("noDieAfter2", null, that)) return;
@@ -22527,7 +22511,7 @@ export default () => {
 						else source.discard(source.getCards("he"));
 					}
 				},
-				dieAfter: function (source) {
+				dieAfter(source) {
 					this.showCharacter(2);
 					if (get.is.jun(this.name1)) {
 						if (source && source.identity == this.identity) source.shijun = true;
@@ -22548,7 +22532,7 @@ export default () => {
 					}
 					game.tryResult();
 				},
-				viewCharacter: function (target, num) {
+				viewCharacter(target, num) {
 					if (num != 0 && num != 1) {
 						num = 2;
 					}
@@ -22579,7 +22563,7 @@ export default () => {
 						player.chooseControl("ok").set("dialog", content);
 					});
 				},
-				checkViceSkill: function (skill, disable) {
+				checkViceSkill(skill, disable) {
 					if (game.expandSkills(lib.character[this.name2][3].slice(0)).includes(skill)) {
 						return true;
 					} else {
@@ -22589,7 +22573,7 @@ export default () => {
 						return false;
 					}
 				},
-				checkMainSkill: function (skill, disable) {
+				checkMainSkill(skill, disable) {
 					if (game.expandSkills(lib.character[this.name1][3].slice(0)).includes(skill)) {
 						return true;
 					} else {
@@ -22599,7 +22583,7 @@ export default () => {
 						return false;
 					}
 				},
-				removeMaxHp: function (num) {
+				removeMaxHp(num) {
 					if (game.online) return;
 					if (!num) num = 1;
 					while (num > 0) {
@@ -22617,7 +22601,7 @@ export default () => {
 					}
 					this.update();
 				},
-				hideCharacter: function (num, log) {
+				hideCharacter(num, log) {
 					if (this.isUnseen(2)) return;
 					var name = this["name" + (num + 1)];
 					var next = game.createEvent("hideCharacter");
@@ -22628,7 +22612,7 @@ export default () => {
 					next.setContent("hideCharacter");
 					return next;
 				},
-				removeCharacter: function (num) {
+				removeCharacter(num) {
 					var name = this["name" + (num + 1)];
 					var next = game.createEvent("removeCharacter");
 					next.player = this;
@@ -22637,7 +22621,7 @@ export default () => {
 					next.setContent("removeCharacter");
 					return next;
 				},
-				$removeCharacter: function (num) {
+				$removeCharacter(num) {
 					var name = this["name" + (num + 1)];
 					var info = lib.character[name];
 					if (!info) return;
@@ -22647,7 +22631,7 @@ export default () => {
 					this.showCharacter(num, false);
 					_status.characterlist.add(name);
 				},
-				changeVice: function (hidden) {
+				changeVice(hidden) {
 					var next = game.createEvent("changeVice");
 					next.player = this;
 					next.setContent("changeVice");
@@ -22655,13 +22639,13 @@ export default () => {
 					if (hidden) next.hidden = true;
 					return next;
 				},
-				hasMainCharacter: function () {
+				hasMainCharacter() {
 					return this.name1.indexOf("gz_shibing") != 0;
 				},
-				hasViceCharacter: function () {
+				hasViceCharacter() {
 					return this.name2.indexOf("gz_shibing") != 0;
 				},
-				$showCharacter: function (num, log) {
+				$showCharacter(num, log) {
 					var showYe = false;
 					if (num == 0 && !this.isUnseen(0)) {
 						return;
@@ -22800,7 +22784,7 @@ export default () => {
 					}
 					game.tryResult();
 				},
-				wontYe: function (group, numOfReadyToShow) {
+				wontYe(group, numOfReadyToShow) {
 					if (!group) {
 						if (this.trueIdentity) group = this.trueIdentity;
 						else group = lib.character[this.name1][1];
@@ -22810,7 +22794,7 @@ export default () => {
 					if (!numOfReadyToShow) numOfReadyToShow = 1;
 					return get.totalPopulation(group) + numOfReadyToShow <= (_status.separatism ? Math.max(get.population() / 2 - 1, 1) : get.population() / 2);
 				},
-				perfectPair: function (choosing) {
+				perfectPair(choosing) {
 					if (_status.connectMode) {
 						if (!lib.configOL.zhulian) return false;
 					} else {
@@ -22840,7 +22824,7 @@ export default () => {
 					if (!list.includes(name1) || !list.includes(name2)) return false;
 					return (lib.perfectPair[name1] && lib.perfectPair[name1].flat(Infinity).includes(name2)) || (lib.perfectPair[name2] && lib.perfectPair[name2].flat(Infinity).includes(name1));
 				},
-				siege: function (player) {
+				siege(player) {
 					if (this.identity == "unknown" || this.hasSkill("undist")) return false;
 					if (!player) {
 						var next = this.getNext();
@@ -22852,7 +22836,7 @@ export default () => {
 						return player.sieged() && (player.getNext() == this || player.getPrevious() == this);
 					}
 				},
-				sieged: function (player) {
+				sieged(player) {
 					if (this.identity == "unknown") return false;
 					if (player) {
 						return player.siege(this);
@@ -22866,7 +22850,7 @@ export default () => {
 						return false;
 					}
 				},
-				inline: function () {
+				inline() {
 					if (this.identity == "unknown" || this.identity == "ye" || this.hasSkill("undist")) return false;
 					var next = this,
 						previous = this;
@@ -22895,7 +22879,7 @@ export default () => {
 					}
 					return true;
 				},
-				logAi: function (targets, card) {
+				logAi(targets, card) {
 					if (this.ai.shown == 1 || this.isMad()) return;
 					if (typeof targets == "number") {
 						this.ai.shown += targets;
@@ -22937,7 +22921,7 @@ export default () => {
 			},
 		},
 		get: {
-			guozhanReverse: function (name1, name2) {
+			guozhanReverse(name1, name2) {
 				if (get.is.double(name2)) return false;
 				if (["gz_xunyou", "gz_lvfan", "gz_liubei"].includes(name2)) return true;
 				if (name1 == "gz_re_xushu") return true;
@@ -22945,7 +22929,7 @@ export default () => {
 				if (["gz_sunce", "gz_jiangwei"].includes(name1)) return name2 == "gz_zhoutai" || lib.character[name2][2] % 2 == 1;
 				return false;
 			},
-			guozhanRank: function (name, player) {
+			guozhanRank(name, player) {
 				if (name.indexOf("gz_shibing") == 0) return -1;
 				if (name.indexOf("gz_jun_") == 0) return 7;
 				if (player) {
@@ -22964,7 +22948,7 @@ export default () => {
 				}
 				return 0;
 			},
-			junlingEffect: function (source, junling, performer, targets, viewer) {
+			junlingEffect(source, junling, performer, targets, viewer) {
 				var att1 = get.attitude(viewer, source),
 					att2 = get.attitude(viewer, performer);
 				var eff1 = 0,
@@ -23034,7 +23018,7 @@ export default () => {
 				}
 				return Math.sign(att1) * eff1 + Math.sign(att2) * eff2;
 			},
-			realAttitude: function (from, to, difficulty, toidentity) {
+			realAttitude(from, to, difficulty, toidentity) {
 				var getIdentity = function (player) {
 					if (player.isUnseen()) {
 						if (!player.wontYe()) return "ye";
@@ -23099,7 +23083,7 @@ export default () => {
 				if (to_p < max - 1) return 0;
 				return -0.5;
 			},
-			rawAttitude: function (from, to) {
+			rawAttitude(from, to) {
 				var getIdentity = function (player) {
 					if (player.isUnseen()) {
 						if (!player.wontYe()) return "ye";


### PR DESCRIPTION
### PR受影响的平台
公元1103年-南宋
### 诱因和背景
群友反馈
### PR描述
修复`mode/guozhan.js`中的丁奉【短兵】和吕范【调度】的`get content`的bug，并删除此文件中所有可以删除的`: function `
修复卫青【北进】无次数限制的卡牌结算异常的bug
修复族王沈【岸然】摸牌触发额外结算可能会使得卡牌可使用的bug和失去不可使用卡牌效果的时机bug
更正势太史慈【战烈】四选项的触发结算
### PR测试
测了，能跑
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码