### PR TITLE
修复macOS系统`__dirname`错误

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -103,7 +103,11 @@
 		// 在http环境下修改__dirname和require的逻辑
 		if (window.__dirname.endsWith("electron.asar\\renderer") || window.__dirname.endsWith("electron.asar/renderer")) {
 			const path = require("path");
-			window.__dirname = path.join(path.resolve(), "resources/app");
+			if (window.process.platform === "darwin") {
+				window.__dirname = path.join(window.process.resourcesPath, "app");
+			} else {
+				window.__dirname = path.join(path.resolve(), "resources/app");
+			}
 			const oldData = Object.entries(window.require);
 			// @ts-ignore
 			window.require = function (moduleId) {


### PR DESCRIPTION
### PR受影响的平台
macOS，Electron客户端


### 诱因和背景
修复macOS下__dirname不能正确获取，导致扩展读取导出异常的问题。

该pr与[此pr](https://github.com/nonameShijian/noname/pull/4)的区别在于，后者还修复了“拖拽安装”扩展中的路径问题，并为客户端添加了macOS的打包脚本。



### PR描述
在`game/game.js`中，在macOS平台下，修改`__dirname`的获取逻辑，利用`process.resourcesPath`取得正确路径。



### PR测试
进行扩展创建、保存、导入、导出操作，能正常操作扩展。



### 扩展适配
一般无需适配，未使用`__dirname`的扩展需检查路径是否正确。



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
