### PR TITLE
隐藏顶部菜单栏，隐藏后支持Alt快捷键临时显示

### DIFF
--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -1217,6 +1217,34 @@ async function setOnError() {
 
 function setWindowListener() {
 	window.onkeydown = function (e) {
+		// F12 切换菜单栏显示
+		if (lib.config && lib.config.hideMenuBar && e.keyCode === 123) {
+			try {
+				if (window.require) {
+					let remote = require("@electron/remote");
+					if (remote) {
+						let win = remote.getCurrentWindow();
+						let visible = typeof win.isMenuBarVisible === "function" ? win.isMenuBarVisible() : void 0;
+						if (typeof visible === "boolean") {
+							win.setMenuBarVisibility(!visible);
+						} else {
+							// @ts-expect-error
+							window.__menuTempShown = !window.__menuTempShown;
+							// @ts-expect-error
+							win.setMenuBarVisibility(!!window.__menuTempShown);
+						}
+					}
+				}
+				else if (window.node && window.node.menuBar) {
+						// @ts-expect-error
+						window.__menuTempShown = !window.__menuTempShown;
+						// @ts-expect-error
+						if (window.__menuTempShown) window.node.menuBar.show();
+						else window.node.menuBar.hide();
+				}
+			}
+			catch (err) {}
+		}
 		if (typeof ui.menuContainer == "undefined" || !ui.menuContainer.classList.contains("hidden")) {
 			if (e.keyCode == 116 || ((e.ctrlKey || e.metaKey) && e.keyCode == 82)) {
 				if (e.shiftKey) {

--- a/noname/init/index.js
+++ b/noname/init/index.js
@@ -1228,19 +1228,19 @@ function setWindowListener() {
 						if (typeof visible === "boolean") {
 							win.setMenuBarVisibility(!visible);
 						} else {
-							// @ts-expect-error
+							// @ts-expect-error - 增强对旧版Electron的兼容性
 							window.__menuTempShown = !window.__menuTempShown;
-							// @ts-expect-error
+							// @ts-expect-error - 用临时标记切换菜单栏可见性
 							win.setMenuBarVisibility(!!window.__menuTempShown);
 						}
 					}
 				}
 				else if (window.node && window.node.menuBar) {
-						// @ts-expect-error
+						// @ts-expect-error - 在电脑上记录临时状态
 						window.__menuTempShown = !window.__menuTempShown;
-						// @ts-expect-error
-						if (window.__menuTempShown) window.node.menuBar.show();
-						else window.node.menuBar.hide();
+						// @ts-expect-error - 调用原生menuBar显示和隐藏
+						if (window.__menuTempShown) { window.node.menuBar.show(); }
+						else { window.node.menuBar.hide(); }
 				}
 			}
 			catch (err) {}

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -39,7 +39,7 @@ export async function onload() {
 				if (remote) {
 					let win = remote.getCurrentWindow();
 					win.setMenuBarVisibility(false);
-					win.setAutoHideMenuBar(true);
+					win.setAutoHideMenuBar(false);
 				}
 			} catch (e) {}
 		}

--- a/noname/init/onload.js
+++ b/noname/init/onload.js
@@ -28,6 +28,23 @@ export async function onload() {
 		createTouchDraggedFilter();
 	}
 
+	if (lib.config.hideMenuBar) {
+		if (window.node && window.node.menuBar) {
+			try {
+				window.node.menuBar.hide();
+			} catch (e) {}
+		} else if (window.require) {
+			try {
+				let remote = require("@electron/remote");
+				if (remote) {
+					let win = remote.getCurrentWindow();
+					win.setMenuBarVisibility(false);
+					win.setAutoHideMenuBar(true);
+				}
+			} catch (e) {}
+		}
+	}
+
 	// 重构了吗？如构
 	let loadingCustomStyle = [
 		tryLoadCustomStyle("card_style", data => {

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -1487,7 +1487,7 @@ export class Library {
 					name: "隐藏顶部菜单栏",
 					init: false,
 					unfrequent: true,
-					intro: "开启后将隐藏顶部菜单栏，隐藏后支持Alt快捷键临时显示",
+					intro: "开启后将隐藏顶部菜单栏，隐藏后支持F12快捷键显示。",
 					onclick(value) {
 						game.saveConfig("hideMenuBar", value);
 						if (value) {
@@ -1501,7 +1501,7 @@ export class Library {
 									if (remote) {
 										let win = remote.getCurrentWindow();
 										win.setMenuBarVisibility(false);
-										win.setAutoHideMenuBar(true);
+										win.setAutoHideMenuBar(false);
 									}
 								} catch (e) {}
 							}

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -1483,6 +1483,46 @@ export class Library {
 					init: false,
 					unfrequent: true,
 				},
+				hideMenuBar: {
+					name: "隐藏顶部菜单栏",
+					init: false,
+					unfrequent: true,
+					intro: "开启后将隐藏顶部菜单栏，隐藏后支持Alt快捷键临时显示",
+					onclick(value) {
+						game.saveConfig("hideMenuBar", value);
+						if (value) {
+							if (window.node && window.node.menuBar) {
+								try {
+									window.node.menuBar.hide();
+								} catch (e) {}
+							} else if (window.require) {
+								try {
+									let remote = require("@electron/remote");
+									if (remote) {
+										let win = remote.getCurrentWindow();
+										win.setMenuBarVisibility(false);
+										win.setAutoHideMenuBar(true);
+									}
+								} catch (e) {}
+							}
+						} else {
+							if (window.node && window.node.menuBar) {
+								try {
+									window.node.menuBar.show();
+								} catch (e) {}
+							} else if (window.require) {
+								try {
+									let remote = require("@electron/remote");
+									if (remote) {
+										let win = remote.getCurrentWindow();
+										win.setMenuBarVisibility(true);
+										win.setAutoHideMenuBar(false);
+									}
+								} catch (e) {}
+							}
+						}
+					},
+				},
 				update_link: {
 					name: "更新地址",
 					init: "coding",
@@ -1677,6 +1717,11 @@ export class Library {
 						map.confirm_exit.show();
 					} else {
 						map.confirm_exit.hide();
+					}
+					if (lib.node || (window.require && !lib.device)) {
+						map.hideMenuBar.show();
+					} else {
+						map.hideMenuBar.hide();
 					}
 				},
 			},


### PR DESCRIPTION
### PR受影响的平台
无


### 诱因和背景
全屏结束一局游戏后重新开始就会弹出菜单栏，需要重新全屏隐藏，强迫症很难受



### PR描述
在选项设置底部新加隐藏诗笺版顶部菜单栏开关，隐藏后支持F12快捷键显示



### PR测试
本体无扩展下进行过测试



### 扩展适配
无



### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码