### PR TITLE
函数修改

### DIFF
--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -27,9 +27,17 @@ const skills = {
 					if (get.info(event.card)?.multitarget) {
 						return false;
 					}
-					const targets = player.getHistory("useCard", evt => {
-						return evt?.targets?.length && evt != event;
-					}, event).map(evt => evt.targets ?? []).flat().toUniqued();
+					const targets = player
+						.getHistory(
+							"useCard",
+							evt => {
+								return evt?.targets?.length && evt != event;
+							},
+							event
+						)
+						.map(evt => evt.targets ?? [])
+						.flat()
+						.toUniqued();
 					return targets.some(target => {
 						if (event.targets?.includes(target)) {
 							return true;
@@ -39,23 +47,34 @@ const skills = {
 				},
 				charlotte: true,
 				async cost(event, trigger, player) {
-					const targets = player.getHistory("useCard", evt => {
-						return evt?.targets?.length && evt != trigger;
-					}, trigger).map(evt => evt.targets ?? []).flat().toUniqued();
+					const targets = player
+						.getHistory(
+							"useCard",
+							evt => {
+								return evt?.targets?.length && evt != trigger;
+							},
+							trigger
+						)
+						.map(evt => evt.targets ?? [])
+						.flat()
+						.toUniqued();
 					event.result = await player
-						.chooseTarget((card, player, target) => {
-							const { targetx, targety, cardx } = get.event();
-							if (!targetx.includes(target)) {
-								return false;
-							}
-							if (ui.selected.targets?.length) {
-								const first = ui.selected.targets[0];
-								if (targety.includes(first) !== targety.includes(target)) {
+						.chooseTarget(
+							(card, player, target) => {
+								const { targetx, targety, cardx } = get.event();
+								if (!targetx.includes(target)) {
 									return false;
 								}
-							}
-							return targety.includes(target) || lib.filter.targetEnabled2(cardx, player, target);
-						}, [1, Infinity])
+								if (ui.selected.targets?.length) {
+									const first = ui.selected.targets[0];
+									if (targety.includes(first) !== targety.includes(target)) {
+										return false;
+									}
+								}
+								return targety.includes(target) || lib.filter.targetEnabled2(cardx, player, target);
+							},
+							[1, Infinity]
+						)
 						.set("targetx", targets)
 						.set("targety", trigger.targets)
 						.set("cardx", trigger.card)
@@ -117,9 +136,12 @@ const skills = {
 						return player.canCompare(target);
 					},
 					ai1(button) {
-						const card = player.getCards("h").maxBy(card => {
-							return get.number(card);
-						}, card => card.name == button.link[2]);
+						const card = player.getCards("h").maxBy(
+							card => {
+								return get.number(card);
+							},
+							card => card.name == button.link[2]
+						);
 						if (card) {
 							return get.number(card);
 						}
@@ -139,7 +161,10 @@ const skills = {
 			}
 		},
 		async content(event, trigger, player) {
-			const { targets: [target], cost_data: name } = event;
+			const {
+				targets: [target],
+				cost_data: name,
+			} = event;
 			game.log(player, "声明的牌名为", `#y${get.translation(name)}`);
 			player.chat(get.translation(name));
 			const result = await player.chooseToCompare(target).forResult();
@@ -167,20 +192,23 @@ const skills = {
 					}
 					return true;
 				});
-				const result2 = skills.length > 1 ? await player
-					.chooseButton(["迎乡：失去一个技能", [skills, "skill"]], true)
-					.set("ai", button => {
-						const { link } = button;
-						const info = get.info(link);
-						if (info?.ai?.neg || info?.ai?.halfneg) {
-							return 3;
-						}
-						return ["clanyingxiang", "clanxumin"].indexOf(link) + 1;
-					})
-					.forResult() : {
-						bool: true,
-						links: skills,
-					};
+				const result2 =
+					skills.length > 1
+						? await player
+								.chooseButton(["迎乡：失去一个技能", [skills, "skill"]], true)
+								.set("ai", button => {
+									const { link } = button;
+									const info = get.info(link);
+									if (info?.ai?.neg || info?.ai?.halfneg) {
+										return 3;
+									}
+									return ["clanyingxiang", "clanxumin"].indexOf(link) + 1;
+								})
+								.forResult()
+						: {
+								bool: true,
+								links: skills,
+						  };
 				if (result2?.bool && result2?.links?.length) {
 					await player.removeSkills(result2.links);
 				}
@@ -1588,7 +1616,10 @@ const skills = {
 						break;
 					}
 					if (result.bool) {
-						const { links: toGive, targets: [target] } = result;
+						const {
+							links: toGive,
+							targets: [target],
+						} = result;
 						cards.removeArray(toGive);
 						const given = (given_map.get(target) ?? []).concat(toGive);
 						given_map.set(target, given);
@@ -4606,11 +4637,18 @@ const skills = {
 			for (var skill of skills) {
 				var info = get.info(skill);
 				if (info.usable !== undefined) {
-					if (player.hasSkill("counttrigger") && player.storage.counttrigger[skill] && player.storage.counttrigger[skill] >= 1) {
+					if (typeof player.getStat("triggerSkill")[skill] == "number" && player.getStat("triggerSkill")[skill] >= 1) {
+						delete player.getStat("triggerSkill")[skill];
+						resetSkills.add(skill);
+					}
+					/*
+					这段逻辑和上面的新逻辑任选一个使用即可
+					if (player.hasSkill("counttrigger") && (player.storage.counttrigger?.[skill] ?? 0) >= 1) {
 						delete player.storage.counttrigger[skill];
 						resetSkills.add(skill);
 					}
-					if (typeof get.skillCount(skill) == "number" && get.skillCount(skill) >= 1) {
+					*/
+					if (typeof player.getStat("skill")[skill] == "number" && player.getStat("skill")[skill] >= 1) {
 						delete player.getStat("skill")[skill];
 						resetSkills.add(skill);
 					}

--- a/character/clan/skill.js
+++ b/character/clan/skill.js
@@ -4659,6 +4659,7 @@ const skills = {
 				}
 				if (player.storage[`temp_ban_${skill}`]) {
 					delete player.storage[`temp_ban_${skill}`];
+					resetSkills.add(skill);
 				}
 				if (player.awakenedSkills.includes(skill)) {
 					player.restoreSkill(skill);

--- a/character/xianding/skill.js
+++ b/character/xianding/skill.js
@@ -8340,12 +8340,15 @@ const skills = {
 					player: "useCard1",
 				},
 				filter(event, player) {
-					return event.addCount !== false &&  player.hasHistory("lose", evt => {
-						if (evt.getParent() != event) {
-							return false;
-						}
-						return Object.values(evt.gaintag_map).flat().includes("dclianjie");
-					});
+					return (
+						event.addCount !== false &&
+						player.hasHistory("lose", evt => {
+							if (evt.getParent() != event) {
+								return false;
+							}
+							return Object.values(evt.gaintag_map).flat().includes("dclianjie");
+						})
+					);
 				},
 				async cost(event, trigger, player) {
 					trigger.addCount = false;
@@ -9900,10 +9903,10 @@ const skills = {
 				for (const skill of gainSkills) {
 					const info = get.info(skill);
 					if (info.usable !== undefined) {
-						if (target.hasSkill("counttrigger") && target.storage.counttrigger[skill] && target.storage.counttrigger[skill] >= 1) {
-							delete target.storage.counttrigger[skill];
+						if (typeof target.getStat("triggerSkill")[skill] == "number" && target.getStat("triggerSkill")[skill] >= 1) {
+							delete target.getStat("triggerSkill")[skill];
 						}
-						if (typeof get.skillCount(skill) == "number" && get.skillCount(skill) >= 1) {
+						if (typeof target.getStat("skill")[skill] == "number" && target.getStat("skill")[skill] >= 1) {
 							delete target.getStat("skill")[skill];
 						}
 					}

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -366,7 +366,7 @@ export const Content = {
 			_status.characterlist.addArray(rawPairs);
 		}
 		//变更一下获得前后的技能
-		const next =  player.changeSkills(addSkills, removeSkills);
+		const next = player.changeSkills(addSkills, removeSkills);
 		if (event.log === false) {
 			next.$handle = (current, add, remove, evt) => {
 				if (add.length) {
@@ -2013,9 +2013,9 @@ player.removeVirtualEquip(card);
 
 				/**
 				 * 计算可以批量移动的按钮
-				 * 
-				 * @param {Button[]} buttonList 
-				 * @param {HTMLDivElement} buttonsDiv 
+				 *
+				 * @param {Button[]} buttonList
+				 * @param {HTMLDivElement} buttonsDiv
 				 * @param {"first"|"last"} position
 				 */
 				var filterBatchMove = function (buttonList, buttonsDiv, position) {
@@ -2626,13 +2626,16 @@ player.removeVirtualEquip(card);
 				if (event.prompt2) {
 					next.set("prompt2", event.prompt2);
 				}
-				next.set("choice", (() => {
-					let eff = 0;
-					for (var i = 0; i < event.targets2.length; i++) {
-						eff += get.effect(event.targets2[i], card, player, player);
-					}
-					return eff > 0;
-				})());
+				next.set(
+					"choice",
+					(() => {
+						let eff = 0;
+						for (var i = 0; i < event.targets2.length; i++) {
+							eff += get.effect(event.targets2[i], card, player, player);
+						}
+						return eff > 0;
+					})()
+				);
 				if (typeof event.ai == "function") {
 					next.set("ai", event.ai);
 				}
@@ -4289,15 +4292,8 @@ player.removeVirtualEquip(card);
 		}
 		var next = game.createEvent(event.skill);
 		if (info.usable !== undefined) {
-			player.addSkill("counttrigger");
-			if (!player.storage.counttrigger) {
-				player.storage.counttrigger = {};
-			}
-			if (!player.storage.counttrigger[event.skill]) {
-				player.storage.counttrigger[event.skill] = 1;
-			} else {
-				player.storage.counttrigger[event.skill]++;
-			}
+			player.getStat("triggerSkill")[event.skill] ??= 0;
+			player.getStat("triggerSkill")[event.skill]++;
 		}
 		next.player = player;
 		next._trigger = trigger;
@@ -4741,7 +4737,7 @@ player.removeVirtualEquip(card);
 				custom: [],
 				useSkill: [],
 			});
-			current.stat.push({ card: {}, skill: {} });
+			current.stat.push({ card: {}, skill: {}, triggerSkill: {} });
 			if (isRound) {
 				current.getHistory().isRound = true;
 				current.getStat().isRound = true;
@@ -4994,10 +4990,7 @@ player.removeVirtualEquip(card);
 		},
 		async (event, trigger, player) => {
 			if (!event.cancelled && !event.nojudge) {
-				event.result = await player
-					.judge(event.card)
-					.set("type", "phase")
-					.forResult();
+				event.result = await player.judge(event.card).set("type", "phase").forResult();
 			}
 		},
 		async (event, trigger, player) => {
@@ -5879,10 +5872,10 @@ player.removeVirtualEquip(card);
 			})(event);
 			const skills = player.getSkills("invisible").concat(lib.skill.global);
 			game.expandSkills(skills);
-			const hasSkill = skills.some(skill=> {
+			const hasSkill = skills.some(skill => {
 				const info = lib.skill[skill];
 				return info?.enable?.includes(event.name) || info?.enable == event.name;
-			})
+			});
 			if (_status.noclearcountdown !== "direct") {
 				_status.noclearcountdown = true;
 			}
@@ -6455,7 +6448,7 @@ player.removeVirtualEquip(card);
 		},
 		async (event, trigger) => {
 			const targets = event.targets;
-			const player = event.player = event.tempplayer;
+			const player = (event.player = event.tempplayer);
 			delete event.tempplayer;
 			event.str = "无人拼点成功";
 			const winner = event.forceWinner || event.winner;
@@ -6495,7 +6488,7 @@ player.removeVirtualEquip(card);
 	chooseToCompareMultiple: [
 		async (event, trigger, player) => {
 			const targets = event.targets;
-			if ((!event.fixedResult?.[player.playerid]) && player.countCards("h") == 0) {
+			if (!event.fixedResult?.[player.playerid] && player.countCards("h") == 0) {
 				event.result = { cancelled: true, bool: false };
 				event.finish();
 				return;

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1919,12 +1919,29 @@ export class Player extends HTMLDivElement {
 			this,
 			skill
 		);
-		const next = game.createEvent("changeZhuanhuanji", false, get.event());
-		next.player = this;
-		next.skill = skill;
+		let player = this;
+		let evt = _status.event;
+		//转换技转换后
+		let next = game.createEvent("changeZhuanhuanji", false);
+		next.player = player;
 		next.forceDie = true;
 		next.includeOut = true;
+		next.skill = skill;
+		evt.next.remove(next);
+		if (evt.logSkill || evt.name?.startsWith("pre_")) {
+			evt = evt.getParent();
+		}
+		next.log_event = evt;
+		evt.after.push(next);
 		next.setContent("emptyEvent");
+		//转换技转换时
+		let next2 = game.createEvent("changeZhuanhuanjiBegin", false, get.event());
+		next2.player = player;
+		next2.forceDie = true;
+		next2.includeOut = true;
+		next.skill = skill;
+		next.log_event = evt;
+		next2.setContent("emptyEvent");
 	}
 	/**
 	 * @param { string } skill
@@ -8978,7 +8995,7 @@ export class Player extends HTMLDivElement {
 			next.forceDie = true;
 			next.includeOut = true;
 			evt.next.remove(next);
-			if (evt.logSkill) {
+			if (evt.logSkill || evt.name?.startsWith("pre_")) {
 				evt = evt.getParent();
 			}
 			for (var i in logInfo) {

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -120,6 +120,7 @@ export class Player extends HTMLDivElement {
 			{
 				card: {},
 				skill: {},
+				triggerSkill: {},
 			},
 		];
 		player.actionHistory = [
@@ -136,7 +137,30 @@ export class Player extends HTMLDivElement {
 			},
 		];
 		player.tempSkills = {};
-		player.storage = {};
+		player.storage = {
+			counttrigger: new Proxy({}, {
+				get(_, prop) {
+					return player.getStat("triggerSkill")?.[prop];
+				},
+				set(_, prop, value) {
+					player.getStat("triggerSkill")[prop] = value;
+					return true;
+				},
+				deleteProperty(_, prop) {
+					delete player.getStat("triggerSkill")[prop];
+					return true;
+				},
+				has(_, prop) {
+					return prop in player.getStat("triggerSkill");
+				},
+				ownKeys() {
+					return Reflect.ownKeys(player.getStat("triggerSkill"));
+				},
+				getOwnPropertyDescriptor(_, prop) {
+					return Object.getOwnPropertyDescriptor(player.getStat("triggerSkill"), prop);
+				}
+			}),
+		};
 		player.marks = {};
 		player.expandedSlots = {};
 		player.disabledSlots = {};
@@ -3645,9 +3669,32 @@ export class Player extends HTMLDivElement {
 		this.awakenedSkills = [];
 		this.forbiddenSkills = {};
 		this.phaseNumber = 0;
-		this.stat = [{ card: {}, skill: {} }];
+		this.stat = [{ card: {}, skill: {}, triggerSkill: {} }];
 		this.tempSkills = {};
-		this.storage = {};
+		this.storage = {
+			counttrigger: new Proxy({}, {
+				get(_, prop) {
+					return this.getStat("triggerSkill")?.[prop];
+				},
+				set(_, prop, value) {
+					this.getStat("triggerSkill")[prop] = value;
+					return true;
+				},
+				deleteProperty(_, prop) {
+					delete this.getStat("triggerSkill")[prop];
+					return true;
+				},
+				has(_, prop) {
+					return prop in this.getStat("triggerSkill");
+				},
+				ownKeys() {
+					return Reflect.ownKeys(this.getStat("triggerSkill"));
+				},
+				getOwnPropertyDescriptor(_, prop) {
+					return Object.getOwnPropertyDescriptor(this.getStat("triggerSkill"), prop);
+				}
+			}),
+		};
 		this.marks = {};
 		this.expandedSlots = {};
 		this.disabledSlots = {};
@@ -4647,24 +4694,14 @@ export class Player extends HTMLDivElement {
 	 */
 	countSkill(skill) {
 		const info = lib.skill[skill];
-		let num = 0;
 		if (!info) {
 			console.warn("“" + skill + "”为无效技能ID！");
 			return 0;
 		}
-		if (info.usable !== undefined && this.hasSkill("counttrigger") && this.storage.counttrigger) {
-			num = this.storage.counttrigger[skill];
-			if (typeof num === "number") {
-				return num;
-			}
+		if (typeof this.getStat("skill")[skill] === "number" || typeof this.getStat("triggerSkill")[skill] === "number") {
+			return Number(this.getStat("skill")?.[skill] ?? 0) + Number(this.getStat("triggerSkill")?.[skill] ?? 0);
 		}
-		num = this.getStat("skill")[skill];
-		if (typeof num === "number") {
-			return num;
-		}
-		return this.getHistory("useSkill", evt => {
-			return evt.skill === skill;
-		}).length;
+		return this.getHistory("useSkill", evt => evt.skill === skill).length;
 	}
 	/**
 	 * @param {*} [unowned]
@@ -8596,7 +8633,7 @@ export class Player extends HTMLDivElement {
 	 * 返回某些牌是否能进入玩家的判定区
 	 * @overload
 	 * @param { string | Card } card
-	 * @param { Player } player 
+	 * @param { Player } player
 	 * @returns { boolean }
 	 */
 	canAddJudge(card, player) {
@@ -10076,7 +10113,7 @@ export class Player extends HTMLDivElement {
 				this.addSkill(skill[i]);
 			}
 		} else {
-			if (this.skills.includes(skill)) {
+			if (skill === "counttrigger" || this.skills.includes(skill)) {
 				return;
 			}
 			_status.event.clearStepCache();
@@ -10552,62 +10589,67 @@ export class Player extends HTMLDivElement {
 				this.removeSkill(skill[i]);
 			}
 		} else {
-			var info = lib.skill[skill];
-			if (info && info.fixed && arguments[1] !== true) {
-				return skill;
-			}
-			this.unmarkSkill(skill);
-			game.broadcastAll(
-				function (player, skill) {
-					player.skills.remove(skill);
-					player.hiddenSkills.remove(skill);
-					player.invisibleSkills.remove(skill);
-					delete player.tempSkills[skill];
-					for (var i in player.additionalSkills) {
-						player.additionalSkills[i].remove(skill);
-					}
-				},
-				this,
-				skill
-			);
-			this.checkConflict(skill);
-			if (info) {
-				if (info.onremove) {
-					if (typeof info.onremove == "function") {
-						info.onremove(this, skill);
-					} else if (typeof info.onremove == "string") {
-						if (info.onremove == "storage") {
+			if (skill === "counttrigger") {
+				this.getStat("triggerSkill") = {};
+				return;
+			} else {
+				var info = lib.skill[skill];
+				if (info?.fixed && arguments[1] !== true) {
+					return skill;
+				}
+				this.unmarkSkill(skill);
+				game.broadcastAll(
+					function (player, skill) {
+						player.skills.remove(skill);
+						player.hiddenSkills.remove(skill);
+						player.invisibleSkills.remove(skill);
+						delete player.tempSkills[skill];
+						for (var i in player.additionalSkills) {
+							player.additionalSkills[i].remove(skill);
+						}
+					},
+					this,
+					skill
+				);
+				this.checkConflict(skill);
+				if (info) {
+					if (info.onremove) {
+						if (typeof info.onremove == "function") {
+							info.onremove(this, skill);
+						} else if (typeof info.onremove == "string") {
+							if (info.onremove == "storage") {
+								delete this.storage[skill];
+							} else {
+								var cards = this.storage[skill];
+								if (get.itemtype(cards) == "card") {
+									cards = [cards];
+								}
+								if (get.itemtype(cards) == "cards") {
+									if (this.onremove == "discard") {
+										this.$throw(cards);
+									}
+									if (this.onremove == "discard" || this.onremove == "lose") {
+										game.cardsDiscard(cards);
+										delete this.storage[skill];
+									}
+								}
+							}
+						} else if (Array.isArray(info.onremove)) {
+							for (var i = 0; i < info.onremove.length; i++) {
+								delete this.storage[info.onremove[i]];
+							}
+						} else if (info.onremove === true) {
 							delete this.storage[skill];
-						} else {
-							var cards = this.storage[skill];
-							if (get.itemtype(cards) == "card") {
-								cards = [cards];
-							}
-							if (get.itemtype(cards) == "cards") {
-								if (this.onremove == "discard") {
-									this.$throw(cards);
-								}
-								if (this.onremove == "discard" || this.onremove == "lose") {
-									game.cardsDiscard(cards);
-									delete this.storage[skill];
-								}
-							}
 						}
-					} else if (Array.isArray(info.onremove)) {
-						for (var i = 0; i < info.onremove.length; i++) {
-							delete this.storage[info.onremove[i]];
-						}
-					} else if (info.onremove === true) {
-						delete this.storage[skill];
+					}
+					this.removeSkillTrigger(skill);
+					if (!info.keepSkill) {
+						this.removeAdditionalSkills(skill);
 					}
 				}
-				this.removeSkillTrigger(skill);
-				if (!info.keepSkill) {
-					this.removeAdditionalSkills(skill);
-				}
+				this.enableSkill(skill + "_awake");
+				game.callHook("removeSkillCheck", [skill, this]);
 			}
-			this.enableSkill(skill + "_awake");
-			game.callHook("removeSkillCheck", [skill, this]);
 		}
 		return skill;
 	}
@@ -12211,6 +12253,9 @@ export class Player extends HTMLDivElement {
 	 * @returns { boolean }
 	 */
 	hasSkill(skill, arg2, arg3, arg4) {
+		if (skill === "counttrigger") {
+			return true;
+		}
 		return game.expandSkills(this.getSkills(arg2, arg3, arg4)).includes(skill);
 	}
 	/**

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -1939,8 +1939,8 @@ export class Player extends HTMLDivElement {
 		next2.player = player;
 		next2.forceDie = true;
 		next2.includeOut = true;
-		next.skill = skill;
-		next.log_event = evt;
+		next2.skill = skill;
+		next2.log_event = evt;
 		next2.setContent("emptyEvent");
 	}
 	/**

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -140,7 +140,7 @@ export class Player extends HTMLDivElement {
 		player.storage = {
 			counttrigger: new Proxy({}, {
 				get(_, prop) {
-					return player.getStat("triggerSkill")?.[prop];
+					return player.getStat("triggerSkill")[prop];
 				},
 				set(_, prop, value) {
 					player.getStat("triggerSkill")[prop] = value;
@@ -3674,7 +3674,7 @@ export class Player extends HTMLDivElement {
 		this.storage = {
 			counttrigger: new Proxy({}, {
 				get(_, prop) {
-					return this.getStat("triggerSkill")?.[prop];
+					return this.getStat("triggerSkill")[prop];
 				},
 				set(_, prop, value) {
 					this.getStat("triggerSkill")[prop] = value;

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -2039,7 +2039,7 @@ export class Library {
 								var fileList = Array.from(files);
 								var totalFiles = fileList.length;
 								var processedFiles = 0;
-								fileList.forEach(function(file, index) {
+								fileList.forEach(function (file, index) {
 									if (file) {
 										var name = file.name;
 										if (name.includes(".")) {
@@ -11154,12 +11154,12 @@ export class Library {
 			if (event._notrigger.includes(player) && !lib.skill.global.includes(skill)) {
 				return false;
 			}
-			if (info.usable !== undefined && player.hasSkill("counttrigger") && player.storage.counttrigger) {
+			if (info.usable !== undefined) {
 				let num = info.usable;
 				if (typeof num === "function") {
 					num = info.usable(skill, player);
 				}
-				if (typeof num === "number" && player.storage.counttrigger[skill] >= num) {
+				if (typeof num === "number" && (player.getStat("triggerSkill")[skill] ?? 0) >= num) {
 					return false;
 				}
 			}
@@ -12241,16 +12241,16 @@ export class Library {
 						const cardName = get.name(cards[0], player);
 						return cardName
 							? new lib.element.VCard({
-								name: cardName,
-								nature: get.nature(cards[0], player),
-								suit: get.suit(cards[0], player),
-								number: get.number(cards[0], player),
-								isCard: true,
-								cards: [cards[0]],
-								storage: {
-									stratagem_buffed: 1,
-								},
-							})
+									name: cardName,
+									nature: get.nature(cards[0], player),
+									suit: get.suit(cards[0], player),
+									number: get.number(cards[0], player),
+									isCard: true,
+									cards: [cards[0]],
+									storage: {
+										stratagem_buffed: 1,
+									},
+							  })
 							: new lib.element.VCard();
 					}
 					return null;
@@ -12584,8 +12584,7 @@ export class Library {
 					}
 					if (typeof select == "string" && select !== "all") {
 						targets = [trigger[select]];
-					}
-					else {
+					} else {
 						targets = player.getEnemies(filter(target), false);
 						if (select !== "all" && typeof select == "number") {
 							targets = targets.randomGets(select);
@@ -13413,9 +13412,9 @@ export class Library {
 					return typeof evt.filterCard == "function" && evt.filterCard({ name: "shan" }, player, evt) && evt.filterCard({ name: "sha" }, player, evt);
 				},
 				async content(event, trigger, player) {
-					const control = await player.
-						chooseControl(["sha", "shan"])
-						.set("prompt", `鏖战：请选择${get.translation(trigger.cards[0])}视为${(trigger.name == "respond" ? "打出" : "使用")}的牌名`)
+					const control = await player
+						.chooseControl(["sha", "shan"])
+						.set("prompt", `鏖战：请选择${get.translation(trigger.cards[0])}视为${trigger.name == "respond" ? "打出" : "使用"}的牌名`)
 						.set("ai", () => {
 							const choice = _status.event.getParent(5).choice;
 							if (choice && ["sha", "shan"].includes(choice)) {
@@ -13437,7 +13436,7 @@ export class Library {
 					skillTagFilter(player, tag, arg) {
 						if (!player.countCards("hs", card => card.name == "tao")) {
 							return false;
-						};
+						}
 					},
 				},
 			},
@@ -13691,31 +13690,6 @@ export class Library {
 					},
 				},
 				markimage: "image/card/shield.png",
-			},
-			counttrigger: {
-				trigger: { global: "phaseAfter" },
-				silent: true,
-				charlotte: true,
-				priority: -100,
-				lastDo: true,
-				content: function () {
-					player.removeSkill("counttrigger");
-					delete player.storage.counttrigger;
-				},
-				group: "counttrigger_2",
-				subSkill: {
-					2: {
-						trigger: { global: ["phaseBeforeStart", "roundStart"] },
-						silent: true,
-						charlotte: true,
-						firstDo: true,
-						priority: 100,
-						content: function () {
-							player.removeSkill("counttrigger");
-							delete player.storage.counttrigger;
-						},
-					},
-				},
 			},
 			/**
 			 * @deprecated
@@ -14203,7 +14177,7 @@ export class Library {
 		},
 		{
 			set(target, prop, newValue) {
-				if (typeof prop === 'string' && typeof newValue === 'object') {
+				if (typeof prop === "string" && typeof newValue === "object") {
 					newValue.skill_id ??= prop;
 				}
 				return Reflect.set(target, prop, newValue);

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -435,9 +435,11 @@ export class Library {
 
 	objectURL = new Map();
 	hookmap = {};
-	//共联时机的map（目前有很大的兼容问题，请不要使用）
+	//共联时机的map
 	#relatedTrigger = {
-		phaseAny: ["phaseJudge", "phaseDraw", "phaseUse", "phaseDiscard", "phaseJieshu"],
+		get phaseAny() {
+			return lib.phaseName;
+		},
 		//loseAsync: ["lose", "gain", "addToExpansion", "addJudge", "eqiup"],
 	};
 	get relatedTrigger() {


### PR DESCRIPTION
### PR受影响的平台
牢大肘击会（会长牢萌副会长星语，出了事找他们）
### 诱因和背景
解决看到的和遇到的bug
解决会长的任务
### PR描述
`phaseAny`共联时机改为`getter`获取`lib.phaseName`
修复在`chooseToUse`和`chooseToRespond`里面的`pre_skill`事件的`logSkill`层级寻找问题
调整`changeZhuanhuanji`时机逻辑同`logSkill`逻辑（修复谋许攸二技能摸牌时机问题），增加`changeZhuanhuanjiBegin`代替原`changeZhuanhuanji`瞬时时机
[请counttrigger趋势](https://github.com/libnoname/noname/issues/2769)，对`Player.storage.counttrigger`进行重定向，指向`Player.getStat().triggerSkill`，具体修改如下：
消灭技能`counttrigger`，对`Player.storage.counttrigger`进行代理，指向`Player.getStat().triggerSkill`
建立角色和`uninit`角色时`player.storage`中默认含`proxy`代理的`counttrigger`
`Player.hasSkill("counttrigger")`默认返回`true`
`Player.addSkill("counttrigger")`默认直接中止流程
`Player.removeSkill("counttrigger")`改为令`Player.getStat().triggerSkill`赋空
修改`get.skillCount`逻辑为同时获得一个有`usable`技能的`enable`和`trigger`两类发动次数之和
### PR测试
已测，能运行
### 扩展适配
修改了创建初始角色逻辑/`lib.element.player.uninit`/`game.check`/`lib.element.player.changeZhuanhuanji`的扩展
### 检查清单
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码