### PR TITLE
bugfix

### DIFF
--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -28688,7 +28688,7 @@ const skills = {
 		silent: true,
 		sourceSkill: "xianfu",
 		filter(event, player) {
-			return event.player == player || (player.storage.xianfu2 && player.storage.xianfu2.includes(player));
+			return event.player == player || (player.storage.xianfu2 && player.storage.xianfu2.includes(event.player));
 		},
 		content() {
 			if (player == trigger.player) {


### PR DESCRIPTION
修复戏志才【先辅】在先辅角色死亡后不移除死亡角色在storage.xianfu2中的记录的问题