### PR TITLE
夺舍`Yield Content`，增加`result`，修复Bug

### DIFF
--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -9515,7 +9515,7 @@ const skills = {
 						.chooseButtonOL(list)
 						.set("switchToAuto", () => (_status.event.result = "ai"))
 						.set("processAI", () => {
-							var cards = _status.event.dialog.buttons.slice();
+							var cards = _status.event?.getParent()?.cards?.slice() ?? _status.event.dialog.buttons.map(button => button.link);
 							var card = cards.find(card => lib.card.list.some(cardx => cardx[2] == card.name) && !lib.card.list.some(cardx => cardx[2] == card.name && cardx[0] == get.suit(card, false) && cardx[0] == get.number(card, false)));
 							return {
 								bool: true,

--- a/character/mobile/skill.js
+++ b/character/mobile/skill.js
@@ -9515,7 +9515,7 @@ const skills = {
 						.chooseButtonOL(list)
 						.set("switchToAuto", () => (_status.event.result = "ai"))
 						.set("processAI", () => {
-							var cards = _status.event.cards.slice();
+							var cards = _status.event.dialog.buttons.slice();
 							var card = cards.find(card => lib.card.list.some(cardx => cardx[2] == card.name) && !lib.card.list.some(cardx => cardx[2] == card.name && cardx[0] == get.suit(card, false) && cardx[0] == get.number(card, false)));
 							return {
 								bool: true,

--- a/noname/library/element/GameEvent/compilers/ArrayCompiler.js
+++ b/noname/library/element/GameEvent/compilers/ArrayCompiler.js
@@ -23,7 +23,7 @@ export default class ArrayCompiler extends ContentCompilerBase {
 				if (!compiler.isPrevented(event)) {
 					const original = content[event.step];
 					//@ts-ignore
-					const next = await Reflect.apply(original, this, [event, event._trigger, event.player]);
+					const next = await Reflect.apply(original, this, [event, event._trigger, event.player, event._result]);
 					result = next instanceof GameEvent ? next.result : next;
 				}
 				const nextResult = await event.waitNext();

--- a/noname/library/element/GameEvent/compilers/ArrayCompiler.ts
+++ b/noname/library/element/GameEvent/compilers/ArrayCompiler.ts
@@ -28,7 +28,7 @@ export default class ArrayCompiler extends ContentCompilerBase {
 				if (!compiler.isPrevented(event)) {
 					const original = content[event.step];
 					//@ts-ignore
-					const next = await Reflect.apply(original, this, [event, event._trigger, event.player]);
+					const next = await Reflect.apply(original, this, [event, event._trigger, event.player, event._result]);
 					result = next instanceof GameEvent ? next.result : next;
 				}
 				const nextResult = await event.waitNext();

--- a/noname/library/element/GameEvent/compilers/YieldCompiler.js
+++ b/noname/library/element/GameEvent/compilers/YieldCompiler.js
@@ -48,11 +48,14 @@ export default class YieldCompiler extends ContentCompilerBase {
 
 				if (!compiler.isPrevented(event)) {
 					({ value, done = true } = generator.next(result));
+					if (done) {
+						break;
+					}
 					result = await (value instanceof GameEvent ? value.forResult() : value);
 				}
 
 				const nextResult = await event.waitNext();
-				event._result = result ?? nextResult ?? event._result;
+				result ??= nextResult;
 			}
 
 			generator.return();

--- a/noname/library/element/GameEvent/compilers/YieldCompiler.ts
+++ b/noname/library/element/GameEvent/compilers/YieldCompiler.ts
@@ -51,6 +51,9 @@ export default class YieldCompiler extends ContentCompilerBase {
 
 				if (!compiler.isPrevented(event)) {
 					({ value, done = true } = generator.next(result));
+					if (done) {
+						break;
+					}
 					result = await (value instanceof GameEvent ? value.forResult() : value);
 				}
 


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
一开始，人们以为是`Yield Content`的问题

由于人人喜爱`Async Content`，`Yield Content`没人在意，故计划被`Async Content`夺舍

虽然现在已经还`Yield Content`清白，但由于`Yield Content`确实没人在意

那就夺舍了算了，反正现在`Async Content`也被`Array Content`/`Async Contents`夺舍了，正好天下大同，归一`Content`形式，多好

顺带为`Array Content`/`Async Contents`加点内容，修点Bug

### PR描述
<!-- 详细描述您的更改 -->
将`Yield Content`的编程器改为传入`Async Contents`的编译器

为`Array Content`/`Async Contents`增加第四个参数，用于表示结果

修复【盗书】在主机上因客机中断导致的Bug

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测了，能跑

感谢 @1937475624 的协助

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配，除非有人改了`Yield Content`的编译器

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
