### PR TITLE
更改`Get#coreInfo`的一些特性

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -458,59 +458,83 @@
 				if (typeof window.process != "undefined" && typeof window.process.versions == "object") {
 					// 如果存在versions.chrome，默认为electron的versions.chrome
 					if (window.process.versions.chrome) {
-						// @ts-expect-error Type must be right
-						return [
-							"chrome",
-							...window.process.versions.chrome
-								.split(".")
-								.slice(0, 3)
-								.map(item => parseInt(item)),
-						];
+						return parseVersion("chrome", window.process.versions.chrome);
 					}
 				}
 
+				// Chrome/Chromium下的实验性特性，具体可参见
+				// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData
 				// @ts-ignore
 				if (typeof navigator.userAgentData != "undefined") {
 					// @ts-ignore
 					const userAgentData = navigator.userAgentData;
 					if (userAgentData.brands && userAgentData.brands.length) {
-						let brand = userAgentData.brands.find(({ brand }) => {
+						const brand = userAgentData.brands.find(({ brand }) => {
 							let str = brand.toLowerCase();
 							// 当前支持的浏览器中只有chrome支持userAgentData，故只判断chrome的情况
 							return str.includes("chrome") || str.includes("chromium");
 						});
 
-						return brand ? ["chrome", parseInt(brand.version), 0, 0] : ["other", NaN, NaN, NaN];
+						// 如果能通过userAgentData找到对应的浏览器信息，则直接返回
+						// 反之则继续通过正则表达式匹配userAgent
+						if (brand) {
+							return ["chrome", parseInt(brand.version), 0, 0];
+						}
 					}
 				}
 
+				// 目前仅考虑Firefox, Chrome和Safari三种浏览器
+				// 其余浏览器均归于other
 				const regex = /(firefox|chrome|safari)\/(\d+(?:\.\d+)+)/;
-				let result = userAgent.match(regex);
-				if (result == null) return ["other", NaN, NaN, NaN];
+				let result = userAgentLowerCase.match(regex);
+				if (result == null) {
+					return ["other", NaN, NaN, NaN];
+				}
 
-				// 非Safari情况直接返回结果
+				// 非Safari情况可直接返回结果
 				if (result[1] !== "safari") {
-					const [major, minor, patch] = result[2].split(".");
-					// @ts-expect-error "Matched result must be the status."
-					return [result[1], parseInt(major), parseInt(minor), parseInt(patch)];
+					// @ts-expect-error Type must be right
+					return parseVersion(result[1], result[2]);
 				}
 
 				// 以下是所有Safari平台的判断方法
 				// macOS以及以桌面显示的移动端则直接判断
-				if (/macintosh/.test(userAgent)) {
-					result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/);
-					if (result == null) return ["other", NaN, NaN, NaN];
+				if (/macintosh/.test(userAgentLowerCase)) {
+					result = userAgentLowerCase.match(/version\/(\d+(?:\.\d+)+).*safari/);
+					if (result == null) {
+						return ["other", NaN, NaN, NaN];
+					}
 				}
 				// 不然则通过OS后面的版本号来获取内容
 				else {
 					let safariRegex = /(?:iphone|ipad); cpu (?:iphone )?os (\d+(?:_\d+)+)/;
-					result = userAgent.match(safariRegex);
-					if (result == null) return ["other", NaN, NaN, NaN];
+					result = userAgentLowerCase.match(safariRegex);
+					if (result == null) {
+						return ["other", NaN, NaN, NaN];
+					}
 				}
 				// result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
-				// @ts-ignore
-				const [major, minor, patch] = result[1].split(".");
-				return ["safari", parseInt(major), parseInt(minor), parseInt(patch)];
+				return parseVersion("safari", result[1]);
+
+				/**
+				 * 通用解析版本号方法
+				 *
+				 * @param {"firefox" | "chrome" | "safari" | "other"} coreName
+				 * @param {string} versions
+				 * @returns {["firefox" | "chrome" | "safari" | "other", number, number, number]}
+				 */
+				function parseVersion(coreName, versions) {
+					const [major, minor, patch] = versions.split(".");
+					const majorVersion = parseInt(major);
+
+					// 如果major解析为NaN，则整体解析为NaN（此时不考虑minor和patch）
+					if (Number.isNaN(majorVersion)) {
+						return [coreName, NaN, NaN, NaN];
+					}
+
+					// 反之则将不为NaN的minor和patch解析为0
+					return [coreName, majorVersion, parseInt(minor) || 0, parseInt(patch) || 0];
+				}
 			}
 		}
 

--- a/noname/get/compatible.js
+++ b/noname/get/compatible.js
@@ -59,18 +59,24 @@ export class GetCompatible {
 			}
 		}
 
