### PR TITLE
hasUsableCard进一步优化；bugfix

### DIFF
--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -10892,7 +10892,6 @@ const skills = {
 			return player.storage.rehuashen?.character?.length > 0;
 		},
 		async cost(event, trigger, player) {
-			_status.noclearcountdown = true;
 			if (trigger.name !== "phase" || event.triggername === "phaseBefore") {
 				event.result = { bool: true, cost_data: ["替换当前化身"] };
 				return;
@@ -10920,6 +10919,7 @@ const skills = {
 				lib.skill.rehuashen.addHuashens(player, 3);
 				[choice] = choice;
 			}
+			_status.noclearcountdown = true;
 			const id = lib.status.videoId++,
 				prompt = choice === "替换当前化身" ? "化身：请选择你要更换的武将牌" : "化身：选择制衡至多两张武将牌";
 			const cards = player.storage.rehuashen.character;

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -793,9 +793,6 @@ const skills = {
 				if (tag === "nokeep") return (!arg || (arg?.card && get.name(arg.card) === "tao")) && get.event()?.type === "phase" && game.hasPlayer(current => current.hasSkill("spoljinglei") && !current.storage.counttrigger?.spoljinglei && get.attitude(current, player) > 0 && current.getHp() > 1) && player.hasCard(card => get.name(card) !== "tao", "h");
 			},
 		},
-		hiddenCard(player, name) {
-			return !player.isTempBanned("spolzhujiu") && name === "jiu";
-		},
 	},
 	spoljinglei: {
 		audio: 2,
@@ -822,12 +819,7 @@ const skills = {
 		},
 		async content(event, trigger, player) {
 			await player.damage("thunder", "nosource");
-			if (
-				!game.hasPlayer(target => {
-					return target.hasSkill("spolzhujiu", null, null, false);
-				})
-			)
-				return;
+			if (!player.isIn() || !game.hasPlayer(target => target.hasSkill("spolzhujiu", null, null, false))) return;
 			const result = await player
 				.chooseTarget(
 					"惊雷：请选择一名拥有〖煮酒〗的角色",

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -2160,8 +2160,8 @@ export class Player extends HTMLDivElement {
 		game.expandSkills(skills);
 		for (let i = 0; i < skills.length; i++) {
 			const skill = skills[i],
-				hiddenCard = ifo.hiddenCard,
-				ifo = get.info(skills[i]);
+				ifo = get.info(skill),
+				hiddenCard = ifo.hiddenCard;
 			if (ifo.usable !== undefined) {
 				let num = ifo.usable;
 				if (typeof num === "function") num = ifo.usable(skill, player);

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -2139,39 +2139,47 @@ export class Player extends HTMLDivElement {
 	 * @returns { boolean | undefined }
 	 */
 	hasUsableCard(name, type) {
+		const player = this;
 		if (typeof type !== "string") type = type ? "limit" : "all";
+		let event = get.event();
+		let evtNames = typeof type !== "string" || type === "all" ? ["chooseToUse", "chooseToRespond"] : ["chooseTo" + type.slice(0, 1).toUpperCase() + type.slice(1)];
 		if (
-			this.hasCard(i => {
-				if (get.name(i, this) !== name) return false;
+			player.hasCard(i => {
+				if (get.name(i, player) !== name) return false;
 				if (type === "all") return true;
-				let event = _status.event,
-					evt = event.getParent("chooseToUse");
-				if (get.itemtype(evt) !== "event") evt = event;
-				if (type === "respond") return lib.filter.cardRespondable(i, this, evt);
-				return lib.filter.cardEnabled(i, this, type === "limit" ? evt : "forceEnable");
+				return evtNames.some(evtName => {
+					let evt = event.getParent(evtName);
+					if (get.itemtype(evt) !== "event") evt = event;
+					if (type === "respond") return lib.filter.cardRespondable(i, player, evt);
+					return lib.filter.cardEnabled(i, player, type === "limit" ? evt : "forceEnable");
+				});
 			}, "hs")
 		)
 			return true;
-		const skills = this.getSkills("invisible").concat(lib.skill.global);
+		const skills = player.getSkills("invisible").concat(lib.skill.global);
 		game.expandSkills(skills);
 		for (let i = 0; i < skills.length; i++) {
-			const ifo = get.info(skills[i]),
-				hiddenCard = ifo.hiddenCard;
+			const skill = skills[i],
+				hiddenCard = ifo.hiddenCard,
+				ifo = get.info(skills[i]);
+			if (ifo.usable !== undefined) {
+				let num = ifo.usable;
+				if (typeof num === "function") num = ifo.usable(skill, player);
+				if (typeof num === "number" && get.skillCount(skill, player) >= num) continue;
+			}
 			if (ifo.viewAs && typeof ifo.viewAs !== "function" && typeof ifo.viewAs !== "string" && ifo.viewAs.name === name) {
-				const goon = !ifo.viewAsFilter || ifo.viewAsFilter(this) !== false;
+				const goon = !ifo.viewAsFilter || ifo.viewAsFilter(player) !== false;
 				const bool =
 					!ifo.filter ||
-					(() => {
-						let evtNames = typeof type !== "string" || type === "all" ? ["chooseToUse", "chooseToRespond"] : ["chooseTo" + type.slice(0, 1).toUpperCase() + type.slice(1)];
-						return evtNames.some(evtName => {
-							let evt = get.event().getParent(evtName);
-							if (get.itemtype(evt) !== "event") evt = get.event();
-							return ifo.filter(evt, this, evt.triggername);
-						});
-					})();
+					evtNames.some(evtName => {
+						let evt = event.getParent(evtName);
+						if (get.itemtype(evt) !== "event") evt = get.event();
+						if (ifo["on" + evtName.slice(0, 1).toUpperCase() + evtName.slice(1)]) ifo["on" + evtName.slice(0, 1).toUpperCase() + evtName.slice(1)](evt);
+						return ifo.filter(evt, player, evt.triggername);
+					});
 				if (goon && bool) return true;
 			} else if (typeof hiddenCard == "function") {
-				if (hiddenCard(this, name)) return true;
+				if (hiddenCard(player, name)) return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
### PR受影响的平台
冇
### 诱因和背景
hasUsableCard进一步优化
bugfix
### PR描述
新增hasUsableCard过一次技能的onChooseToUse/Respond以过部分主动技能检测
新增前置判断角色手中卡牌检测的respond通过部分
新增拒绝技能次数到达上限的技能通过hasUsableCard检测
修复SP刘备惊雷死亡后仍可选择角色补牌的bug
### PR测试
测了，目前没遇到问题，且有争议的技能均能顺利通过技能检测
### 扩展适配
修改了`lib.element.player.hasUsableCard`的扩展
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码