### PR TITLE
ci: 将定时Action的时间提前/提后；给编译Action加上名称

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build and Deploy
 
 on:
   push:
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    name: Build and Deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,7 +1,7 @@
 name: Close Stale Issues
 on:
   schedule:
-    - cron: "0 11 * * *" # 每天的 11:00 运行
+    - cron: "49 11 * * *" # 每天的 19:49 运行
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -2,7 +2,7 @@ name: Nightly Publish
 
 on:
   schedule:
-    - cron: '0 14 * * *'
+    - cron: '11 13 * * *' # 每天的 21:11 运行
   workflow_dispatch: # 允许手动点击按钮触发编译
 
 permissions:

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Upload Nightly Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: nightly-${{ steps.info.outputs.date }}
+          name: 测试包-${{ steps.info.outputs.date }}
           path: output/testpack
           retention-days: 7


### PR DESCRIPTION
由于Github将整点视为高峰期，导致整点的定时Action并非在整点运行，~~然后我等测试包就会非常着急~~

于是将目前的两个定时Action提前/提后，避开整点:
- 测试包现在会于21:11发布
- 自动关闭过时issue会于19:49执行

顺带，将测试包名改为群里发布时的名字，~~省的每次重命名碍事，Github也应该几乎没啥人去Artifact里下~~