+		// Chrome/Chromium下的实验性特性，具体可参见
+		// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData
 		// @ts-ignore
 		if (typeof navigator.userAgentData != "undefined") {
 			// @ts-ignore
 			const userAgentData = navigator.userAgentData;
 			if (userAgentData.brands && userAgentData.brands.length) {
-				let brand = userAgentData.brands.find(({ brand }) => {
+				const brand = userAgentData.brands.find(({ brand }) => {
 					let str = brand.toLowerCase();
 					// 当前支持的浏览器中只有chrome支持userAgentData，故只判断chrome的情况
 					return str.includes("chrome") || str.includes("chromium");
 				});
 
-				return brand ? ["chrome", parseInt(brand.version), 0, 0] : ["other", NaN, NaN, NaN];
+				// 如果能通过userAgentData找到对应的浏览器信息，则直接返回
+				// 反之则继续通过正则表达式匹配userAgent
+				if (brand) {
+					return ["chrome", parseInt(brand.version), 0, 0];
+				}
 			}
 		}
 

--- a/noname/get/compatible.js
+++ b/noname/get/compatible.js
@@ -48,14 +48,7 @@ export class GetCompatible {
 		if (typeof window.process != "undefined" && typeof window.process.versions == "object") {
 			// 如果存在versions.chrome，默认为electron的versions.chrome
 			if (window.process.versions.chrome) {
-				// @ts-expect-error Type must be right
-				return [
-					"chrome",
-					...window.process.versions.chrome
-						.split(".")
-						.slice(0, 3)
-						.map(item => parseInt(item)),
-				];
+				return parseVersion("chrome", window.process.versions.chrome);
 			}
 		}
 
@@ -80,33 +73,58 @@ export class GetCompatible {
 			}
 		}
 
+		// 目前仅考虑Firefox, Chrome和Safari三种浏览器
+		// 其余浏览器均归于other
 		const regex = /(firefox|chrome|safari)\/(\d+(?:\.\d+)+)/;
 		let result = userAgentLowerCase.match(regex);
-		if (result == null) return ["other", NaN, NaN, NaN];
+		if (result == null) {
+			return ["other", NaN, NaN, NaN];
+		}
 
-		// 非Safari情况直接返回结果
+		// 非Safari情况可直接返回结果
 		if (result[1] !== "safari") {
-			const [major, minor, patch] = result[2].split(".");
-			// @ts-expect-error "Matched result must be the status."
-			return [result[1], parseInt(major), parseInt(minor), parseInt(patch)];
+			// @ts-expect-error Type must be right
+			return parseVersion(result[1], result[2]);
 		}
 
 		// 以下是所有Safari平台的判断方法
 		// macOS以及以桌面显示的移动端则直接判断
 		if (/macintosh/.test(userAgentLowerCase)) {
 			result = userAgentLowerCase.match(/version\/(\d+(?:\.\d+)+).*safari/);
-			if (result == null) return ["other", NaN, NaN, NaN];
+			if (result == null) {
+				return ["other", NaN, NaN, NaN];
+			}
 		}
 		// 不然则通过OS后面的版本号来获取内容
 		else {
 			let safariRegex = /(?:iphone|ipad); cpu (?:iphone )?os (\d+(?:_\d+)+)/;
 			result = userAgentLowerCase.match(safariRegex);
-			if (result == null) return ["other", NaN, NaN, NaN];
+			if (result == null) {
+				return ["other", NaN, NaN, NaN];
+			}
 		}
 		// result = userAgent.match(/version\/(\d+(?:\.\d+)+).*safari/)
-		// @ts-ignore
-		const [major, minor, patch] = result[1].split(".");
-		return ["safari", parseInt(major), parseInt(minor), parseInt(patch)];
+		return parseVersion("safari", result[1]);
+
+		/**
+		 * 通用解析版本号方法
+		 *
+		 * @param {"firefox" | "chrome" | "safari" | "other"} coreName
+		 * @param {string} versions
+		 * @returns {["firefox" | "chrome" | "safari" | "other", number, number, number]}
+		 */
+		function parseVersion(coreName, versions) {
+			const [major, minor, patch] = versions.split(".");
+			const majorVersion = parseInt(major);
+
+			// 如果major解析为NaN，则整体解析为NaN（此时不考虑minor和patch）
+			if (Number.isNaN(majorVersion)) {
+				return [coreName, NaN, NaN, NaN];
+			}
+
+			// 反之则将不为NaN的minor和patch解析为0
+			return [coreName, majorVersion, parseInt(minor) || 0, parseInt(patch) || 0];
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
之前的`Get#coreInfo`的特性不符合现在无名杀的需求

### PR描述
<!-- 详细描述您的更改 -->
现在`Get#coreInfo`在检测到`navigator.userAgentData`但检测不到Chromium环境的情况下，将继续进行对userAgent的正则判断，而不是直接返回`other`

现在`Get#coreInfo`在解析版本号数字时，若第一位解析的结果为`NaN`，则直接假定所有位为`NaN`；反之，在其他位解析出`NaN`时，返回`0`

现在除了`navigator.userAgentData`和`other`，均通过统一的方式解析版本号

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
在Chromium, Firefox和Electron上均测试正常

Safari因为条件困难没测试，理论正常，而且Safari用户应该会被拦在别的地方，用不到`Get#coreInfo`

> 什么地狱笑话

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
