### PR TITLE
添加自动删除无效扩展配置选项

### DIFF
--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -467,11 +467,11 @@ export class Library {
 								_status.event._resultid = id;
 								game.resume();
 							};
-							("step 1");
+							"step 1";
 							var type = get.type2(card);
 							event.list = game.filterPlayer(current => current != player && current.countCards("h") && (_status.connectMode || current.hasCard(cardx => get.type2(cardx) == type, "h"))).sortBySeat(_status.currentPhase || player);
 							event.id = get.id();
-							("step 2");
+							"step 2";
 							if (!event.list.length) {
 								event.finish();
 							} else if (_status.connectMode && (event.list[0].isOnline() || event.list[0] == game.me)) {
@@ -479,7 +479,7 @@ export class Library {
 							} else {
 								event.send((event.current = event.list.shift()), event.card, player, trigger.targets, event.id, trigger.parent.id, trigger.yingbianZhuzhanAI);
 							}
-							("step 3");
+							"step 3";
 							if (result.bool) {
 								event.zhuzhanresult = event.current;
 								event.zhuzhanresult2 = result;
@@ -490,7 +490,7 @@ export class Library {
 							} else {
 								event.goto(2);
 							}
-							("step 4");
+							"step 4";
 							var id = event.id,
 								sendback = (result, player) => {
 									if (result && result.id == id && !event.zhuzhanresult && result.bool) {
@@ -537,20 +537,20 @@ export class Library {
 								});
 							}
 							event.withol = withol;
-							("step 5");
+							"step 5";
 							if (!result || !result.bool || event.zhuzhanresult) {
 								return;
 							}
 							game.broadcast("cancel", event.id);
 							event.zhuzhanresult = game.me;
 							event.zhuzhanresult2 = result;
-							("step 6");
+							"step 6";
 							if (event.withol && !event.resultOL) {
 								game.pause();
 							}
-							("step 7");
+							"step 7";
 							game.players.forEach(value => value.hideTimer());
-							("step 8");
+							"step 8";
 							if (event.zhuzhanresult) {
 								var target = event.zhuzhanresult;
 								target.line(player, "green");
@@ -1305,6 +1305,7 @@ export class Library {
 					},
 					unfrequent: true,
 				},
+
 				extension_auto_removeConfig: {
 					name: "自动删除配置",
 					intro: dedent`
@@ -12905,7 +12906,7 @@ export class Library {
 				"step 0";
 				player._groupChosen = "double";
 				player.chooseControl(get.is.double(player.name1, true)).set("prompt", "请选择你的势力");
-				("step 1");
+				"step 1";
 				player.changeGroup(result.control);
 			},
 		},
@@ -13482,7 +13483,7 @@ export class Library {
 			content: function () {
 				"step 0";
 				event.logvid = trigger.getLogv();
-				("step 1");
+				"step 1";
 				event.targets = game.filterPlayer(function (current) {
 					return current != event.player && current.isLinked();
 				});
@@ -13495,7 +13496,7 @@ export class Library {
 				} else {
 					event._args.push("nosource");
 				}
-				("step 2");
+				"step 2";
 				if (event.targets.length) {
 					var target = event.targets.shift();
 					if (target.isLinked()) {

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -1305,7 +1305,6 @@ export class Library {
 					},
 					unfrequent: true,
 				},
-
 				extension_auto_removeConfig: {
 					name: "自动删除配置",
 					intro: dedent`

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -467,11 +467,11 @@ export class Library {
 								_status.event._resultid = id;
 								game.resume();
 							};
-							"step 1";
+							("step 1");
 							var type = get.type2(card);
 							event.list = game.filterPlayer(current => current != player && current.countCards("h") && (_status.connectMode || current.hasCard(cardx => get.type2(cardx) == type, "h"))).sortBySeat(_status.currentPhase || player);
 							event.id = get.id();
-							"step 2";
+							("step 2");
 							if (!event.list.length) {
 								event.finish();
 							} else if (_status.connectMode && (event.list[0].isOnline() || event.list[0] == game.me)) {
@@ -479,7 +479,7 @@ export class Library {
 							} else {
 								event.send((event.current = event.list.shift()), event.card, player, trigger.targets, event.id, trigger.parent.id, trigger.yingbianZhuzhanAI);
 							}
-							"step 3";
+							("step 3");
 							if (result.bool) {
 								event.zhuzhanresult = event.current;
 								event.zhuzhanresult2 = result;
@@ -490,7 +490,7 @@ export class Library {
 							} else {
 								event.goto(2);
 							}
-							"step 4";
+							("step 4");
 							var id = event.id,
 								sendback = (result, player) => {
 									if (result && result.id == id && !event.zhuzhanresult && result.bool) {
@@ -537,20 +537,20 @@ export class Library {
 								});
 							}
 							event.withol = withol;
-							"step 5";
+							("step 5");
 							if (!result || !result.bool || event.zhuzhanresult) {
 								return;
 							}
 							game.broadcast("cancel", event.id);
 							event.zhuzhanresult = game.me;
 							event.zhuzhanresult2 = result;
-							"step 6";
+							("step 6");
 							if (event.withol && !event.resultOL) {
 								game.pause();
 							}
-							"step 7";
+							("step 7");
 							game.players.forEach(value => value.hideTimer());
-							"step 8";
+							("step 8");
 							if (event.zhuzhanresult) {
 								var target = event.zhuzhanresult;
 								target.line(player, "green");
@@ -1302,6 +1302,46 @@ export class Library {
 					init: false,
 					async onclick(bool) {
 						await game.promises.saveConfig("extension_auto_import", bool);
+					},
+					unfrequent: true,
+				},
+				extension_auto_removeConfig: {
+					name: "自动删除配置",
+					intro: dedent`
+						开启后无名杀会检查lib.config.extensions中的扩展是否在extension文件夹中存在，若不存在则删除该扩展的config配置信息（默认关闭）
+						<br />
+						※ 该选项为点击后执行一次代码，不会一直打开
+						<br />
+						※ 该选项仅能检测lib.config["extension_extensionName_"]的配置，扩展直接使用lib.config.xx储存的没有办法
+					`,
+					init: false,
+					async onclick() {
+						let config = lib.config;
+						if (get.is.object(config)) {
+							let extensionList = config.extensions;
+							for (let name of extensionList) {
+								let num = await game.promises.checkDir(`extension/${name}`);
+								if (num !== 1) {
+									game.removeExtension(name);
+								} else {
+									let all = await game.promises.getFileList(`extension/${name}`);
+									if (Boolean(all?.[1].length)) {
+										const hasExtensionJs = all[1].includes("extension.js");
+										const hasInfoJson = all[1].includes("info.json");
+
+										if (!hasExtensionJs) {
+											const message = hasInfoJson ? `扩展${name}有 info.json 但缺少 extension.js 文件` : `扩展${name}缺少必须的 extension.js 文件`;
+											console.error(message);
+											game.removeExtension(name);
+										}
+									}
+								}
+							}
+						}
+						let ret = confirm(`检测完成，已为你清除无效配置，是否重启？`);
+						if (ret) {
+							game.reload();
+						}
 					},
 					unfrequent: true,
 				},
@@ -12865,7 +12905,7 @@ export class Library {
 				"step 0";
 				player._groupChosen = "double";
 				player.chooseControl(get.is.double(player.name1, true)).set("prompt", "请选择你的势力");
-				"step 1";
+				("step 1");
 				player.changeGroup(result.control);
 			},
 		},
@@ -13442,7 +13482,7 @@ export class Library {
 			content: function () {
 				"step 0";
 				event.logvid = trigger.getLogv();
-				"step 1";
+				("step 1");
 				event.targets = game.filterPlayer(function (current) {
 					return current != event.player && current.isLinked();
 				});
@@ -13455,7 +13495,7 @@ export class Library {
 				} else {
 					event._args.push("nosource");
 				}
-				"step 2";
+				("step 2");
 				if (event.targets.length) {
 					var target = event.targets.shift();
 					if (target.isLinked()) {


### PR DESCRIPTION
### PR受影响的平台
无


### 诱因和背景
※有些扩展会存在隐藏了“删除此扩展”的选项，或者因为部分安卓手机权限的问题，导致在游戏内无法直接删除扩展，或者删除了扩展，但是extension文件夹的扩展文件还在，于是有些时候会直接在文件夹内删除扩展，这会导致关于扩展的lib.config[extension_${extensionName}_]的配置文件还在，最显著的就是lib.config.extensions内还有该扩展存在，以及Lib.config.extension_extensionName_的配置信息还存在，如果有某个扩展以检测另一个扩展是否存在或者打开而开启某个功能，就会导致报错。


### PR描述
※该选项点击后将检查lib.config.extensions内的扩展，根据扩展名检查相对应的扩展文件夹是否存在，如果存在即检查是否存在extension.js/info.json文件，如果都不满足就执行game.removeExtension(extensionName)来删除扩展的配置文件。

※该选项实现比较粗暴/简单，所以点击打开时需充分小心，同时需要注意的是，我在之前遇到过一个扩展，扩展文件夹是“aaa”,扩展的extension.js和info.js写的扩展名是“bbb”，如果你的扩展内有这样的扩展，请勿打开此选项。


### PR测试
PC本地客户端充分测试通过，安卓端未测试


### 扩展适配
无需适配


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [ ] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
