### PR TITLE
添加安卓客户端版本限制,菜单增加内核查看和修改功能

### DIFF
--- a/node_modules/@types/noname-typings/NonameAndroidBridge.d.ts
+++ b/node_modules/@types/noname-typings/NonameAndroidBridge.d.ts
@@ -45,4 +45,9 @@ interface NonameAndroidBridge {
 	 * 切换App内使用的Webview实现
 	 */
 	changeWebviewProvider(): void;
+
+	/**
+	 * 获取当前app的versionCode
+	 */
+	getPackageVersionCode(): number;
 }

--- a/node_modules/@types/noname-typings/NonameAndroidBridge.d.ts
+++ b/node_modules/@types/noname-typings/NonameAndroidBridge.d.ts
@@ -40,4 +40,9 @@ interface NonameAndroidBridge {
 	 * @param fileName 文件名(不加后缀)
 	 */
 	captureScreen(fileName: string): boolean;
+
+	/**
+	 * 切换App内使用的Webview实现
+	 */
+	changeWebviewProvider(): void;
 }

--- a/node_modules/@types/noname-typings/cordova-plugin-device.d.ts
+++ b/node_modules/@types/noname-typings/cordova-plugin-device.d.ts
@@ -30,6 +30,8 @@ interface Device {
     isVirtual: boolean;
     /** Get the device hardware serial number. */
     serial: string;
+    /** Get the Android device's SDK version. (Android-only) */
+    sdkVersion?: string;
 }
 
 declare var device: Device;

--- a/node_modules/@types/noname-typings/cordova-plugin-file.d.ts
+++ b/node_modules/@types/noname-typings/cordova-plugin-file.d.ts
@@ -26,12 +26,8 @@ interface Window {
      * @param errorCallback    invoked if error occurs retrieving file system entry
      */
     resolveLocalFileSystemURL(url: string,
-		successCallback: (entry: Entry) => void,
+        successCallback: (entry: Entry) => void,
         errorCallback?: (error: FileError) => void): void;
-	
-	resolveLocalFileSystemURL(url: string,
-		successCallback: (entry: DirectoryEntry) => void,
-		errorCallback?: (error: FileError) => void): void;
     /**
      * Look up file system Entry referred to by local URI.
      * @param string uri       URI referring to a local file or directory
@@ -43,6 +39,14 @@ interface Window {
         errorCallback?: (error: FileError) => void): void;
     TEMPORARY: number;
     PERSISTENT: number;
+}
+
+/** This interface represents a file system. */
+interface FileSystem {
+    /* The name of the file system, unique across the list of exposed file systems. */
+    name: string;
+    /** The root directory of the file system. */
+    root: DirectoryEntry;
 }
 
 /**
@@ -292,7 +296,7 @@ interface FileWriter extends FileSaver {
      * Write the supplied data to the file at position.
      * @param {Blob|string|ArrayBuffer} data The blob to write.
      */
-	write(data: Blob | string | ArrayBuffer): void;
+    write(data: Blob|string|ArrayBuffer): void;
     /**
      * The file position at which the next write will occur.
      * @param offset If nonnegative, an absolute byte offset into the file.

--- a/noname/init/cordova.js
+++ b/noname/init/cordova.js
@@ -103,6 +103,31 @@ export async function cordovaReady() {
 				})
 				.catch(console.log);
 		}
+		if (typeof window.NonameAndroidBridge == "undefined" || 
+			typeof window.NonameAndroidBridge.getPackageName != "function" ||
+			typeof window.NonameAndroidBridge.getPackageVersionCode != "function") {
+			throw new Error("您的安卓客户端版本过低，请升级至最新版");
+		}
+		const versionCode = window.NonameAndroidBridge.getPackageVersionCode();
+		switch(window.NonameAndroidBridge.getPackageName()) {
+			case "com.noname.shijian":
+				if (versionCode < 16007) {
+					throw new Error("您的安卓诗笺版客户端版本过低，请升级至最新版");
+				}
+				break;
+			case "yuri.nakamura.noname_android":
+				if (versionCode < 10904) {
+					throw new Error("您的安卓由理版客户端版本过低，请升级至最新版");
+				}
+				break;
+			case "yuri.nakamura.noname":
+				if (versionCode < 108004) {
+					throw new Error("您的安卓兼容版客户端版本过低，请升级至最新版");
+				}
+				break;
+			default:
+				// todo: 懒人包提示
+		}
 	}
 	game.download = function (url, folder, onsuccess, onerror, dev, onprogress) {
 		if (!url.startsWith("http")) {

--- a/noname/init/cordova.js
+++ b/noname/init/cordova.js
@@ -112,22 +112,22 @@ export async function cordovaReady() {
 		switch(window.NonameAndroidBridge.getPackageName()) {
 			case "com.noname.shijian":
 				if (versionCode < 16007) {
-					throw new Error("您的安卓诗笺版客户端版本过低，请升级至最新版");
+					throw new Error("您的安卓诗笺版客户端版本过低，请升级至v1.6.7或以上");
 				}
 				break;
 			case "yuri.nakamura.noname_android":
 				if (versionCode < 10904) {
-					throw new Error("您的安卓由理版客户端版本过低，请升级至最新版");
+					throw new Error("您的安卓由理版客户端版本过低，请升级至v1.9.4或以上");
 				}
 				break;
 			case "yuri.nakamura.noname":
 				if (versionCode < 108004) {
-					throw new Error("您的安卓兼容版客户端版本过低，请升级至最新版");
+					throw new Error("您的安卓兼容版客户端版本过低，请升级至v1.8.4或以上");
 				}
 				break;
 			case "com.widget.noname.cola":
 				if (versionCode < 10320) {
-					throw new Error("您的安卓增强版客户端版本过低，请升级至最新版");
+					throw new Error("您的安卓增强版客户端版本过低，请升级至v1.3.2或以上");
 				}
 				break;
 			default:

--- a/noname/init/cordova.js
+++ b/noname/init/cordova.js
@@ -125,6 +125,11 @@ export async function cordovaReady() {
 					throw new Error("您的安卓兼容版客户端版本过低，请升级至最新版");
 				}
 				break;
+			case "com.widget.noname.cola":
+				if (versionCode < 10320) {
+					throw new Error("您的安卓增强版客户端版本过低，请升级至最新版");
+				}
+				break;
 			default:
 				// todo: 懒人包提示
 		}

--- a/noname/ui/create/menu/pages/otherMenu.js
+++ b/noname/ui/create/menu/pages/otherMenu.js
@@ -1366,11 +1366,14 @@ export const otherMenu = function (/** @type { boolean | undefined } */ connectM
 					agentText += dedent`安卓应用包名: ${window.NonameAndroidBridge.getPackageName()}<br/>`;
 				}
 
