### PR TITLE
修复“一个可能的逻辑错误”，下

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -4618,7 +4618,7 @@ export const Content = {
 			if (event.onresult) {
 				event.onresult(event.result);
 			}
-			if ((!event.result || !event.result.bool || event.result._noHidingTimer) && (event.result.skill || event.logSkill)) {
+			if ((!event.result?.bool || event.result?._noHidingTimer) && (event.result?.skill || event.logSkill)) {
 				var info = get.info(event.result.skill || (Array.isArray(event.logSkill) ? event.logSkill[0] : event.logSkill));
 				if (info.direct && !info.clearTime) {
 					_status.noclearcountdown = "direct";


### PR DESCRIPTION
之前提过一个issue: [2436](https://github.com/libnoname/noname/issues/2436)，实际上出错的代码在[noname/library/element/content.js](https://github.com/libnoname/noname/blob/master/noname/library/element/content.js)文件中出现了两次，大佬在[PR 2465](https://github.com/libnoname/noname/pull/2465/files#diff-8ce9abd1be8c801dcf85a2230f1af14d5085cb69bd1b60d8d106ecaf0436c6c4)中修了其中一处。我按照这个改法把另外一处也改了。