### PR TITLE
修复变更副将导致某些晋势力武将的无敌甲

### DIFF
--- a/mode/guozhan.js
+++ b/mode/guozhan.js
@@ -2361,9 +2361,7 @@ export default () => {
 					event.toRemove = player.name2;
 					event.toChange = name;
 					if (event.change) event.trigger("removeCharacterBefore");
-					if (event.hidden) {
-						if (!player.isUnseen(1)) player.hideCharacter(1);
-					}
+					if (!player.isUnseen(1)) player.hideCharacter(1);
 					"step 2";
 					var name = event.toChange;
 					if (event.hidden) game.log(player, "替换了副将", "#g" + get.translation(player.name2));
@@ -2371,6 +2369,7 @@ export default () => {
 					player.viceChanged = true;
 					player.reinitCharacter(player.name2, name, false);
 					"step 3";
+					if (!event.hidden) player.showCharacter(1);
 					if (event.change && event.toRemove) {
 						const list = [event.toRemove];
 						player.markAuto("fakeshilu", list);
@@ -22374,15 +22373,15 @@ export default () => {
 					event.toChange = name;
 					if (event.change) event.trigger("removeCharacterBefore");
 					"step 1";
-					if (event.hidden) {
-						if (!player.isUnseen(1)) player.hideCharacter(1);
-					}
+					if (!player.isUnseen(1)) player.hideCharacter(1);
 					"step 2";
 					var name = event.toChange;
 					if (event.hidden) game.log(player, "替换了副将", "#g" + get.translation(player.name2));
 					else game.log(player, "将副将从", "#g" + get.translation(player.name2), "变更为", "#g" + get.translation(name));
 					player.viceChanged = true;
 					player.reinitCharacter(player.name2, name, false);
+					"step 3";
+					if (!event.hidden) player.showCharacter(1);
 				},
 				changeVice() {
 					"step 0";
@@ -22433,15 +22432,15 @@ export default () => {
 					event.toRemove = player.name2;
 					event.toChange = name;
 					if (event.change) event.trigger("removeCharacterBefore");
-					if (event.hidden) {
-						if (!player.isUnseen(1)) player.hideCharacter(1);
-					}
+					if (!player.isUnseen(1)) player.hideCharacter(1);
 					"step 2";
 					var name = event.toChange;
 					if (event.hidden) game.log(player, "替换了副将", "#g" + get.translation(player.name2));
 					else game.log(player, "将副将从", "#g" + get.translation(player.name2), "变更为", "#g" + get.translation(name));
 					player.viceChanged = true;
 					player.reinitCharacter(player.name2, name, false);
+					"step 3";
+					if (!event.hidden) player.showCharacter(1);
 				},
 				/*----分界线----*/
 				mayChangeVice() {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
目前国战的变更副将机制不会重新亮一次将，导致变出王元姬、羊徽瑜、夏侯徽等明置武将牌防止伤害的技能时可以无限触发


### PR描述
<!-- 详细描述您的更改 -->
当前的逻辑是只有技能要求变更完不展示（好像只有黄祖【袭射】）时暗置副将，其他情况下都是明置状态换将，不会触发`showCharacter`

修改后的逻辑是先一律暗置原副将，如果变更完成后需展示再亮将，这样可以结算亮将时的技能

同步修改了【嗜戮】、变更副将、联机变更副将三个函数


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
跑了没问题


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
N/A


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
