### PR TITLE
国战武将bugfix

### DIFF
--- a/mode/guozhan/src/skill/character/normal.js
+++ b/mode/guozhan/src/skill/character/normal.js
@@ -768,7 +768,7 @@ export default {
 			if (player == target) {
 				return false;
 			}
-			if (target.hasSkill("reqiangxi_off")) {
+			if (target.hasSkill("gz_qiangxi_off")) {
 				return false;
 			}
 			return player.inRange(target);

--- a/mode/guozhan/src/skill/character/normal.js
+++ b/mode/guozhan/src/skill/character/normal.js
@@ -1587,20 +1587,20 @@ export default {
 				filter(event, player) {
 					return event.skill == "gz_longdan_sha";
 				},
-				async cost(event, trigger, player) {
-					event.result = await player
+				logTarget: "targets",
+				async content(event, trigger, player) {
+					let result = await player
 						.chooseTarget("是否发动【龙胆】对一名其他角色造成1点伤害？", function (card, player, target) {
-							return target != _status.event?.target && target != player;
+							return target != trigger.target && target != player;
 						})
 						.set("ai", function (target) {
-							return -get.attitude(_status.event?.player, target);
+							return -get.attitude(player, target);
 						})
 						.set("target", trigger.target)
 						.forResult();
-				},
-				logTarget: "targets",
-				async content(event, _trigger, _player) {
-					await event.targets[0].damage();
+					if (result.bool) {
+						await result.targets[0].damage();
+					}
 				},
 			},
 			draw: {

--- a/mode/guozhan/src/skill/character/rest.js
+++ b/mode/guozhan/src/skill/character/rest.js
@@ -6314,7 +6314,7 @@ export default {
 		trigger: { player: "phaseZhunbeiBegin" },
 		filter(event, player) {
 			return game.hasPlayer(function (current) {
-				return !current.isFriendOf(player) && current.countDiscardableCards("hej", player) > 0;
+				return !current.isFriendOf(player) && current.countDiscardableCards(player, "hej") > 0;
 			});
 		},
 		direct: true,

--- a/mode/guozhan/src/skill/character/rest.js
+++ b/mode/guozhan/src/skill/character/rest.js
@@ -17155,17 +17155,15 @@ export default {
 				if (player == event.player) {
 					return false;
 				}
-				if (event.card.name == "feilongduofeng" && event.player.getCards("e").includes(event.card)) {
+				if (event.cards.some(card => card.name == "feilongduofeng" && event.player.getCards("e").includes(card))) {
 					return true;
 				}
 				return event.player.hasHistory("lose", function (evt) {
 					if (evt.position != ui.discardPile || evt.getParent().name != "equip") {
 						return false;
 					}
-					for (var i of evt.cards) {
-						if (i.name == "feilongduofeng" && get.position(i, true) == "d") {
-							return true;
-						}
+					if (evt.cards.some(card => card.name == "feilongduofeng" && get.position(card, true) == "d")) {
+						return true;
 					}
 					return false;
 				});
@@ -17173,50 +17171,53 @@ export default {
 			if (event.name == "lose" && (event.position != ui.discardPile || event.getParent().name == "equip")) {
 				return false;
 			}
-			for (var i of event.cards) {
-				if (i.name == "feilongduofeng" && get.position(i, true) == "d") {
-					return true;
-				}
+			if (event.cards.some(card => card.name == "feilongduofeng" && get.position(card, true) == "d")) {
+				return true;
 			}
 			return false;
 		},
 		logTarget(event, player) {
-			if (event.name == "equip" && event.card.name == "feilongduofeng" && event.player.getCards("e").includes(event.card)) {
+			if (event.name == "equip" && event.cards.some(card => card.name == "feilongduofeng" && event.player.getCards("e").includes(card))) {
 				return event.player;
 			}
 			return [];
 		},
-		content() {
-			game.delayx();
-			var cards = [];
+		async content(event, trigger, player) {
+			await game.delayx();
+			let cards = [];
 			if (trigger.name == "equip") {
-				if (trigger.card.name == "feilongduofeng" && trigger.player.getCards("e").includes(trigger.card)) {
-					cards.push(trigger.card);
+				for (const card of trigger.cards) {
+					if (card.name == "feilongduofeng" && trigger.player.getCards("e").includes(card)) {
+						cards.push(card);
+					}
 				}
 				trigger.player.getHistory("lose", function (evt) {
 					if (evt.position != ui.discardPile || evt.getParent() != trigger) {
 						return false;
 					}
-					for (var i of evt.cards) {
-						if (i.name == "feilongduofeng" && get.position(i, true) == "d") {
-							cards.push(i);
+					for (const card of evt.cards) {
+						if (card.name == "feilongduofeng" && get.position(card, true) == "d") {
+							cards.push(card);
 						}
 					}
 					return false;
 				});
 			}
-			if (trigger.name == "lose") {
-				for (var i of trigger.cards) {
-					if (i.name == "feilongduofeng" && get.position(i, true) == "d") {
-						cards.push(i);
+			if (["lose", "cardsDiscard"].includes(trigger.name)) {
+				for (const card of trigger.cards) {
+					if (card.name == "feilongduofeng" && get.position(card, true) == "d") {
+						cards.push(card);
 					}
 				}
 			}
-			var owner = get.owner(cards[0]);
+			if (!cards.length) {
+				return;
+			}
+			let owner = get.owner(cards[0]);
 			if (owner) {
-				player.gain(cards, "give", owner, "bySelf");
+				await player.gain(cards, "give", owner, "bySelf");
 			} else {
-				player.gain(cards, "gain2");
+				await player.gain(cards, "gain2");
 			}
 		},
 		group: "zhangwu_draw",

--- a/mode/guozhan/src/skill/character/rest.js
+++ b/mode/guozhan/src/skill/character/rest.js
@@ -16161,8 +16161,8 @@ export default {
 			if (event.num >= 3 && !(player.hasSkill("shelie") || player.hasSkill("jiahe_shelie"))) {
 				list.push("shelie");
 			}
-			if (event.num >= 4 && !(player.hasSkill("gzduoshi") || player.hasSkill("jiahe_duoshi"))) {
-				list.push("gzduoshi");
+			if (event.num >= 4 && !(player.hasSkill("gz_duoshi") || player.hasSkill("jiahe_duoshi"))) {
+				list.push("gz_duoshi");
 			}
 			if (!list.length) {
 				event.finish();

--- a/mode/guozhan/src/skill/character/rest.js
+++ b/mode/guozhan/src/skill/character/rest.js
@@ -9085,7 +9085,12 @@ export default {
 					.set("choiceList", ["执行该军令", "不执行该军令并受到1点伤害"])
 					.set("ai", function () {
 						var evt = _status.event.getParent(2);
-						return get.junlingEffect(evt.player, evt.junling, evt.current, evt.targets, evt.current) > get.damageEffect(evt.current, evt.player, evt.current) / get.attitude(evt.current, evt.current) ? 0 : 1;
+						var junlingEff = get.junlingEffect(evt.player, evt.junling, evt.current, evt.targets, evt.current);
+    					var damageEff = get.damageEffect(evt.current, evt.player, evt.current);
+					    var attitudeSelf = get.attitude(evt.current, evt.current);
+						var drawEff = get.effect(evt.player, { name: "draw" }, evt.player, evt.current);
+
+    					return junlingEff > damageEff / attitudeSelf + drawEff ? 0 : 1;
 					});
 			} else {
 				event.goto(4);


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
修复一些国战武将的bug，详细列表见下


### PR描述
<!-- 详细描述您的更改 -->

- 龙胆shamiss部分direct为true，这类技能不会执行cost函数，所以目前闪当杀对方出闪时，会直接掉血。将cost移到了content内部。
- 同一回合内强袭可对同一武将多次使用。修复了相关技能名。
- 探锋在所有敌方没有装备但有手牌时不会提示发动。修复了countDiscardableCards的参数顺序。
- 君孙权4张烽火时，度势显示为gzduoshi且无法正常发动。修复了相关技能名。
- 君刘备在他人装备、弃置、转化使用飞龙夺凤时，经常无法获得之。重构了该技能，主要是event.card改为event.cards。
- 黩武在选择军令三失去体力时，非卖血将的敌对AI经常无脑掉血给诸葛恪摸牌。AI加入了对摸牌的考虑。
- 目前版本钟会技能代码的X没有实现上限，导致过于超模，在贴吧也有反馈。修改了技能代码和官方技能保持一致（X最少为1最多为体力上限，[ref](https://i1.hdslb.com/bfs/article/162e28410d6aeb76c46114634efb30af416e7783.jpg@1000w_1404h.avif)出自[紫乔](https://www.bilibili.com/opus/753214913190559782)）。
- 钟会排异对象的AI计算摸牌effect的符号反了，导致敌对AI经常无脑给钟会摸一把牌。修复了这部分代码。


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
能玩


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
N/A


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [ ] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [ ] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [ ] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [ ] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
