### PR TITLE
SP貂蝉bugfix+异步化

### DIFF
--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -38569,11 +38569,13 @@ const skills = {
 		filterCard: true,
 		position: "he",
 		logAudio: () => 1,
-		content() {
-			player.gainPlayerCard(target, true, "h", target.countCards("h"));
-			player.turnOver();
+		async content(event, trigger, player) {
+			const { target } = event;
+			await player.gainPlayerCard(target, true, "h", target.countCards("h"));
+			await player.turnOver();
 			player.addSkill("lihun2");
-			player.storage.lihun = target;
+			if (!player.storage.lihun) player.storage.lihun = [];
+			player.storage.lihun.push(target);
 		},
 		check(card) {
 			return 8 - get.value(card);
@@ -38602,21 +38604,20 @@ const skills = {
 		forced: true,
 		audio: "lihun2.mp3",
 		sourceSkill: "lihun",
-		content() {
-			"step 0";
-			var cards = player.getCards("he");
-			player.removeSkill("lihun2");
-			if (player.storage.lihun.classList.contains("dead") || player.storage.lihun.hp <= 0 || cards.length == 0) {
-				event.finish();
-			} else {
-				if (cards.length < player.storage.lihun.hp) {
-					event._result = { bool: true, cards: cards };
-				} else {
-					player.chooseCard("he", true, player.storage.lihun.hp, "离魂：选择要交给" + get.translation(player.storage.lihun) + "的牌");
+		async content(event, trigger, player) {
+			player.storage.lihun = player.storage.lihun.sortBySeat();
+			for (let i of player.storage.lihun) {
+				if (i.isDead() || i.hp <= 0) continue;
+				if (!player.countCards("he")) break;
+				let cards = player.getCards("he");
+				if (cards.length > i.hp) {
+					const next = await player.chooseCard("he", true, i.hp, "离魂：选择要交给" + get.translation(i) + "的牌").forResult();
+					cards = next.cards;
 				}
+				await player.give(cards, i);
 			}
-			"step 1";
-			player.give(result.cards, player.storage.lihun);
+			player.removeSkill("lihun2");
+			delete player.storage.lihun;
 		},
 	},
 	yuanhu: {


### PR DESCRIPTION
### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
发现当SP貂蝉的【离魂】被重置后，lihun2的还牌仅适用于最后被还牌的角色


### PR描述
<!-- 详细描述您的更改 -->
将SP貂蝉的技能lihun,lihun2进行了修改同时异步化，使其可以在对多个人发动后仍然正常还牌
注：我是按照自己对描述的理解修改的，即如果出牌阶段内对同一个人发动多次【离魂】，此阶段结束时会多次返还其牌，同时最后返还牌是按照座位顺序返还，不是按照发动顺序先后


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
实测，在关闭所有扩展的情况下对多种可能的情况进行了实测，均无报错或其他问题


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->



### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
