### PR TITLE
部分时机增添即时性

### DIFF
--- a/mode/guozhan/src/info/index.js
+++ b/mode/guozhan/src/info/index.js
@@ -5,7 +5,9 @@ export const junList = ["liubei", "zhangjiao", "sunquan", "caocao", "jin_simayi"
 
 export const substitute = {
 	gz_shichangshi: [
+		//似了
 		["gz_shichangshi_dead", ["character:shichangshi_dead", "die:shichangshi"]],
+		//没似
 		["gz_scs_zhangrang", ["character:scs_zhangrang", "die:shichangshi"]],
 		["gz_scs_zhaozhong", ["character:scs_zhaozhong", "die:shichangshi"]],
 		["gz_scs_sunzhang", ["character:scs_sunzhang", "die:shichangshi"]],
@@ -16,5 +18,16 @@ export const substitute = {
 		["gz_scs_duangui", ["character:scs_duangui", "die:shichangshi"]],
 		["gz_scs_guosheng", ["character:scs_guosheng", "die:shichangshi"]],
 		["gz_scs_gaowang", ["character:scs_gaowang", "die:shichangshi"]],
+		//似了
+		["gz_scs_zhangrang_dead", ["character:scs_zhangrang_dead", "die:shichangshi"]],
+		["gz_scs_zhaozhong_dead", ["character:scs_zhaozhong_dead", "die:shichangshi"]],
+		["gz_scs_sunzhang_dead", ["character:scs_sunzhang_dead", "die:shichangshi"]],
+		["gz_scs_bilan_dead", ["character:scs_bilan_dead", "die:shichangshi"]],
+		["gz_scs_xiayun_dead", ["character:scs_xiayun_dead", "die:shichangshi"]],
+		["gz_scs_hankui_dead", ["character:scs_hankui_dead", "die:shichangshi"]],
+		["gz_scs_lisong_dead", ["character:scs_lisong_dead", "die:shichangshi"]],
+		["gz_scs_duangui_dead", ["character:scs_duangui_dead", "die:shichangshi"]],
+		["gz_scs_guosheng_dead", ["character:scs_guosheng_dead", "die:shichangshi"]],
+		["gz_scs_gaowang_dead", ["character:scs_gaowang_dead", "die:shichangshi"]],
 	],
 };

--- a/mode/guozhan/src/skill/character/rest.js
+++ b/mode/guozhan/src/skill/character/rest.js
@@ -496,15 +496,12 @@ export default {
 		group: ["gz_mowang_die", "gz_mowang_return"],
 		async content(event, trigger, player) {
 			if (event.triggername == "rest") {
-				game.broadcastAll(player => {
-					if (player.name1 == "gz_shichangshi") {
-						player.node.name.innerHTML = get.slimName(player.name1);
-					}
-					if (player.name2 == "gz_shichangshi") {
-						player.node.name2.innerHTML = get.slimName(player.name2);
-					}
-				}, player);
-				player.changeSkin("gz_mowang", "gz_shichangshi_dead");
+				if (player.name1 == "gz_shichangshi") {
+					player.changeSkin("gz_mowang", `${player.skin.name}_dead`);
+				}
+				if (player.name2 == "gz_shichangshi") {
+					player.changeSkin("gz_mowang", `${player.skin.name}_dead2`);
+				}
 				return;
 			}
 			if (_status._rest_return?.[player.playerid]) {
@@ -543,16 +540,16 @@ export default {
 				forced: true,
 				forceDie: true,
 				async content(event, trigger, player) {
-					player.changeSkin("gz_mowang", "gz_shichangshi_dead");
-					game.broadcastAll(player => {
-						if (player.name1 == "gz_shichangshi") {
-							player.node.name.innerHTML = get.slimName(player.name1);
-						}
-						if (player.name2 == "gz_shichangshi") {
-							player.node.name2.innerHTML = get.slimName(player.name2);
-						}
-					}, player);
 					if (!player.getStorage("gz_danggu").length) {
+						player.changeSkin("gz_mowang", "gz_shichangshi_dead");
+						game.broadcastAll(player => {
+							if (player.name1 == "gz_shichangshi") {
+								player.node.name.innerHTML = get.slimName(player.name1);
+							}
+							if (player.name2 == "gz_shichangshi") {
+								player.node.name2.innerHTML = get.slimName(player.name2);
+							}
+						}, player);
 						await game.delay();
 					}
 					await player.die();

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -8910,7 +8910,7 @@ export class Player extends HTMLDivElement {
 			player.getHistory("useSkill").push(logInfo);
 			//尽可能别往这写插入结算
 			//不能用来终止技能发动！！！
-			var next2 = game.createEvent("logSkillBegin", false);
+			var next2 = game.createEvent("logSkillBegin", false, get.event());
 			next2.player = player;
 			next2.forceDie = true;
 			next2.includeOut = true;

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1891,6 +1891,12 @@ export class Player extends HTMLDivElement {
 			this,
 			skill
 		);
+		const next = game.createEvent("changeZhuanhuanji", false, get.event());
+		next.player = this;
+		next.skill = skill;
+		next.forceDie = true;
+		next.includeOut = true;
+		next.setContent("emptyEvent");
 	}
 	/**
 	 * @param { string } skill
@@ -4229,7 +4235,7 @@ export class Player extends HTMLDivElement {
 		}
 		this.syncStorage(i);
 		this[this.storage[i] || (lib.skill[i] && lib.skill[i].mark) ? "markSkill" : "unmarkSkill"](i);
-		const next = game.createEvent("removeMark", false);
+		const next = game.createEvent("removeMark", false, get.event());
 		next.player = this;
 		next.num = num;
 		next.markName = i;
@@ -4266,7 +4272,7 @@ export class Player extends HTMLDivElement {
 		}
 		this.syncStorage(i);
 		this.markSkill(i);
-		const next = game.createEvent("addMark", false);
+		const next = game.createEvent("addMark", false, get.event());
 		next.player = this;
 		next.num = num;
 		next.markName = i;


### PR DESCRIPTION
### PR受影响的平台
内蒙古光之国
### 诱因和背景
今晚给集美讲述向下兼容时关注到的部分携带时机函数，对这些函数做出修改
### PR描述
为lib.element.player.addMark/removeMark/logSkill创造的时机加上即时性
添加lib.element.player.changeZhuanhuanji添加即时时机
修改国战十常侍休整图片显示
### PR测试
测了，能跑
### 扩展适配
无
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
