### PR TITLE
Fix: correct usage of Set prototype APIs

### DIFF
--- a/apps/core/game/package.js
+++ b/apps/core/game/package.js
@@ -124,9 +124,6 @@ window.noname_package = {
 		music_danji: "千里走单骑",
 		music_jifeng: "祭风",
 		music_jilve: "极略",
-		effect_caomaoBJM: "向死存魏",
-		effect_yinzhanBGM: "势魏延饮战",
-		effect_tuishouBGM: "势魏延退守",
 	},
 	font: {
 		xiaozhuan: "方正小篆体",

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -451,7 +451,7 @@ export class Game {
 		}
 
 		// @ts-expect-error childNodes是可迭代的
-		const elements = new Set(parentFrom.childNodes).union(parentTo.childNodes);
+		const elements = new Set(parentFrom.childNodes).union(new Set(parentTo.childNodes));
 
 		for (const element of elements) {
 			recordAsFirstPosition(element);
@@ -471,7 +471,7 @@ export class Game {
 
 		// 然后是LAST喵，记录结束位置哦喵
 		// @ts-expect-error childNodes是可迭代的
-		const elements2 = new Set(parentFrom.childNodes).union(parentTo.childNodes);
+		const elements2 = new Set(parentFrom.childNodes).union(new Set(parentTo.childNodes));
 
 		for (const element of elements2) {
 			recordAsLastPosition(element);

--- a/apps/core/noname/ui/create/index.js
+++ b/apps/core/noname/ui/create/index.js
@@ -2177,7 +2177,7 @@ export class Create {
 			game.check();
 
 			const selectables = get.selectableCards();
-			// @ts-expect-error 啊至少垫片函数是接受数组的喵
+			// @ts-expect-error 啊，还是直接变成Set喵
 			const cards = selecteds.length ? [...new Set(selectables).difference(new Set(selecteds))] : selectables;
 
 			if (cards.length <= range[1]) {
@@ -2244,7 +2244,7 @@ export class Create {
 			game.check();
 
 			const selectables = get.selectableButtons();
-			// @ts-expect-error 啊至少垫片函数是接受数组的喵
+			// @ts-expect-error 啊直接变成set更好喵
 			const buttons = selecteds.length ? [...new Set(selectables).difference(new Set(selecteds))] : selectables;
 
 			if (buttons.length <= range[1]) {

--- a/apps/core/noname/ui/create/index.js
+++ b/apps/core/noname/ui/create/index.js
@@ -2178,7 +2178,7 @@ export class Create {
 
 			const selectables = get.selectableCards();
 			// @ts-expect-error 啊至少垫片函数是接受数组的喵
-			const cards = selecteds.length ? [...new Set(selectables).difference(selecteds)] : selectables;
+			const cards = selecteds.length ? [...new Set(selectables).difference(new Set(selecteds))] : selectables;
 
 			if (cards.length <= range[1]) {
 				// 如果可以就全选喵
@@ -2245,7 +2245,7 @@ export class Create {
 
 			const selectables = get.selectableButtons();
 			// @ts-expect-error 啊至少垫片函数是接受数组的喵
-			const buttons = selecteds.length ? [...new Set(selectables).difference(selecteds)] : selectables;
+			const buttons = selecteds.length ? [...new Set(selectables).difference(new Set(selecteds))] : selectables;
 
 			if (buttons.length <= range[1]) {
 				// 如果可以就全选喵


### PR DESCRIPTION
ECMAScript2025在Set的原型上新增了一些方法，这些方法的参数不一定非得是 Set 对象。它可以是任何 Set-like 对象（即具有 .size 属性和 .has() 方法的对象，或者是任何可迭代对象，如 Array 或 Map）。
我在打包无名杀时为了性能会删除core-js-bundle，但是在webview148上运行时发现报错：.size is NaN。
将元素显式地转化为Set即可消除，在core-js-bundle存在时也不会造成影响