### PR TITLE
修复lib.element.content.equip检查销毁实体牌的bug

### DIFF
--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -1070,16 +1070,21 @@ export const Content = {
 			}
 		};
 		//检查实体牌会不会被销毁
-		if (event.cards?.some(card => card.willBeDestroyed("equip", player, event) || "hejx".includes(get.position(card, true)))) {
-			const willBeDestroyed = event.cards.filter(card => card.willBeDestroyed("equip", player, event));
-			if (willBeDestroyed.length) {
-				for (let cardx of willBeDestroyed) {
-					cardx.selfDestroy(event);
-				}
-				const cards = event.cards.slice().removeArray(willBeDestroyed);
-				if (cards.length) {
-					await game.cardsDiscard(cards);
-				}
+		let stop = false;
+		const list = [];
+		for (const cardx of event.cards) {
+			if (cardx.willBeDestroyed("equip", player, event)) {
+				cardx.selfDestroy(event);
+				stop = true;
+			} else if ("hejx".includes(get.position(cardx, true))) {
+				stop = true;
+			} else {
+				list.add(cardx);
+			}
+		}
+		if (stop) {
+			if (list.length) {
+				await game.cardsDiscard(list);
 			}
 			return;
 		}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -1070,13 +1070,18 @@ export const Content = {
 			}
 		};
 		//检查实体牌会不会被销毁
-		for (let cardx of event.cards) {
-			if (cardx.willBeDestroyed("equip", player, event)) {
-				cardx.selfDestroy(event);
-				return;
-			} else if ("hejx".includes(get.position(cardx, true))) {
-				return;
+		if (event.cards?.some(card => card.willBeDestroyed("equip", player, event) || "hejx".includes(get.position(card, true)))) {
+			const willBeDestroyed = event.cards.filter(card => card.willBeDestroyed("equip", player, event));
+			if (willBeDestroyed.length) {
+				for (let cardx of willBeDestroyed) {
+					cardx.selfDestroy(event);
+				}
+				const cards = event.cards.slice().removeArray(willBeDestroyed);
+				if (cards.length) {
+					await game.cardsDiscard(cards);
+				}
 			}
+			return;
 		}
 		//同时播放所有装备牌的装备动画
 		if (event.cards.length) {


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
修复 #2752  反馈的一个bug：装备装备牌流程中未考虑实体牌数大于1且其中有满足销毁条件的情况，直接就终止后续结算


### PR描述
<!-- 详细描述您的更改 -->
1.修复equip检查销毁实体牌未考虑实体牌数大于1且其中有满足销毁条件直接终止结算的bug


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
已使用【巧手】测试


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
更改了lib.element.content.equip的扩展需要跟进


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码

