### PR TITLE
一些特性的增加

### DIFF
--- a/noname/init/onload/OnloadSplash.js
+++ b/noname/init/onload/OnloadSplash.js
@@ -1,8 +1,9 @@
 import { lib, get } from "../../../noname.js";
 import { ref, onMounted } from "../../../game/vue.esm-browser.js";
 import { delay } from "../../util/index.js";
+import dedent from "../../../game/dedent.js";
 
-const html = (strings, ...values) => String.raw({ raw: strings }, ...values);
+const html = dedent;
 /**
  * @type {import("vue").Component}
  */

--- a/noname/library/element/GameEvent/GameEventManager.js
+++ b/noname/library/element/GameEvent/GameEventManager.js
@@ -43,7 +43,7 @@ export default class GameEventManager {
 	popStatusEvent() {
 		const lastEvent = this.eventStack.pop();
 		const now = this.getStatusEvent();
-		if (lastEvent == null || lastEvent != now) {
+		if (lastEvent == null || lastEvent !== now) {
 			lib.announce.publish("Noname.Game.Event.Changed", [now, lastEvent]);
 		}
 	}

--- a/noname/library/element/GameEvent/GameEventManager.js
+++ b/noname/library/element/GameEvent/GameEventManager.js
@@ -1,3 +1,4 @@
+import { lib } from "../../index.js";
 import { GameEvent } from "../gameEvent.js";
 
 export default class GameEventManager {
@@ -16,10 +17,34 @@ export default class GameEventManager {
 	getStatusEvent() {
 		return this.tempEvent || this.eventStack.at(-1) || this.rootEvent;
 	}
-	setStatusEvent(event) {
-		if (!(event instanceof GameEvent)) return;
-		if (this.eventStack.length === 0) this.rootEvent = event;
-		else if (this.eventStack.includes(event)) this.tempEvent = event;
-		else throw new Error("Cannot assign a value to _status.event that is not in eventStack.");
+	setStatusEvent(event, internal = false) {
+		if (!(event instanceof GameEvent)) {
+			return;
+		}
+
+		const oldEvent = this.getStatusEvent();
+		if (this.eventStack.length === 0) {
+			this.rootEvent = event;
+			if (internal) {
+				this.eventStack.push(event);
+			}
+		} else if (internal) {
+			this.eventStack.push(event);
+		} else if (this.eventStack.includes(event)) {
+			this.tempEvent = event;
+		} else {
+			throw new Error("Cannot assign a value to _status.event that is not in eventStack.");
+		}
+
+		if (oldEvent == null || event !== oldEvent) {
+			lib.announce.publish("Noname.Game.Event.Changed", [event, oldEvent]);
+		}
+	}
+	popStatusEvent() {
+		const lastEvent = this.eventStack.pop();
+		const now = this.getStatusEvent();
+		if (lastEvent == null || lastEvent != now) {
+			lib.announce.publish("Noname.Game.Event.Changed", [now, lastEvent]);
+		}
 	}
 }

--- a/noname/library/element/GameEvent/GameEventManager.ts
+++ b/noname/library/element/GameEvent/GameEventManager.ts
@@ -1,3 +1,4 @@
+import { lib } from "../../index.js";
 import { GameEvent } from "../gameEvent.js";
 
 export default class GameEventManager {
@@ -16,10 +17,34 @@ export default class GameEventManager {
 	getStatusEvent() {
 		return this.tempEvent || this.eventStack.at(-1) || this.rootEvent;
 	}
-	setStatusEvent(event: GameEvent) {
-		if (!(event instanceof GameEvent)) return;
-		if (this.eventStack.length === 0) this.rootEvent = event;
-		else if (this.eventStack.includes(event)) this.tempEvent = event;
-		else throw new Error("Cannot assign a value to _status.event that is not in eventStack.");
+	setStatusEvent(event: GameEvent, internal: boolean = false) {
+		if (!(event instanceof GameEvent)) {
+			return;
+		}
+
+		const oldEvent = this.getStatusEvent();
+		if (this.eventStack.length === 0) {
+			this.rootEvent = event;
+			if (internal) {
+				this.eventStack.push(event);
+			}
+		} else if (internal) {
+			this.eventStack.push(event);
+		} else if (this.eventStack.includes(event)) {
+			this.tempEvent = event;
+		} else {
+			throw new Error("Cannot assign a value to _status.event that is not in eventStack.");
+		}
+
+		if (oldEvent == null || event !== oldEvent) {
+			lib.announce.publish("Noname.Game.Event.Changed", [event, oldEvent]);
+		}
+	}
+	popStatusEvent() {
+		const lastEvent = this.eventStack.pop();
+		const now = this.getStatusEvent();
+		if (lastEvent == null || lastEvent != now) {
+			lib.announce.publish("Noname.Game.Event.Changed", [now, lastEvent]);
+		}
 	}
 }

--- a/noname/library/element/GameEvent/GameEventManager.ts
+++ b/noname/library/element/GameEvent/GameEventManager.ts
@@ -1,6 +1,8 @@
 import { lib } from "../../index.js";
 import { GameEvent } from "../gameEvent.js";
 
+export type NonameGameEventChangedArgs = [newEvent: GameEvent, oldEvent: GameEvent];
+
 export default class GameEventManager {
 	get [Symbol.toStringTag]() {
 		return "GameEventManager";
@@ -37,14 +39,14 @@ export default class GameEventManager {
 		}
 
 		if (oldEvent == null || event !== oldEvent) {
-			lib.announce.publish("Noname.Game.Event.Changed", [event, oldEvent]);
+			lib.announce.publish<NonameGameEventChangedArgs>("Noname.Game.Event.Changed", [event, oldEvent!]);
 		}
 	}
 	popStatusEvent() {
 		const lastEvent = this.eventStack.pop();
 		const now = this.getStatusEvent();
-		if (lastEvent == null || lastEvent != now) {
-			lib.announce.publish("Noname.Game.Event.Changed", [now, lastEvent]);
+		if (lastEvent == null || lastEvent !== now) {
+			lib.announce.publish<NonameGameEventChangedArgs>("Noname.Game.Event.Changed", [now!, lastEvent!]);
 		}
 	}
 }

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -1062,10 +1062,14 @@ export class GameEvent {
 		this.#start = (async () => {
 			if (this.parent) this.parent.childEvents.push(this);
 			game.getGlobalHistory("everything").push(this);
-			if (this.manager.eventStack.length === 0) this.manager.rootEvent = this;
-			this.manager.eventStack.push(this);
+			// if (this.manager.eventStack.length === 0) {
+			// 	this.manager.rootEvent = this;
+			// }
+			// this.manager.eventStack.push(this);
+			this.manager.setStatusEvent(this, true);
 			await this.loop().then(() => {
-				this.manager.eventStack.pop();
+				// this.manager.eventStack.pop();
+				this.manager.popStatusEvent();
 			});
 		})();
 		return this.#start;

--- a/noname/status/index.js
+++ b/noname/status/index.js
@@ -1,5 +1,6 @@
 import { lib } from "../library/index.js";
 import PauseManager from "../game/PauseManager.js";
+import { GameEvent } from "../library/element/gameEvent.js";
 import { GameEventManager } from "../library/element/gameEvent.js";
 
 export class status {
@@ -8,9 +9,10 @@ export class status {
 	auto = false;
 	eventManager= new GameEventManager();
 	/**
-	 * @type { GameEvent | undefined }
+	 * @type { GameEvent }
 	 */
 	get event() {
+		// @ts-expect-error 除开局外，必然存在当前事件
 		return this.eventManager.getStatusEvent();
 	}
 	set event(event) {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
增加一些后续需要的特性


### PR描述
<!-- 详细描述您的更改 -->
- 整理事件变更代码，在事件变更时通过`lib.announce`的`Noname.Game.Event.Changed`事件广播当前事件的变更，其中订阅的函数参数如下:

```typescript
/**
 * 变更事件的参数类型，具体为一个长度为2的数组，其中:
 * - 第一个元素为替换后的事件，同时也是收到订阅时的当前事件，由事件管理保证一定存在
 * - 第二个元素为替换前的事件，如果`newEvent`为游戏第一个事件，则该事件不存在（一般情况下无需判空）
 */
type NonameGameEventChangedArgs = [newEvent: GameEvent, oldEvent: GameEvent];

function NonameGameEventChanged(args: NonameGameEventChangedArgs, name: "Noname.Game.Event.Changed");
```

使用例子:

```javascript
lib.announce.subscribe("Noname.Game.Event.Changed", ([now, last]) => {
	// 在事件变更前后打印相关事件的名字
	console.log(`[Event Change] To "${now.name}" From "${last.name}"`);
});
```

- 为游戏的“帮助”增添对[vue.js](https://cn.vuejs.org/)的直接支持以及其他框架/库的间接支持:
  - 如果传递的是一个对象，且具有`data`方式（对应vue的选项式）或`setup`方式（对应vue的组合式），则视为vue组件，将通过本体自带的vue库创建并挂载
  - 如果传递的是一个对象，且具有`mount`方式，则将调用`content.mount(page)`；此项兼容已经创建的vue组件，也可将其他框架/库包装在`mount`方式内
  - 否则像旧式字符串一样直接赋值给`innerHTML`

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
- 经过多次托管测试，事件顺利执行
- 经过测试，直接mount、提供vue组件以及旧式的提供字符串均能正常运行

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
如果未曾更改本体GameEvent和帮助页面的创建，则无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
