### PR TITLE
界面缩放更改补充

### DIFF
--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -408,7 +408,7 @@ export class Library {
 														return 0;
 													}
 													return 5 - get.value(cardx);
-												},
+											  },
 								});
 								if (!game.online) {
 									return;
@@ -1760,66 +1760,22 @@ export class Library {
 				// },
 				ui_zoom: {
 					name: "界面缩放",
-					unfrequent: true,
-					init: "normal",
-					item: {
-						esmall: "80%",
-						usmall: "85%",
-						vsmall: "90%",
-						small: "95%",
-						normal: "100%",
-						big: "105%",
-						vbig: "110%",
-						ebig: "120%",
-						eebig: "150%",
-						eeebig: "180%",
-						eeeebig: "200%",
-					},
-					onclick(zoom) {
-						game.saveConfig("ui_zoom", zoom);
-						switch (zoom) {
-							case "esmall":
-								zoom = 0.8;
-								break;
-							case "usmall":
-								zoom = 0.85;
-								break;
-							case "vsmall":
-								zoom = 0.9;
-								break;
-							case "small":
-								zoom = 0.93;
-								break;
-							case "big":
-								zoom = 1.05;
-								break;
-							case "vbig":
-								zoom = 1.1;
-								break;
-							case "ebig":
-								zoom = 1.2;
-								break;
-							case "eebig":
-								zoom = 1.5;
-								break;
-							case "eeebig":
-								zoom = 1.8;
-								break;
-							case "eeeebig":
-								zoom = 2;
-								break;
-							default:
-								zoom = 1;
+					intro: "填入0.5-3以内的数值作为界面缩放比例",
+					init: 1,
+					input: true,
+					restart: true,
+					onblur(e) {
+						let text = e.target,
+							zoom = Number(text.innerText);
+						if (isNaN(zoom) || zoom < 0.5 || zoom > 3) {
+							alert("填入数值不符合规范！");
+							return;
 						}
+						text.innerText = zoom;
+						game.saveConfig("ui_zoom", zoom);
 						game.documentZoom = game.deviceZoom * zoom;
 						ui.updatez();
-						if (Array.isArray(lib.onresize)) {
-							lib.onresize.forEach(fun => {
-								if (typeof fun == "function") {
-									fun();
-								}
-							});
-						}
+						Array.isArray(lib.onresize) && lib.onresize.forEach(fun => typeof fun === "function" && fun());
 					},
 				},
 				image_background: {
@@ -8726,7 +8682,7 @@ export class Library {
 					for (const content of item) {
 						yield content;
 					}
-				})()
+			  })()
 			: Promise.resolve(item);
 	}
 	gnc = {
@@ -11808,7 +11764,7 @@ export class Library {
 								storage: {
 									stratagem_buffed: 1,
 								},
-							})
+						  })
 						: new lib.element.VCard();
 				}
 				return null;

--- a/noname/ui/create/index.js
+++ b/noname/ui/create/index.js
@@ -2417,42 +2417,9 @@ export class Create {
 		ui.sidebar.ontouchmove = ui.click.touchScroll;
 		ui.sidebar.style.webkitOverflowScrolling = "touch";
 
-		var zoom;
-		switch (lib.config.ui_zoom) {
-			case "esmall":
-				zoom = 0.8;
-				break;
-			case "vsmall":
-				zoom = 0.9;
-				break;
-			case "small":
-				zoom = 0.93;
-				break;
-			case "big":
-				zoom = 1.05;
-				break;
-			case "vbig":
-				zoom = 1.1;
-				break;
-			case "ebig":
-				zoom = 1.2;
-				break;
-			case "eebig":
-				zoom = 1.5;
-				break;
-			case "eeebig":
-				zoom = 1.8;
-				break;
-			case "eeeebig":
-				zoom = 2;
-				break;
-			default:
-				zoom = 1;
-		}
+		var zoom = lib.config.ui_zoom || 1;
 		game.documentZoom = game.deviceZoom * zoom;
-		if (zoom != 1) {
-			ui.updatez();
-		}
+		zoom !== 1 && ui.updatez();
 
 		ui.system1 = ui.create.div("#system1", ui.system);
 		ui.system2 = ui.create.div("#system2", ui.system);


### PR DESCRIPTION
### PR受影响的平台
内蒙古
### 诱因和背景
界面缩放比例需求各不相同，给本体界面缩放添加比例毫无疑问是一个解决不了根源的问题
### PR描述
将界面缩放更改为自填数值，使得能更灵活控制缩放比例
**注：为防止输入过于离谱的数值导致界面“崩坏”，故比例范围限定为0.5-3以内**
### PR测试
测过了，能跑
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码