### PR TITLE
增加一个提供异步迭代方法的类

### DIFF
--- a/noname/library/concurrent/index.d.ts
+++ b/noname/library/concurrent/index.d.ts
@@ -5,8 +5,8 @@ export class Concurrent extends Uninstantable {
 	 * 执行一个异步的、步长为1的for range循环
 	 *
 	 * 由于异步的特性，你无法中途中止循环
-     * 
-     * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
+	 *
+	 * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
 	 *
 	 * @param start - 开始索引（包含）
 	 * @param end - 结束索引（不包含）
@@ -20,18 +20,79 @@ export class Concurrent extends Uninstantable {
 	 * 执行一个异步的for range循环
 	 *
 	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
-     * 
-     * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
-     * 
+	 *
+	 * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
+	 *
 	 * @param start - 开始索引（包含）
 	 * @param end - 结束索引（不包含）
 	 * @param signal - AbortSignal信号，用于自行中止循环
 	 * @param callback - 回调函数，接收当前索引和提供的信号；如果回调函数不包含异步操作，则将退化为同步操作
-     * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @returns 返回一个Promise，包含执行其中所有的异常
 	 * @throws {TypeError} 如果提供的回调函数不是一个函数
 	 */
 	static async for<T extends number>(start: T, end: T, signal: AbortSignal, callback: ForCallback<T>): Promise<ForException<T>[]>;
+
+	/**
+	 * 执行一个异步的for of循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环
+	 *
+	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
+	 *
+	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
+	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 */
+	static async forEach<T>(iterable: Iterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
+
+	/**
+	 * 执行一个异步的for of循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
+	 *
+	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
+	 *
+	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
+	 * @param signal - AbortSignal信号，用于自行中止循环
+	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 */
+	static async forEach<T>(iterable: Iterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
+
+	/**
+	 * 执行一个异步的for of循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环
+	 *
+	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
+	 *
+	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
+	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 */
+	static async forEach<T>(iterable: AsyncIterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
+
+	/**
+	 * 执行一个异步的for of循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
+	 *
+	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
+	 *
+	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
+	 * @param signal - AbortSignal信号，用于自行中止循环
+	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 */
+	static async forEach<T>(iterable: AsyncIterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
 }
 
 type ForCallback<T extends number> = (index: T, signal: AbortSignal) => Promise<void> | void;
 type ForException<T extends number, E extends Error = Error> = { index: number; error: E };
+
+type ForEachCallback<T> = (item: T, signal: AbortSignal) => Promise<void> | void;
+type ForEachException<T, E extends Error = Error> = { item: T; error: E };

--- a/noname/library/concurrent/index.d.ts
+++ b/noname/library/concurrent/index.d.ts
@@ -1,5 +1,11 @@
 import { Uninstantable } from "../../util/index.js";
 
+/**
+ * 提供一组用于并发异步操作的静态工具方法
+ * 
+ * 由于 JavaScript 的单线程特性，不能实现真正的并行操作。
+ * 该类提供的方法通过异步操作模拟并发执行，优化处理多个异步任务的效率。
+ */
 export class Concurrent extends Uninstantable {
 	/**
 	 * 执行一个异步的、步长为1的for range循环
@@ -11,8 +17,13 @@ export class Concurrent extends Uninstantable {
 	 * @param start - 开始索引（包含）
 	 * @param end - 结束索引（不包含）
 	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的回调函数不是一个函数
+	 * @example
+	 * // 对1到5的每个数字进行异步处理
+	 * await Concurrent.for(1, 6, async (i) => {
+	 *   await someAsyncOperation(i);
+	 * });
 	 */
 	static async for<T extends number>(start: T, end: T, callback: ForCallback<T>): Promise<ForException<T>[]>;
 
@@ -27,8 +38,15 @@ export class Concurrent extends Uninstantable {
 	 * @param end - 结束索引（不包含）
 	 * @param signal - AbortSignal信号，用于自行中止循环
 	 * @param callback - 回调函数，接收当前索引和提供的信号；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的回调函数不是一个函数
+	 * @example
+	 * // 使用AbortController来控制循环的终止
+	 * const controller = new AbortController();
+	 * await Concurrent.for(1, 100, controller.signal, async (i, signal) => {
+	 *   if (signal.aborted) return;
+	 *   await someAsyncOperation(i);
+	 * });
 	 */
 	static async for<T extends number>(start: T, end: T, signal: AbortSignal, callback: ForCallback<T>): Promise<ForException<T>[]>;
 
@@ -40,9 +58,15 @@ export class Concurrent extends Uninstantable {
 	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
 	 *
 	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
-	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 * @example
+	 * // 对数组中的每项进行异步处理
+	 * const items = [1, 2, 3, 4, 5];
+	 * await Concurrent.forEach(items, async (item) => {
+	 *   await processItem(item);
+	 * });
 	 */
 	static async forEach<T>(iterable: Iterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
 
@@ -55,8 +79,8 @@ export class Concurrent extends Uninstantable {
 	 *
 	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
 	 * @param signal - AbortSignal信号，用于自行中止循环
-	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
 	 */
 	static async forEach<T>(iterable: Iterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
@@ -69,8 +93,8 @@ export class Concurrent extends Uninstantable {
 	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
 	 *
 	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
-	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
 	 */
 	static async forEach<T>(iterable: AsyncIterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
@@ -84,15 +108,35 @@ export class Concurrent extends Uninstantable {
 	 *
 	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
 	 * @param signal - AbortSignal信号，用于自行中止循环
-	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
 	 */
 	static async forEach<T>(iterable: AsyncIterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
 }
 
+/**
+ * For循环回调函数类型
+ * @template T 索引类型，必须是数字类型
+ */
 type ForCallback<T extends number> = (index: T, signal: AbortSignal) => Promise<void> | void;
+
+/**
+ * For循环异常信息类型
+ * @template T 索引类型，必须是数字类型
+ * @template E 错误类型，默认为Error
+ */
 type ForException<T extends number, E extends Error = Error> = { index: number; error: E };
 
+/**
+ * ForEach循环回调函数类型
+ * @template T 元素类型
+ */
 type ForEachCallback<T> = (item: T, signal: AbortSignal) => Promise<void> | void;
+
+/**
+ * ForEach循环异常信息类型
+ * @template T 元素类型
+ * @template E 错误类型，默认为Error
+ */
 type ForEachException<T, E extends Error = Error> = { item: T; error: E };

--- a/noname/library/concurrent/index.d.ts
+++ b/noname/library/concurrent/index.d.ts
@@ -2,31 +2,11 @@ import { Uninstantable } from "../../util/index.js";
 
 /**
  * 提供一组用于并发异步操作的静态工具方法
- * 
+ *
  * 由于 JavaScript 的单线程特性，不能实现真正的并行操作。
  * 该类提供的方法通过异步操作模拟并发执行，优化处理多个异步任务的效率。
  */
 export class Concurrent extends Uninstantable {
-	/**
-	 * 执行一个异步的、步长为1的for range循环
-	 *
-	 * 由于异步的特性，你无法中途中止循环
-	 *
-	 * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
-	 *
-	 * @param start - 开始索引（包含）
-	 * @param end - 结束索引（不包含）
-	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行过程中所有的异常
-	 * @throws {TypeError} 如果提供的回调函数不是一个函数
-	 * @example
-	 * // 对1到5的每个数字进行异步处理
-	 * await Concurrent.for(1, 6, async (i) => {
-	 *   await someAsyncOperation(i);
-	 * });
-	 */
-	static async for<T extends number>(start: T, end: T, callback: ForCallback<T>): Promise<ForException<T>[]>;
-
 	/**
 	 * 执行一个异步的for range循环
 	 *
@@ -36,19 +16,19 @@ export class Concurrent extends Uninstantable {
 	 *
 	 * @param start - 开始索引（包含）
 	 * @param end - 结束索引（不包含）
-	 * @param signal - AbortSignal信号，用于自行中止循环
 	 * @param callback - 回调函数，接收当前索引和提供的信号；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @param options - 可选参数，具体可参阅`ConcurrentOptions`
 	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的回调函数不是一个函数
 	 * @example
 	 * // 使用AbortController来控制循环的终止
 	 * const controller = new AbortController();
-	 * await Concurrent.for(1, 100, controller.signal, async (i, signal) => {
-	 *   if (signal.aborted) return;
-	 *   await someAsyncOperation(i);
-	 * });
+	 * await Concurrent.for(1, 100, async (i, signal) => {
+	 * 	if (signal.aborted) return;
+	 * 	await someAsyncOperation(i);
+	 * }, { signal: controller.signal });
 	 */
-	static async for<T extends number>(start: T, end: T, signal: AbortSignal, callback: ForCallback<T>): Promise<ForException<T>[]>;
+	static async for<T extends number>(start: T, end: T, callback: ForCallback<T>, options?: ConcurrentOptions): Promise<ForException<T>[]>;
 
 	/**
 	 * 执行一个异步的for of循环
@@ -59,60 +39,28 @@ export class Concurrent extends Uninstantable {
 	 *
 	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
 	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @param options - 可选参数，具体可参阅`ConcurrentOptions`
 	 * @returns 返回一个Promise，包含执行过程中所有的异常
 	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
 	 * @example
 	 * // 对数组中的每项进行异步处理
+	 * const controller = new AbortController();
 	 * const items = [1, 2, 3, 4, 5];
 	 * await Concurrent.forEach(items, async (item) => {
 	 *   await processItem(item);
-	 * });
+	 * }, { signal: controller.signal });
 	 */
-	static async forEach<T>(iterable: Iterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
+	static async forEach<T>(iterable: Iterable<T> | AsyncIterable<T>, callback: ForEachCallback<T>, options?: ConcurrentOptions): Promise<ForEachException<T>[]>;
+}
 
+/**
+ * 并发循环的可选项
+ */
+export interface ConcurrentOptions {
 	/**
-	 * 执行一个异步的for of循环
-	 *
-	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
-	 *
-	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
-	 *
-	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
-	 * @param signal - AbortSignal信号，用于自行中止循环
-	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行过程中所有的异常
-	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
+	 * AbortSignal信号，用于自行中止循环
 	 */
-	static async forEach<T>(iterable: Iterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
-
-	/**
-	 * 执行一个异步的for of循环
-	 *
-	 * 由于异步的特性，你无法中途中止循环
-	 *
-	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
-	 *
-	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
-	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行过程中所有的异常
-	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
-	 */
-	static async forEach<T>(iterable: AsyncIterable<T>, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
-
-	/**
-	 * 执行一个异步的for of循环
-	 *
-	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
-	 *
-	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
-	 *
-	 * @param iterable - 异步可迭代对象（请勿传递无限迭代器）
-	 * @param signal - AbortSignal信号，用于自行中止循环
-	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
-	 * @returns 返回一个Promise，包含执行过程中所有的异常
-	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
-	 */
-	static async forEach<T>(iterable: AsyncIterable<T>, signal: AbortSignal, callback: ForEachCallback<T>): Promise<ForEachException<T>[]>;
+	signal?: AbortSignal;
 }
 
 /**

--- a/noname/library/concurrent/index.d.ts
+++ b/noname/library/concurrent/index.d.ts
@@ -1,0 +1,37 @@
+import { Uninstantable } from "../../util/index.js";
+
+export class Concurrent extends Uninstantable {
+	/**
+	 * 执行一个异步的、步长为1的for range循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环
+     * 
+     * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
+	 *
+	 * @param start - 开始索引（包含）
+	 * @param end - 结束索引（不包含）
+	 * @param callback - 回调函数，接收当前索引；如果回调函数不包含异步操作，则将退化为同步操作
+	 * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的回调函数不是一个函数
+	 */
+	static async for<T extends number>(start: T, end: T, callback: ForCallback<T>): Promise<ForException<T>[]>;
+
+	/**
+	 * 执行一个异步的for range循环
+	 *
+	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
+     * 
+     * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
+     * 
+	 * @param start - 开始索引（包含）
+	 * @param end - 结束索引（不包含）
+	 * @param signal - AbortSignal信号，用于自行中止循环
+	 * @param callback - 回调函数，接收当前索引和提供的信号；如果回调函数不包含异步操作，则将退化为同步操作
+     * @returns 返回一个Promise，包含执行其中所有的异常
+	 * @throws {TypeError} 如果提供的回调函数不是一个函数
+	 */
+	static async for<T extends number>(start: T, end: T, signal: AbortSignal, callback: ForCallback<T>): Promise<ForException<T>[]>;
+}
+
+type ForCallback<T extends number> = (index: T, signal: AbortSignal) => Promise<void> | void;
+type ForException<T extends number, E extends Error = Error> = { index: number; error: E };

--- a/noname/library/concurrent/index.js
+++ b/noname/library/concurrent/index.js
@@ -4,15 +4,12 @@ import { Uninstantable } from "../../util/index.js";
 export class Concurrent extends Uninstantable {
 	static #control = new AbortController();
 
-	static async for(begin, end, signal, callback) {
-		if (typeof signal == "function") {
-			callback = signal;
-			signal = this.#control.signal;
-		}
+	static async for(begin, end, callback, options) {
 		if (typeof callback != "function") {
 			throw new TypeError("Callback must be a function");
 		}
 
+		const signal = options?.signal ?? this.#control.signal;
 		const length = end - begin;
 
 		const promises = Array(length);
@@ -34,17 +31,15 @@ export class Concurrent extends Uninstantable {
 	}
 
 	// 谁传一个无限迭代器我必拷打谁
-	static async forEach(iterable, signal, callback) {
+	static async forEach(iterable, callback, options) {
 		if (iterable == null || typeof iterable != "object") {
 			throw new TypeError("Iterable must be an object");
-		}
-		if (typeof signal == "function") {
-			callback = signal;
-			signal = this.#control.signal;
 		}
 		if (typeof callback != "function") {
 			throw new TypeError("Callback must be a function");
 		}
+
+		const signal = options?.signal ?? this.#control.signal;
 
 		let promises;
 		if (Symbol.asyncIterator in iterable) {

--- a/noname/library/concurrent/index.js
+++ b/noname/library/concurrent/index.js
@@ -32,4 +32,43 @@ export class Concurrent extends Uninstantable {
 			.map(result => ({ index: result.index, error: result.value }))
 			.toArray();
 	}
+
+	// 谁传一个无限迭代器我必拷打谁
+	static async forEach(iterable, signal, callback) {
+		if (iterable == null || typeof iterable != "object") {
+			throw new TypeError("Iterable must be an object");
+		}
+		if (typeof signal == "function") {
+			callback = signal;
+			signal = this.#control.signal;
+		}
+		if (typeof callback != "function") {
+			throw new TypeError("Callback must be a function");
+		}
+
+		let promises;
+		if (Symbol.asyncIterator in iterable) {
+			promises = [];
+			// 异步迭代除了`for await`外似乎没什么好的办法，先使用`for await`，后续再考虑全盘异步
+			for await (const item of iterable) {
+				promises.push(createPromise(item));
+			}
+		} else {
+			promises = Iterator.from(iterable)
+				.map(item => createPromise(item))
+				.toArray();
+		}
+
+		const results = await Promise.all(promises);
+		return Iterator.from(results)
+			.filter(result => result != null)
+			.toArray();
+
+		function createPromise(item) {
+			return Promise.try(callback, item, signal).then(
+				() => null,
+				error => ({ item, error })
+			);
+		}
+	}
 }

--- a/noname/library/concurrent/index.js
+++ b/noname/library/concurrent/index.js
@@ -1,0 +1,35 @@
+import { Uninstantable } from "../../util/index.js";
+
+// 文档信息请查阅对应的`index.d.ts`文件
+export class Concurrent extends Uninstantable {
+	static #control = new AbortController();
+
+	static async for(begin, end, signal, callback) {
+		if (typeof signal == "function") {
+			callback = signal;
+			signal = this.#control.signal;
+		}
+		if (typeof callback != "function") {
+			throw new TypeError("Callback must be a function");
+		}
+
+		const length = end - begin;
+
+		const promises = Array(length);
+		for (let i = begin; i < end; i++) {
+			promises[i - begin] = Promise.try(callback, i, signal);
+		}
+		const results = await Promise.allSettled(promises);
+
+		return Iterator.from(results)
+			.map((result, index) => {
+				if (result.status == "rejected") {
+					return { status: "rejected", index: index + begin, value: result.reason };
+				}
+				return { status: "fulfilled", index: index + begin, value: result.value };
+			})
+			.filter(result => result.status == "rejected")
+			.map(result => ({ index: result.index, error: result.value }))
+			.toArray();
+	}
+}

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -26,6 +26,7 @@ import { defaultHooks } from "./hooks/index.js";
 import { freezeButExtensible } from "../util/index.js";
 import security from "../util/security.js";
 import { ErrorManager } from "../util/error.js";
+import { Concurrent } from "./concurrent/index.js";
 
 import { defaultSplashs } from "../init/onload/index.js";
 
@@ -306,6 +307,11 @@ export class Library {
 	 * lib.announce.unsubscribe("skinChange", method);
 	 */
 	announce = new Announce(new EventTarget(), new WeakMap());
+
+	/**
+	 * 提供一组用于并发异步操作的静态工具方法
+	 */
+	concurrent = Concurrent;
 
 	objectURL = new Map();
 	hookmap = {};


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
实际上也没什么实际痛点，但写`Array#map + Promise.all`写烦了，就从隔壁C#抄了个类过来

### PR描述
<!-- 详细描述您的更改 -->
提供`lib.concurrent`静态类，其中暴露的方法为:

```typescript
export class Concurrent extends Uninstantable {
	/**
	 * 执行一个异步的for range循环
	 *
	 * 由于异步的特性，你无法中途中止循环，但你可以提供一个AbortSignal，来使回调函数能通过该信号中止
	 *
	 * > 步长为1主要是C#的Parallel.ForAsync的步长只能为1，~~绝对不是我懒~~
	 *
	 * @param start - 开始索引（包含）
	 * @param end - 结束索引（不包含）
	 * @param callback - 回调函数，接收当前索引和提供的信号；如果回调函数不包含异步操作，则将退化为同步操作
	 * @param options - 可选参数，具体可参阅`ConcurrentOptions`
	 * @returns 返回一个Promise，包含执行过程中所有的异常
	 * @throws {TypeError} 如果提供的回调函数不是一个函数
	 * @example
	 * // 使用AbortController来控制循环的终止
	 * const controller = new AbortController();
	 * await Concurrent.for(1, 100, async (i, signal) => {
	 * 	if (signal.aborted) return;
	 * 	await someAsyncOperation(i);
	 * }, { signal: controller.signal });
	 */
	static async for<T extends number>(start: T, end: T, callback: ForCallback<T>, options?: ConcurrentOptions): Promise<ForException<T>[]>;

	/**
	 * 执行一个异步的for of循环
	 *
	 * 由于异步的特性，你无法中途中止循环
	 *
	 * > 为了性能考虑，假定传入的可迭代对象均为有限迭代器，请勿传递无限迭代器
	 *
	 * @param iterable - 可迭代对象（请勿传递无限迭代器）
	 * @param callback - 回调函数，接收当前元素；如果回调函数不包含异步操作，则将退化为同步操作
	 * @param options - 可选参数，具体可参阅`ConcurrentOptions`
	 * @returns 返回一个Promise，包含执行过程中所有的异常
	 * @throws {TypeError} 如果提供的`iterable`不是一个对象，或回调函数不是一个函数
	 * @example
	 * // 对数组中的每项进行异步处理
	 * const controller = new AbortController();
	 * const items = [1, 2, 3, 4, 5];
	 * await Concurrent.forEach(items, async (item) => {
	 *   await processItem(item);
	 * }, { signal: controller.signal });
	 */
	static async forEach<T>(iterable: Iterable<T> | AsyncIterable<T>, callback: ForEachCallback<T>, options?: ConcurrentOptions): Promise<ForEachException<T>[]>;
}
```

> ~~我知道你们不喜欢看函数声明，但我也懒得写其他文档~~

---

下面是一些简单~~申必~~的例子

```javascript
// 从0遍历到10，打印其中的奇数
await lib.concurrent.for(0, 11, i => {
    if (i % 2 == 1) {
        console.log(i)
    }
})

// 遍历扩展目录下所有扩展的目录结构
const [folders] = await game.promises.getFileList("extension")

await lib.concurrent.forEach(folders, async folder => {
    const result = await game.promises.getFileList(`extension/${folder}`)
    console.log(result)
})
```

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
测了，能跑

### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无需适配

### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
