### PR TITLE
为无名杀添加自动导入扩展的功能

### DIFF
--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -728,7 +728,7 @@ async function autoImportExtensions(extensionlist) {
 
 	const unimportedExtensions = extFolders.filter(folder => !includedPlays.includes(folder) && !savedExtensions.includes(folder));
 
-	for (const ext of unimportedExtensions) {
+	const promises = unimportedExtensions.map(async ext => {
 		const path = new URL(`./${ext}/`, extensionPath);
 		const file = new URL("./extension.js", path);
 		const tsFile = new URL("./extension.ts", path);
@@ -741,7 +741,8 @@ async function autoImportExtensions(extensionlist) {
 				await game.promises.saveConfig(`extension_${ext}_enable`, false);
 			}
 		}
-	}
+	});
+	await Promise.allSettled(promises);
 
 	if (changed) {
 		await game.promises.saveConfig("extensions", savedExtensions);

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -722,14 +722,14 @@ async function autoImportExtensions(extensionlist) {
 
 	const includedPlays = config.get("all").plays;
 	const savedExtensions = config.get("extensions");
-	const extensionPath = get.relativePath(new URL("./extension/", rootURL));
-	const [extFolders] = await game.promises.getFileList(extensionPath);
+	const extensionPath = new URL("./extension/", rootURL);
+	const [extFolders] = await game.promises.getFileList(get.relativePath(extensionPath));
 	let changed = false;
 
 	const unimportedExtensions = extFolders.filter(folder => !includedPlays.includes(folder) && !savedExtensions.includes(folder));
 
 	for (const ext of unimportedExtensions) {
-		const path = new URL(`./extension/${ext}/`, rootURL);
+		const path = new URL(`./${ext}/`, extensionPath);
 		const file = new URL("./extension.js", path);
 		const tsFile = new URL("./extension.ts", path);
 

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -11,6 +11,7 @@ import { promiseErrorHandlerMap } from "../util/browser.js";
 import { importCardPack, importCharacterPack, importExtension, importMode } from "./import.js";
 import { initializeSandboxRealms } from "../util/initRealms.js";
 import { ErrorManager } from "../util/error.js";
+import { rootURL } from "../../noname.js";
 
 // 判断是否从file协议切换到http/s协议
 export function canUseHttpProtocol() {
@@ -133,6 +134,7 @@ export async function boot() {
 		delete window.cordovaLoadTimeout;
 	}
 
+	// @ts-expect-error 类型系统未来可期
 	for (const link of document.head.querySelectorAll("link")) {
 		if (link.href.includes("app/color.css")) {
 			link.remove();
@@ -438,6 +440,7 @@ export async function boot() {
 				extensionlist.push(config.get("plays")[name]);
 			}
 		}
+
 		for (var name = 0; name < config.get("extensions").length; name++) {
 			if (Reflect.get(window, "bannedExtensions").includes(config.get("extensions")[name])) {
 				continue;
@@ -458,6 +461,10 @@ export async function boot() {
 			}
 		}
 	}
+
+	// 自动导入扩展
+	// 其实个人觉得直接加到这里会有问题，但至少现在能跑
+	const importExtensionPromise = autoImportExtensions(extensionlist);
 
 	let layout = config.get("layout");
 	if (layout == "default" || lib.layoutfixed.indexOf(config.get("mode")) !== -1) {
@@ -569,6 +576,7 @@ export async function boot() {
 		Reflect.get(ui, "css")[stylesName[i]] = stylesLoaded[i];
 	}
 
+	await importExtensionPromise;
 	if (extensionlist.length) {
 		_status.extensionLoading = [];
 		_status.extensionLoaded = [];
@@ -703,6 +711,40 @@ export async function boot() {
 }
 
 export { onload } from "./onload.js";
+
+async function autoImportExtensions(extensionlist) {
+	const configValue = config.get("extension_auto_import");
+	const fsAccess = typeof game.getFileList == "function" && typeof game.checkFile == "function";
+
+	if (!configValue || !fsAccess) {
+		return;
+	}
+
+	const includedPlays = config.get("all").plays;
+	const savedExtensions = config.get("extensions");
+	const extensionPath = get.relativePath(new URL("./extension/", rootURL));
+	const [extFolders] = await game.promises.getFileList(extensionPath);
+	let changed = false;
+
+	const unimportedExtensions = extFolders.filter(folder => !includedPlays.includes(folder) && !savedExtensions.includes(folder));
+
+	for (const ext of unimportedExtensions) {
+		const path = new URL(`./extension/${ext}/`, rootURL);
+		const file = new URL("./extension.js", path);
+		const tsFile = new URL("./extension.ts", path);
+
+		if ((await game.promises.checkFile(get.relativePath(file))) == 1 || (await game.promises.checkFile(get.relativePath(tsFile))) == 1) {
+			extensionlist.push(ext);
+			savedExtensions.push(ext);
+			changed = true;
+			await game.promises.saveConfig(`extension_${ext}_enable`, false);
+		}
+	}
+
+	if (changed) {
+		await game.promises.saveConfig("extensions", savedExtensions);
+	}
+}
 
 function initSheet(libConfig) {
 	if (libConfig.player_style && libConfig.player_style != "default" && libConfig.player_style != "custom") {

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -737,7 +737,9 @@ async function autoImportExtensions(extensionlist) {
 			extensionlist.push(ext);
 			savedExtensions.push(ext);
 			changed = true;
-			await game.promises.saveConfig(`extension_${ext}_enable`, false);
+			if (!config.has(`extension_${ext}_enable`)) {
+				await game.promises.saveConfig(`extension_${ext}_enable`, false);
+			}
 		}
 	}
 

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -28,6 +28,7 @@ import security from "../util/security.js";
 import { ErrorManager } from "../util/error.js";
 
 import { defaultSplashs } from "../init/onload/index.js";
+import dedent from "../../game/dedent.js"
 
 export class Library {
 	configprefix = "noname_0.9_";
@@ -1150,6 +1151,21 @@ export class Library {
 							delete window.lib;
 							delete window._status;
 						}
+					},
+					unfrequent: true,
+				},
+				extension_auto_import: {
+					name: "自动导入扩展",
+					intro: dedent`
+						开启后无名杀会自动导入扩展目录下的扩展
+						<br />
+						※ 如果你的运行环境不支持文件操作，则该选项无效
+						<br />
+						※ 鉴于不同平台下文件操作的性能区别，开启后可能会降低加载速度
+					`,
+					init: false,
+					async onclick(bool) {
+						await game.promises.saveConfig("extension_auto_import", bool);
 					},
 					unfrequent: true,
 				},

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -1157,7 +1157,7 @@ export class Library {
 				extension_auto_import: {
 					name: "自动导入扩展",
 					intro: dedent`
-						开启后无名杀会自动导入扩展目录下的扩展
+						开启后无名杀会自动导入扩展目录下的扩展（以此法导入的扩展默认关闭）
 						<br />
 						※ 如果你的运行环境不支持文件操作，则该选项无效
 						<br />


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
在以前网页端无法使用fs的时候，为了兼容网页端，扩展加载是直接读取储存在`lib.db`/LocalStorage里的信息，这导致添加扩展无法直接将扩展放入文件夹，必须通过无名杀内部导入扩展或“万能导入”才能让扩展被加载

现在不一样了，虽然本质上是ban了不能用fs的网页端（其实还没完全ban），但至少从网页端到手机端都能使用上文件管理，故可以考虑添加扩展自动导入

### PR描述
<!-- 详细描述您的更改 -->
添加“自动导入扩展”选项，开启后将在启动时自动检索扩展文件夹，并导入未导入的扩展

- 由于可能存在某一平台下文件管理的效率低下，导致启动页加载效率过低，故不自动开启，有需求请自行开启
- 当以此法导入新扩展时，为防止一些特殊情况，此扩展将默认被关闭

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测了，能跑

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配

~~当然你可以把提供类似功能的扩展删了~~

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