+				if (typeof window.NonameAndroidBridge?.getPackageVersionCode === "function") {
+					agentText += dedent`安卓应用版本: ${window.NonameAndroidBridge.getPackageVersionCode()}<br/>`;
+				}
+
 				if (typeof window.device === "object") {
 					agentText += dedent`安卓版本: ${device.version}<br/>
 					安卓SDK版本: ${device.sdkVersion}<br/>
-					设备制造商: ${device.manufacturer}<br/>
-					`;
+					设备制造商: ${device.manufacturer}<br/>`;
 				}
 			}
 			else if (lib.device === 'ios') {

--- a/noname/ui/create/menu/pages/otherMenu.js
+++ b/noname/ui/create/menu/pages/otherMenu.js
@@ -1344,6 +1344,64 @@ export const otherMenu = function (/** @type { boolean | undefined } */ connectM
 	})();
 	(function () {
 		var page = ui.create.div("");
+		var node = ui.create.div(".menubutton.large", "内核", start.firstChild, clickMode);
+		node._initLink = function () {
+			node.link = page;
+			page.classList.add("menu-sym");
+			
+			const coreInfo = get.coreInfo();
+
+			const agent = document.createElement("div");
+			agent.css({
+				margin: "10px 0",
+				textAlign: "left",
+			});
+			let agentText = dedent`浏览器内核: ${coreInfo[0]}<br/>
+			浏览器版本: ${coreInfo[1]}.${coreInfo[2]}.${coreInfo[3]}<br/>`;
+
+			if (lib.device === 'android') {
+				agentText += dedent`应用平台: 安卓<br/>`;
+
+				if (typeof window.NonameAndroidBridge?.getPackageName === "function") {
+					agentText += dedent`安卓应用包名: ${window.NonameAndroidBridge.getPackageName()}<br/>`;
+				}
+
+				if (typeof window.device === "object") {
+					agentText += dedent`安卓版本: ${device.version}<br/>
+					安卓SDK版本: ${device.sdkVersion}<br/>
+					设备制造商: ${device.manufacturer}<br/>
+					`;
+				}
+			}
+			else if (lib.device === 'ios') {
+				agentText += dedent`应用平台: 苹果<br/>`;
+			}
+			else if (typeof window.require == "function" && typeof window.process == "object" && typeof window.__dirname == "string") {
+				agentText += dedent`应用平台: Electron<br/>
+				Electron版本: ${process.versions.electron}<br/>`;
+			}
+
+			agent.innerHTML = agentText;
+
+			page.appendChild(agent);
+
+			const button = document.createElement("button");
+			button.classList.add("changeWebviewProvider");
+			button.innerText = "点击切换WebView实现";
+			button.addEventListener("click", function () {
+				if (typeof window.NonameAndroidBridge?.changeWebviewProvider === "function") {
+					window.NonameAndroidBridge.changeWebviewProvider();
+				}
+				else {
+					alert("此客户端不支持此功能");
+				}
+			});
+			page.appendChild(button);
+		};
+		if (!get.config("menu_loadondemand")) node._initLink();
+	})();
+	(function () {
+		var page = ui.create.div("");
 		var node = ui.create.div(".menubutton.large", "战绩", start.firstChild, clickMode);
 		node.type = "rec";
 		node._initLink = function () {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
安卓

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
需要对旧版安卓客户端进行淘汰

游戏内需要一个便捷查看内核信息和切换webview实现的操作

![9b1a40aa254420ddec49c33a7b5ed44f_720](https://github.com/user-attachments/assets/6357d1a5-1bb7-4ea7-be71-926da7e574cb)

### PR描述
<!-- 详细描述您的更改 -->
添加安卓客户端版本限制,菜单增加内核查看和修改功能


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测试通过


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
