### PR TITLE
修复chooseToMove对于跨块点击无法交换的问题，为所有只能交换的chooseToMove添加noChooseAll

### DIFF
--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -2113,7 +2113,7 @@ const skills = {
 				const topCards = get.cards(num);
 				await game.cardsGotoOrdering(topCards);
 				const result = await player
-					.chooseToMove("诫厉：交换其中任意张牌")
+					.chooseToMove("诫厉：交换其中任意张牌", "noChooseAll")
 					.set("list", [
 						[get.translation(target) + "牌名字数最多的手牌", cards, "dcsushou_tag"],
 						["牌堆顶", topCards],

--- a/character/extra/skill.js
+++ b/character/extra/skill.js
@@ -2744,7 +2744,7 @@ const skills = {
 				},
 				async cost(event, trigger, player) {
 					const hidden = player.getExpansions("jilin").filter(card => !card.storage.jilin);
-					const next = player.chooseToMove("戢鳞：是否交换“志”和手牌？");
+					const next = player.chooseToMove("戢鳞：是否交换“志”和手牌？", "noChooseAll");
 					next.set("list", [
 						[get.translation(player) + "（你）的未明之“志”", hidden],
 						["手牌区", player.getCards("h")],
@@ -11135,7 +11135,7 @@ const skills = {
 				event.finish();
 				return;
 			}
-			var next = player.chooseToMove("七星：是否交换“星”和手牌？");
+			var next = player.chooseToMove("七星：是否交换“星”和手牌？", "noChooseAll");
 			next.set("list", [
 				[get.translation(player) + "（你）的星", cards],
 				["手牌区", player.getCards("h")],
@@ -11205,7 +11205,7 @@ const skills = {
 				event.finish();
 				return;
 			}
-			var next = player.chooseToMove("七星：是否交换“星”和手牌？");
+			var next = player.chooseToMove("七星：是否交换“星”和手牌？", "noChooseAll");
 			next.set("list", [
 				[get.translation(player) + "（你）的星", cards],
 				["手牌区", player.getCards("h")],

--- a/character/huicui/skill.js
+++ b/character/huicui/skill.js
@@ -13700,7 +13700,7 @@ const skills = {
 						event.finish();
 						return;
 					}
-					var next = player.chooseToMove("寻疠：是否交换“疠”和手牌？");
+					var next = player.chooseToMove("寻疠：是否交换“疠”和手牌？", "noChooseAll");
 					next.set("list", [
 						[get.translation(player) + "（你）的疠", cards],
 						["手牌区", player.getCards("h", card => get.color(card, player) == "black")],

--- a/character/onlyOL/skill.js
+++ b/character/onlyOL/skill.js
@@ -4823,7 +4823,7 @@ const skills = {
 					bool: true,
 				};
 			} else {
-				const next = player.chooseToMove("积谷：是否交换“谷”和手牌？");
+				const next = player.chooseToMove("积谷：是否交换“谷”和手牌？", "noChooseAll");
 				next.set("list", [
 					[get.translation(player) + "（你）的“谷”", player.getExpansions("olsbjigu")],
 					["手牌区", player.getCards("h")],

--- a/character/refresh/skill.js
+++ b/character/refresh/skill.js
@@ -1928,7 +1928,7 @@ const skills = {
 			return player.getExpansions("rebizhuan").length > 0 && player.countCards("he") > 0;
 		},
 		async content(event, trigger, player) {
-			const next = player.chooseToMove("通博：是否交换“书”和手牌？");
+			const next = player.chooseToMove("通博：是否交换“书”和手牌？", "noChooseAll");
 			next.set("list", [
 				[get.translation(player) + "（你）的“书”", player.getExpansions("rebizhuan")],
 				["你的牌", player.getCards("he")],

--- a/character/shenhua/skill.js
+++ b/character/shenhua/skill.js
@@ -688,7 +688,7 @@ const skills = {
 			player.awakenSkill(event.name);
 			const cards = player.getExpansions("zhengrong");
 			if (cards.length && player.countCards("h")) {
-				const next = player.chooseToMove("征荣：是否交换“荣”和手牌？");
+				const next = player.chooseToMove("征荣：是否交换“荣”和手牌？", "noChooseAll");
 				next.set("list", [
 					[get.translation(player) + "（你）的“荣”", cards],
 					["手牌区", player.getCards("h")],
@@ -845,7 +845,7 @@ const skills = {
 			player.awakenSkill(event.name);
 			const cards = player.getExpansions("drlt_zhenrong");
 			if (cards.length && player.countCards("h")) {
-				const next = player.chooseToMove("征荣：是否交换“荣”和手牌？");
+				const next = player.chooseToMove("征荣：是否交换“荣”和手牌？", "noChooseAll");
 				next.set("list", [
 					[get.translation(player) + "（你）的“荣”", cards],
 					["手牌区", player.getCards("h")],

--- a/character/sp/skill.js
+++ b/character/sp/skill.js
@@ -16999,7 +16999,7 @@ const skills = {
 					event.cards2 = cards;
 					game.cardsGotoOrdering(cards);
 					var player = trigger.player;
-					var next = player.chooseToMove("铸币：用任意“币”交换牌堆底等量张牌");
+					var next = player.chooseToMove("铸币：用任意“币”交换牌堆底等量张牌", "noChooseAll");
 					var hs = player.getCards("h", card => card.hasGaintag("olzhubi_tag"));
 					next.set("filterMove", function (from, to) {
 						return typeof to != "number";

--- a/character/tw/skill.js
+++ b/character/tw/skill.js
@@ -15185,7 +15185,7 @@ const skills = {
 			if (player.countCards("h") == 0) {
 				event.goto(3);
 			} else {
-				var next = player.chooseToMove("鸿举：请选择要交换的手牌和“荣”");
+				var next = player.chooseToMove("鸿举：请选择要交换的手牌和“荣”", "noChooseAll");
 				next.set("list", [
 					[get.translation(player) + "（你）的“荣”", player.getExpansions("twzhengrong"), "twzhengrong_tag"],
 					["手牌区", player.getCards("h")],

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -8605,7 +8605,7 @@ const skills = {
 				await target.chooseUseTarget(useCard, true);
 			} else {
 				const result = await target
-					.chooseToMove("告谏：是否交换其中任意张牌？")
+					.chooseToMove("告谏：是否交换其中任意张牌？", "noChooseAll")
 					.set("list", [
 						["你的手牌", target.getCards("h"), "dcgaojian_tag"],
 						["展示牌", showCards],
@@ -26679,7 +26679,7 @@ const skills = {
 			var cards = get.bottomCards(3);
 			event.cards2 = cards;
 			game.cardsGotoOrdering(cards);
-			var next = player.chooseToMove("兴作：将三张牌置于牌堆底");
+			var next = player.chooseToMove("兴作：将三张牌置于牌堆底", "noChooseAll");
 			var list = [["牌堆底", cards]],
 				hs = player.getCards("h");
 			if (hs.length) {

--- a/character/yijiang/skill.js
+++ b/character/yijiang/skill.js
@@ -3280,7 +3280,7 @@ const skills = {
 					}
 				}
 			}
-			var next = player.chooseToMove("通博：是否交换“书”和手牌？").set("four", four).set("nofour", nofour);
+			var next = player.chooseToMove("通博：是否交换“书”和手牌？", "noChooseAll").set("four", four).set("nofour", nofour);
 			next.set("list", [
 				[get.translation(player) + "（你）的“书”", expansions],
 				["你的牌", player.getCards("he")],

--- a/mode/guozhan/src/skill/character/yingbian.js
+++ b/mode/guozhan/src/skill/character/yingbian.js
@@ -3067,7 +3067,7 @@ export default {
 			const {
 				result: { bool, moved },
 			} = await player
-				.chooseToMove(get.prompt2("fakequanbian"))
+				.chooseToMove(get.prompt2("fakequanbian"), "noChooseAll")
 				.set("list", [
 					["牌堆顶", cards.slice(0, Math.min(player.maxHp, cards.length)), "fakequanbian_tag"],
 					["手牌", player.getCards("h")],

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -2317,11 +2317,27 @@ player.removeVirtualEquip(card);
 					const clientY = e.clientY / game.documentZoom;
 					let aniamtionPromise = null;
 
-					// 如果是拖动移动或者非多选的情况下，我们走原来的代码喵
-					if (isDragging || (!canMultiselect && ui.selected.buttons.length === 1)) {
+					let spannedSingle = false;
+
+					if (ui.selected.buttons.length === 1) {
+						const curCard = ui.selected.buttons[0];
+						const target = e.target;
+						if (!curCard.contains(target)) {
+							const buttons = buttonss.find(b => {
+								return b.contains(target);
+							});
+							if (buttons && !buttons.contains(curCard)) {
+								// 此时用户点击了第一张牌，并在另一个区域点击了第二张牌喵
+								spannedSingle = true;
+							}
+						}
+					}
+
+					// 如果是拖动移动、非多选或者跨区单个交换的情况下，我们走原来的代码喵
+					if (isDragging || (!canMultiselect && ui.selected.buttons.length === 1) || spannedSingle) {
 						const curCard = ui.selected.buttons[0];
 						// 鼠标当前处于哪个元素上
-						const target = document.elementFromPoint(clientX * game.documentZoom, clientY * game.documentZoom);
+						const target = e.target;
 						// 相当于没移动，让它自己触发后续的click
 						if (curCard.contains(target)) {
 							return;

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -2323,6 +2323,8 @@ export class Player extends HTMLDivElement {
 		for (var i = 0; i < arguments.length; i++) {
 			if (typeof arguments[i] == "boolean") {
 				next.forced = arguments[i];
+			} else if (arguments[i] === "noChooseAll") {
+				next.noChooseAll = true;
 			} else if (typeof arguments[i] == "string") {
 				next.prompt = arguments[i];
 			}


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
无

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
因为白喵反馈了chooseToMove点击不同区域按钮不能交换的问题喵（比如神诸葛亮七星交换牌哦，只能拖动交换而不能点击交换喵）

### PR描述
<!-- 详细描述您的更改 -->
修复了一下chooseToMove点击不同区域按钮不能交换的问题喵
顺便把所有涉及到chooseToMove仅交换而不移动牌（即区域牌数量保持不变）的情况去掉了全选按钮喵

### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
进行了简单的测试喵，选择点击不同区域的按钮会正确执行交换而不是取消选择喵
七星等仅交换牌隐藏的全选按钮喵


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
