### PR TITLE
增加联机里面对Map与Set类型的序列化

### DIFF
--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -2652,6 +2652,10 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 						}
 						return result;
 					} else {
+						if (level == 0) {
+							return {};
+						}
+						
 						const type = Object.prototype.toString.call(item).slice(8, -1);
 
 						switch(type) {
@@ -2660,9 +2664,6 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 							case "Set":
 								return get.setInfoOL(item, level - 1, nomore);
 							case "Object":
-								if (level == 0) {
-									return {};
-								}
 								const result = {};
 								for (const i in item) {
 									result[i] = get.stringifiedResult(item[i], level - 1, nomore);

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -14,6 +14,11 @@ import { CodeSnippet, ErrorManager } from "../util/error.js";
 
 import { GetCompatible } from "./compatible.js";
 
+// 用于标识Map、Set等对象在序列化中的类型
+// 使用了md5("__noname_type")的值作为键
+// 尽可能减少碰撞喵（应该不会碰撞的吧）
+const TYPE_KEY = "a60e024487f63a67c634d782aaaf1127";
+
 export class Get extends GetCompatible {
 	is = new Is();
 	promises = new Promises();
@@ -2539,6 +2544,75 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 	infoVCardsOL(infos) {
 		return Array.from(infos || []).map(get.infoVCardOL);
 	}
+	/**
+	 * @param {Map} map 要序列化的Map
+	 * @param {number} [level] 最大的序列化嵌套层级
+	 * @param {false | null} [nomore] 传递false取消内部事件的序列化
+	 */
+	mapInfoOL(map, level, nomore) {
+		const info = {};
+
+		for (const [key, value] of map.entries()) {
+			Array.prototype.push.call(info, [
+				get.stringifiedResult(key, level, nomore),
+				get.stringifiedResult(value, level, nomore),
+			]);
+		}
+
+		info[TYPE_KEY] = "map";
+		return info;
+	}
+	/**
+	 * @param {Set} set 要序列化的Set
+	 * @param {number} [level] 最大的序列化嵌套层级
+	 * @param {false | null} [nomore] 传递false取消内部事件的序列化
+	 */
+	setInfoOL(set, level, nomore) {
+		const info = {};
+
+		for (const value of set) {
+			Array.prototype.push.call(info,
+				get.stringifiedResult(value, level, nomore));
+		}
+
+		info[TYPE_KEY] = "set";
+		return info;
+	}
+	infoMapOL(item) {
+		const map = new Map();
+
+		for (const index in item) {
+			if (!isFinite(Number(index))) {
+				break;
+			}
+
+			const pair = item[index];
+
+			if (!Array.isArray(pair) || pair.length !== 2) {
+				continue;
+			}
+
+			map.set(
+				get.parsedResult(pair[0]),
+				get.parsedResult(pair[1])
+			);
+		}
+
+		return map;
+	}
+	infoSetOL(item) {
+		const set = new Set();
+
+		for (const index in item) {
+			if (!isFinite(Number(index))) {
+				break;
+			}
+
+			set.add(get.parsedResult(item[index]));
+		}
+
+		return set;
+	}
 	stringifiedResult(item, level, nomore) {
 		if (!item) {
 			return item;
@@ -2572,22 +2646,31 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 						if (level == 0) {
 							return [];
 						}
-						var item2 = [];
-						for (var i = 0; i < item.length; i++) {
-							item2.push(get.stringifiedResult(item[i], level - 1, nomore));
+						const result = [];
+						for (let i = 0; i < item.length; i++) {
+							result.push(get.stringifiedResult(item[i], level - 1, nomore));
 						}
-						return item2;
-					} else if (Object.prototype.toString.call(item) == "[object Object]") {
-						if (level == 0) {
-							return {};
-						}
-						var item2 = {};
-						for (var i in item) {
-							item2[i] = get.stringifiedResult(item[i], level - 1, nomore);
-						}
-						return item2;
+						return result;
 					} else {
-						return {};
+						const type = Object.prototype.toString.call(item).slice(8, -1);
+
+						switch(type) {
+							case "Map":
+								return get.mapInfoOL(item, level - 1, nomore);
+							case "Set":
+								return get.setInfoOL(item, level - 1, nomore);
+							case "Object":
+								if (level == 0) {
+									return {};
+								}
+								const result = {};
+								for (const i in item) {
+									result[i] = get.stringifiedResult(item[i], level - 1, nomore);
+								}
+								return result;
+							default:
+								return {};
+						}
 					}
 			}
 		} else if (item === Infinity) {
@@ -2617,17 +2700,25 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 				return item;
 			}
 		} else if (Array.isArray(item)) {
-			var item2 = [];
-			for (var i = 0; i < item.length; i++) {
-				item2.push(get.parsedResult(item[i]));
+			const result = [];
+			for (let i = 0; i < item.length; i++) {
+				result.push(get.parsedResult(item[i]));
 			}
-			return item2;
+			return result;
 		} else if (typeof item == "object") {
-			var item2 = {};
-			for (var i in item) {
-				item2[i] = get.parsedResult(item[i]);
+			if (TYPE_KEY in item) {
+				switch (item[TYPE_KEY]) {
+					case "map":
+						return get.infoMapOL(item);
+					case "set":
+						return get.infoSetOL(item);
+				}
 			}
-			return item2;
+			const result = {};
+			for (const i in item) {
+				result[i] = get.parsedResult(item[i]);
+			}
+			return result;
 		} else {
 			return item;
 		}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
无

### 诱因和背景
部分技能需要使用到Map或者Set这些新的集合，但是原来的联机数据序列化方面不支持哦

### PR描述
为Map与Set增加了联机中序列化与反序列化的支持喵

### PR测试
在联机中通过神卢植的围铸技能测试（此技能使用了Map的序列化）

### 扩展适配
暂无

### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [ ] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
