### PR TITLE
feat: add workflow of closure of stale issue and pull-request.

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,33 @@
+name: Close Stale Issues
+on:
+  schedule:
+    - cron: "0 11 * * *" # 每天的 11:00 运行
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  close_stale_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.STALE_TOKEN }}
+          days-before-issue-stale: 60                # 60天未活动的议题将被标记为【过时】
+          days-before-pr-stale: 90                   # 90天未活动的PR将被标记为【过时】
+          days-before-issue-close: 7                 # 7天未活动的过时议题将被关闭
+          days-before-pr-close: 30                   # 30天未活动的过时PR将被关闭
+          exempt-all-assignees: true                 # 无视所有拥有指派人的议题/PR
+          exempt-all-milestones: true                # 无视所有里程碑下的议题/PR
+          stale-issue-label: "Note:Legacy"           # 标记为 "Note:Legacy" 的议题视为过时议题
+          stale-pr-label: "Note:Legacy"              # 标记为 "Note:Legacy" 的PR视为过时PR
+          any-of-labels: "Note:Pending,Note:Unclear" # 只有标记为 "Note:Pending" 或 "Note:Unclear" 的议题/PR会被关闭
+          exempt-issue-labels: "Status:Preparing"    # 标记为 "Status:Preparing" 的议题不会被关闭
+          exempt-pr-labels: "Status:Preparing"       # 标记为 "Status:Preparing" 的PR不会被关闭
+          stale-issue-message: "该issue已经超过60天未活动，现已被标记为【过时】，请在7天内进行活动，否则将被关闭！"
+          close-issue-message: "该过时issue已经超过7天未活动，现已被关闭！"
+          stale-pr-message: "该PR已经超过90天未活动，现已被标记为【过时】，请在30天内进行活动，否则将被关闭！"
+          close-pr-message: "该过时PR已经超过30天未活动，现已被关闭！"


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
联系 #2344 ，添加自动化的关闭issue操作

### PR描述
<!-- 详细描述您的更改 -->
添加[actions/stale](https://github.com/actions/stale):

- 对于未活跃超过60天的issue和超过90天的PR，若被标记为【Note:Pending】或【Note:Unclear】，将被标记为【Note:Legacy】
- 标记为【Note:Legacy】的issue，7天内仍然未活跃将被关闭；标记为【Note:Legacy】的PR，30天内仍然未活跃将被关闭
- 被标记为【Status:Preparing】的PR和issue将不会被标记为【Note:Legacy】
- 任何有指派人的issue/PR或位于里程碑的issue/PR将不会被标记为【Note:Legacy】

具体可参阅源文件

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
没测试，但理论上可行

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
