### PR TITLE
孩子们，我回来了（）

### DIFF
--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -261,7 +261,7 @@ const skills = {
 			if (player.isUnderControl(true)) {
 				const cards = lib.skill.olsbzhitian.getCards(player);
 				function createDialogWithControl(result) {
-					const dialog = ui.create.dialog("知天");
+					const dialog = ui.create.dialog("知天", "peaceDialog");
 					result.length > 0 ? dialog.add(result, true) : dialog.addText("牌堆顶无牌");
 					const control = ui.create.control("确定", () => dialog.close());
 					dialog._close = dialog.close;

--- a/character/sp2/skill.js
+++ b/character/sp2/skill.js
@@ -13020,6 +13020,9 @@ const skills = {
 					if (player.getStorage("pingjian").includes(skills2[j])) {
 						continue;
 					}
+					if (player.hasSkill(skills2[j], null, null, false)) {
+						continue;
+					}
 					if (skills.includes(skills2[j])) {
 						list.add(name);
 						if (!map[name]) {
@@ -13128,15 +13131,16 @@ const skills = {
 					if (player.getStorage("pingjian").includes(skills2[j])) {
 						continue;
 					}
+					if (player.hasSkill(skills2[j], null, null, false)) {
+						continue;
+					}
 					if (get.is.locked(skills2[j], player)) {
 						continue;
 					}
-					var info = lib.translate[skills2[j] + "_info"];
-					if (skills.includes(skills2[j]) || (info && info.indexOf("当你于出牌阶段") != -1 && info.indexOf("当你于出牌阶段外") == -1)) {
+					var info = get.plainText(lib.translate[skills2[j] + "_info"] || "");
+					if (skills.includes(skills2[j]) || (info.includes("当你于出牌阶段") && !info.includes("当你于出牌阶段外"))) {
 						list.add(name);
-						if (!map[name]) {
-							map[name] = [];
-						}
+						map[name] ??= [];
 						map[name].push(skills2[j]);
 						skills.add(skills2[j]);
 						continue;

--- a/character/yingbian/skill.js
+++ b/character/yingbian/skill.js
@@ -2153,7 +2153,7 @@ const skills = {
 			if (player.isUnderControl(true)) {
 				const cards = lib.skill.smyyingshi.getCards(player);
 				function createDialogWithControl(result) {
-					const dialog = ui.create.dialog("鹰视");
+					const dialog = ui.create.dialog("鹰视", "peaceDialog");
 					result.length > 0 ? dialog.add(result, true) : dialog.addText("牌堆顶无牌");
 					const control = ui.create.control("确定", () => dialog.close());
 					dialog._close = dialog.close;

--- a/node_modules/@types/noname-typings/nonameModules/noname/library/element/dialog.d.ts
+++ b/node_modules/@types/noname-typings/nonameModules/noname/library/element/dialog.d.ts
@@ -1,68 +1,70 @@
 export class Dialog extends HTMLDivElement {
-    constructor(...args: any[]);
-    /** @type { HTMLDivElement } */
-    contentContainer: HTMLDivElement;
-    /** @type { HTMLDivElement } */
-    content: HTMLDivElement;
-    /** @type { HTMLDivElement } */
-    bar1: HTMLDivElement;
-    /** @type { HTMLDivElement } */
-    bar2: HTMLDivElement;
-    /** @type { Button[] } */
-    buttons: Button[];
-    /** @type { boolean } */
-    static: boolean;
-    /** @type { boolean } */
-    noforcebutton: boolean;
-    /** @type { boolean } */
-    noopen: boolean;
-    /**
-     * dialog添加数据是否支持分页
-     * @type { boolean }
-     **/
-    supportsPagination: boolean;
-    /**
-     * dialog中储存的分页元素(用来兼容一个dialog中多个分页的情况)
-     * @type { Map<HTMLElement, InstanceType<typeof import("../../util/pagination.js").Pagination>> }
-     */
-    paginationMap: Map<HTMLElement, InstanceType<typeof import("../../util/pagination.js").Pagination>>;
-    /**
-     * 根据数据类型，为每一个类型分配一页的最大数据量
-     * @type { Map<keyof UI['create']['buttonPresets'], number> }
-     */
-    paginationMaxCount: Map<keyof UI["create"]["buttonPresets"], number>;
-    /**
-     * 添加分页组件到页面
-     * @param {Pagination} state - 分页组件的配置对象
-     */
-    addPagination(state?: Pagination): void;
-    /**
-     *
-     * @param  {RowItem[]} args
-     */
-    addNewRow(...args: RowItem[]): void;
-    itemContainers: any[];
-    /**
-     *
-     * @param { string | HTMLDivElement | Card[] | Player[] } item
-     * @param {*} [noclick]
-     * @param { boolean } [zoom]
-     */
-    add(item: string | HTMLDivElement | Card[] | Player[], noclick?: any, zoom?: boolean): string | HTMLDivElement | import("noname-typings/nonameModules/noname/library/element/player.js").Player[] | import("noname-typings/nonameModules/noname/library/element/card.js").Card[];
-    forcebutton: boolean;
-    /**
-     * @param { string } str
-     * @param { boolean } [center]
-     */
-    addText(str: string, center?: boolean): this;
-    addSmall(item: any, noclick: any): string | HTMLDivElement | import("noname-typings/nonameModules/noname/library/element/player.js").Player[] | import("noname-typings/nonameModules/noname/library/element/card.js").Card[];
-    addAuto(content: any): void;
-    open(): this;
-    _dragtransform: any;
-    close(): this;
-    /**
-     * @param { string } str
-     */
-    setCaption(str: string): this;
+	constructor(...args: any[]);
+	/** @type { HTMLDivElement } */
+	contentContainer: HTMLDivElement;
+	/** @type { HTMLDivElement } */
+	content: HTMLDivElement;
+	/** @type { HTMLDivElement } */
+	bar1: HTMLDivElement;
+	/** @type { HTMLDivElement } */
+	bar2: HTMLDivElement;
+	/** @type { Button[] } */
+	buttons: Button[];
+	/** @type { boolean } */
+	static: boolean;
+	/** @type { boolean } */
+	noforcebutton: boolean;
+	/** @type { boolean } */
+	peaceDialog: boolean;
+	/** @type { boolean } */
+	noopen: boolean;
+	/**
+	 * dialog添加数据是否支持分页
+	 * @type { boolean }
+	 **/
+	supportsPagination: boolean;
+	/**
+	 * dialog中储存的分页元素(用来兼容一个dialog中多个分页的情况)
+	 * @type { Map<HTMLElement, InstanceType<typeof import("../../util/pagination.js").Pagination>> }
+	 */
+	paginationMap: Map<HTMLElement, InstanceType<typeof import("../../util/pagination.js").Pagination>>;
+	/**
+	 * 根据数据类型，为每一个类型分配一页的最大数据量
+	 * @type { Map<keyof UI['create']['buttonPresets'], number> }
+	 */
+	paginationMaxCount: Map<keyof UI["create"]["buttonPresets"], number>;
+	/**
+	 * 添加分页组件到页面
+	 * @param {Pagination} state - 分页组件的配置对象
+	 */
+	addPagination(state?: Pagination): void;
+	/**
+	 *
+	 * @param  {RowItem[]} args
+	 */
+	addNewRow(...args: RowItem[]): void;
+	itemContainers: any[];
+	/**
+	 *
+	 * @param { string | HTMLDivElement | Card[] | Player[] } item
+	 * @param {*} [noclick]
+	 * @param { boolean } [zoom]
+	 */
+	add(item: string | HTMLDivElement | Card[] | Player[], noclick?: any, zoom?: boolean): string | HTMLDivElement | import("noname-typings/nonameModules/noname/library/element/player.js").Player[] | import("noname-typings/nonameModules/noname/library/element/card.js").Card[];
+	forcebutton: boolean;
+	/**
+	 * @param { string } str
+	 * @param { boolean } [center]
+	 */
+	addText(str: string, center?: boolean): this;
+	addSmall(item: any, noclick: any): string | HTMLDivElement | import("noname-typings/nonameModules/noname/library/element/player.js").Player[] | import("noname-typings/nonameModules/noname/library/element/card.js").Card[];
+	addAuto(content: any): void;
+	open(): this;
+	_dragtransform: any;
+	close(): this;
+	/**
+	 * @param { string } str
+	 */
+	setCaption(str: string): this;
 }
 import { Pagination } from "../../util/pagination.js";

--- a/noname/library/element/dialog.js
+++ b/noname/library/element/dialog.js
@@ -22,6 +22,8 @@ export class Dialog extends HTMLDivElement {
 	/** @type { boolean } */
 	noforcebutton;
 	/** @type { boolean } */
+	peaceDialog;
+	/** @type { boolean } */
 	noopen;
 	/**
 	 * dialog添加数据是否支持分页
@@ -50,6 +52,7 @@ export class Dialog extends HTMLDivElement {
 		let noTouchScroll = false;
 		let forceButton = false;
 		let noForceButton = false;
+		let peaceDialog = false;
 		/** @type { this } */
 		// @ts-expect-error ignore
 		const dialog = ui.create.div(".dialog");
@@ -73,6 +76,8 @@ export class Dialog extends HTMLDivElement {
 				forceButton = true;
 			} else if (argument == "noforcebutton") {
 				noForceButton = true;
+			} else if (argument == "peaceDialog") {
+				peaceDialog = true;
 			} else {
 				dialog.add(argument);
 			}
@@ -93,6 +98,9 @@ export class Dialog extends HTMLDivElement {
 		} else if (forceButton) {
 			dialog.forcebutton = true;
 			dialog.classList.add("forcebutton");
+		}
+		if (peaceDialog) {
+			dialog.peaceDialog = true;
 		}
 		// @ts-expect-error ignore
 		dialog._args = args;
@@ -372,10 +380,12 @@ export class Dialog extends HTMLDivElement {
 				ui.update();
 				return this;
 			}
-			if (ui.dialogs[i].static) {
-				ui.dialogs[i].unfocus();
-			} else {
-				ui.dialogs[i].hide();
+			if (!this.peaceDialog) {
+				if (ui.dialogs[i].static) {
+					ui.dialogs[i].unfocus();
+				} else {
+					ui.dialogs[i].hide();
+				}
 			}
 		}
 		ui.dialog = this;


### PR DESCRIPTION
### PR受影响的平台
内蒙古光之国
### 诱因和背景
对于随时开启的dialog，有时候仅作为查看作用，但是会让其他dialog被隐藏
[issue2874](https://github.com/libnoname/noname/issues/2874)解决
### PR描述
增加dialog的peaceDialog属性，如果拥有这个属性，则不会对已有dialog显示造成影响（天使呐）
修复许劭【评鉴】筛选技能不清除技能翻译的html标签以及可以随机到自己已有技能的bug
### PR测试
测了，能跑
### 扩展适配
修改了dialog.open和ui.create.dialog的扩展
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码