### PR TITLE
清除最近武将记录逻辑补充，增添清除收藏/禁将

### DIFF
--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -1232,17 +1232,69 @@ export class Library {
 					unfrequent: true,
 					intro: "双击武将头像后显示其资料卡",
 				},
-				recent_character_clear: {
-					name: "清除最近选将",
-					intro: "点击此按钮清除最近选将记录",
+				clear_FavoriteCharacter: {
+					name: '清除已收藏武将',
 					clear: true,
 					unfrequent: true,
-					onclick: function () {
-						if (confirm("确定要清除最近选将记录吗？")) {
-							game.saveConfig("recentCharacter", [], true);
-							alert("最近选将记录已清除！");
+					onclick() {
+						if (this.innerHTML == '<span>确认清除</span>') {
+							game.saveConfig('favouriteCharacter', [], true);
+							alert('已清除所有收藏武将');
 						}
-					}
+						else {
+							this.innerHTML = '<span>确认清除</span>';
+							var that = this;
+							setTimeout(function () {
+								that.innerHTML = '<span>清除已收藏武将</span>';
+							}, 1000);
+						}
+					},
+				},
+				clear_BanCharacter: {
+					name: '清除已禁用武将',
+					clear: true,
+					unfrequent: true,
+					onclick() {
+						if (this.innerHTML == '<span>确认清除</span>') {
+							if (confirm("点击确定清除全模式禁用武将，否则清除当前模式禁用武将")) {
+								lib.config.all.mode.forEach(mode => game.saveConfig(`${mode}_banned`, [], mode));
+								alert("全模式禁用武将已清除！");
+								return;
+							}
+							game.saveConfig(`${get.mode()}_banned`, [], true);
+							alert(`${lib.mode[get.mode()]?.name ?? "本"}模式禁用武将已清除！`);
+						}
+						else {
+							this.innerHTML = '<span>确认清除</span>';
+							var that = this;
+							setTimeout(function () {
+								that.innerHTML = '<span>清除已禁用武将</span>';
+							}, 1000);
+						}
+					},
+				},
+				clear_RecentCharacter: {
+					name: '清除最近使用武将',
+					clear: true,
+					unfrequent: true,
+					onclick() {
+						if (this.innerHTML == '<span>确认清除</span>') {
+							if (confirm("点击确定清除全模式最近选将记录，否则清除当前模式最近选将记录")) {
+								lib.config.all.mode.forEach(mode => game.saveConfig("recentCharacter", [], mode));
+								alert("全模式最近选将记录已清除！");
+								return;
+							}
+							game.saveConfig("recentCharacter", [], true);
+							alert(`${lib.mode[get.mode()]?.name ?? "本"}模式最近选将记录已清除！`);
+						}
+						else {
+							this.innerHTML = '<span>确认清除</span>';
+							var that = this;
+							setTimeout(function () {
+								that.innerHTML = '<span>清除最近使用武将</span>';
+							}, 1000);
+						}
+					},
 				},
 				choose_all_button: {
 					name: "启用全选/反选按钮",


### PR DESCRIPTION
### PR受影响的平台
内蒙古X高级初中
### 诱因和背景
因[https://github.com/libnoname/noname/pull/2868](PR2868)的过早合并导致部分设想功能未完善，所以对功能进行了补充
### PR描述
清除最近武将记录功能增添全模式清除的选择
增加清除收藏/禁将武将功能，清除禁将也同时兼顾清除本模式和全模式的选择功能
### PR测试
测了，能跑
### 扩展适配
无，拥有这个功能的扩展可以删了（说的就是@xizifu 的活动武将）
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码