### PR TITLE
为无限火力添加自由选将功能

### DIFF
--- a/mode/single.js
+++ b/mode/single.js
@@ -949,6 +949,51 @@ export default () => {
 						zhu: _status.characterlist.randomRemove(6),
 						fan: _status.characterlist.randomRemove(6),
 					};
+					// 创建自由选将功能
+					const createCharacterDialog = function () {
+						if (get.config("free_choose")) {
+							event.dialogxx = ui.create.characterDialog("heightset");
+						} else {
+							event.dialogxx = ui.create.characterDialog("heightset");
+						}
+					};
+					if (lib.onfree) {
+						lib.onfree.push(createCharacterDialog);
+					} else {
+						createCharacterDialog();
+					}
+					ui.create.cheat2 = function () {
+						ui.cheat2 = ui.create.control("自由选将", function () {
+							if (this.dialog == _status.event.dialog) {
+								if (game.changeCoin) {
+									game.changeCoin(10);
+								}
+								this.dialog.close();
+								_status.event.dialog = this.backup;
+								this.backup.open();
+								delete this.backup;
+								game.uncheck();
+								game.check();
+							} else {
+								if (game.changeCoin) {
+									game.changeCoin(-10);
+								}
+								this.backup = _status.event.dialog;
+								_status.event.dialog.close();
+								_status.event.dialog = _status.event.parent.dialogxx;
+								this.dialog = _status.event.dialog;
+								this.dialog.open();
+								game.uncheck();
+								game.check();
+							}
+						});
+						if (lib.onfree) {
+							ui.cheat2.classList.add("disabled");
+						}
+					};
+					if (!ui.cheat2 && get.config("free_choose")) {
+						ui.create.cheat2();
+					}
 					const dialog = ["请选择出场武将", '<div class="text center">本局游戏Buff</div>'];
 					game.globalBuff.forEach((buff, ind) => {
 						dialog.add(`<div class="text">「${ind === 0 ? "固定" : "随机"}」 ${get.translation(buff)}：${get.skillInfoTranslation(buff)}</div>`);
@@ -956,6 +1001,10 @@ export default () => {
 					dialog.add([_status.characterChoice[game.me.identity], "character"]);
 					game.me.chooseButton(true, dialog);
 					"step 2";
+					if (ui.cheat2) {
+						ui.cheat2.close();
+						delete ui.cheat2;
+					}
 					game.me.init(result.links[0]);
 					_status.characterChoice[game.me.identity].removeArray(result.links);
 					var list = _status.characterChoice[game.me.enemy.identity].randomRemove(1);
@@ -1412,6 +1461,51 @@ export default () => {
 						zhu: _status.characterlist.randomRemove(6),
 						fan: _status.characterlist.randomRemove(6),
 					};
+					// 创建自由选将功能
+					const createCharacterDialog = function () {
+						if (get.config("free_choose")) {
+							event.dialogxx = ui.create.characterDialog("heightset");
+						} else {
+							event.dialogxx = ui.create.characterDialog("heightset");
+						}
+					};
+					if (lib.onfree) {
+						lib.onfree.push(createCharacterDialog);
+					} else {
+						createCharacterDialog();
+					}
+					ui.create.cheat2 = function () {
+						ui.cheat2 = ui.create.control("自由选将", function () {
+							if (this.dialog == _status.event.dialog) {
+								if (game.changeCoin) {
+									game.changeCoin(10);
+								}
+								this.dialog.close();
+								_status.event.dialog = this.backup;
+								this.backup.open();
+								delete this.backup;
+								game.uncheck();
+								game.check();
+							} else {
+								if (game.changeCoin) {
+									game.changeCoin(-10);
+								}
+								this.backup = _status.event.dialog;
+								_status.event.dialog.close();
+								_status.event.dialog = _status.event.parent.dialogxx;
+								this.dialog = _status.event.dialog;
+								this.dialog.open();
+								game.uncheck();
+								game.check();
+							}
+						});
+						if (lib.onfree) {
+							ui.cheat2.classList.add("disabled");
+						}
+					};
+					if (!ui.cheat2 && get.config("free_choose")) {
+						ui.create.cheat2();
+					}
 					const list = ["zhu", "fan"].map(identity => {
 						const dialog = ["请选择出场武将", '<div class="text center">本局游戏Buff</div>'];
 						game.globalBuff.forEach((buff, ind) => {
@@ -1430,6 +1524,10 @@ export default () => {
 						}
 					});
 					"step 2";
+					if (ui.cheat2) {
+						ui.cheat2.close();
+						delete ui.cheat2;
+					}
 					for (var i in result) {
 						var current = lib.playerOL[i];
 						if (result[i] == "ai") {

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -7951,6 +7951,22 @@ export class Library {
 					init: false,
 					restart: true,
 				},
+				free_choose: {
+					name: "自由选将",
+					init: true,
+					onclick(bool) {
+						game.saveConfig("free_choose", bool, this._link.config.mode);
+						if (get.mode() != this._link.config.mode || (!_status.event.getParent().showConfig && !_status.event.showConfig)) {
+							return;
+						}
+						if (!ui.cheat2 && get.config("free_choose")) {
+							ui.create.cheat2();
+						} else if (ui.cheat2 && !get.config("free_choose")) {
+							ui.cheat2.close();
+							delete ui.cheat2;
+						}
+					},
+				},
 				update: function (config, map) {
 					if (config.single_mode != "normal") {
 						map.enable_jin.hide();
@@ -7974,6 +7990,11 @@ export class Library {
 						} else {
 							map.double_hp.hide();
 						}
+					}
+					if (config.single_mode == "wuxianhuoli" || config.single_mode == "dianjiang") {
+						map.free_choose.show();
+					} else {
+						map.free_choose.hide();
 					}
 				},
 			},


### PR DESCRIPTION
### PR受影响的平台
无


### 诱因和背景
自己想玩



### PR描述
无限火力添加自由选将功能



### PR测试
本体无扩展下进行过测试



### 扩展适配
无



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
