### PR TITLE
fix: 修复电脑端不支持`window.prompt`导致无法正常运行

### DIFF
--- a/apps/core/mode/connect.js
+++ b/apps/core/mode/connect.js
@@ -193,10 +193,11 @@ export default () => {
 							read(input.value);
 						} else if (confirm("是否输入邀请链接以进入联机地址和房间？")) {
 							ced = true;
-							var text = prompt("请输入邀请链接");
-							if (typeof text == "string" && text.length > 0) {
-								read(text);
-							}
+							game.prompt("请输入邀请链接", text => {
+								if (typeof text === "string" && text.length > 0) {
+									read(text);
+								}
+							});
 						}
 					}
 				}

--- a/apps/core/noname/library/index.js
+++ b/apps/core/noname/library/index.js
@@ -12772,10 +12772,11 @@ export class Library {
 								if (result || input.value.length > 0) {
 									read(input.value);
 								} else if (confirm("是否输入邀请链接以加入房间？")) {
-									var text = prompt("请输入邀请链接");
-									if (typeof text == "string" && text.length > 0) {
-										read(text);
-									}
+									game.prompt("请输入邀请链接", text => {
+										if (typeof text === "string" && text.length > 0) {
+											read(text);
+										}
+									});
 								}
 							}
 						}

--- a/apps/core/noname/library/index.js
+++ b/apps/core/noname/library/index.js
@@ -5826,25 +5826,26 @@ export class Library {
 						group: "按势力筛选",
 						number: "自选数值",
 					},
-					onclick(item) {
+					async onclick(item) {
 						if (item !== "number") {
-							game.saveConfig("connect_limit_zhu", item, "identity");
+							await game.promises.saveConfig("connect_limit_zhu", item, "identity");
 							return;
 						}
-						const result = prompt("请输入常备主候选武将数");
-						if (/^-?\d+(\.\d+)?$/.test(result)) {
-							const number = Number(result);
-							if (number > 0) {
-								if (Number.isInteger(number)) {
-									this.querySelector("div").innerHTML = result;
-									game.saveConfig("connect_limit_zhu", result, "identity");
-								} else {
-									alert("请输入整数");
-								}
-								return;
+						while (true) {
+							const result = await game.promises.prompt("请输入常备主候选武将数");
+							if (!result) {
+								break;
 							}
+							if (/^-?\d+(\.\d+)?$/.test(result)) {
+								const number = Number(result);
+								if (number > 0 && Number.isInteger(number)) {
+									this.querySelector("div").innerHTML = result;
+									await game.promises.saveConfig("connect_limit_zhu", result, "identity");
+									break;
+								}
+							}
+							alert("请输入大于0的整数");
 						}
-						alert("请输入大于0的整数");
 					},
 				},
 				connect_choice_zhong: {

--- a/apps/core/noname/library/index.js
+++ b/apps/core/noname/library/index.js
@@ -6488,25 +6488,26 @@ export class Library {
 						group: "按势力筛选",
 						number: "自选数值",
 					},
-					onclick(item) {
+					async onclick(item) {
 						if (item !== "number") {
-							game.saveConfig("limit_zhu", item, "identity");
+							await game.promises.saveConfig("limit_zhu", item, "identity");
 							return;
 						}
-						const result = prompt("请输入常备主候选武将数");
-						if (/^-?\d+(\.\d+)?$/.test(result)) {
-							const number = Number(result);
-							if (number > 0) {
-								if (Number.isInteger(number)) {
-									this.querySelector("div").innerHTML = result;
-									game.saveConfig("limit_zhu", result, "identity");
-								} else {
-									alert("请输入整数");
-								}
-								return;
+						while (true) {
+							const result = await game.promises.prompt("请输入常备主候选武将数");
+							if (!result) {
+								break;
 							}
+							if (/^-?\d+(\.\d+)?$/.test(result)) {
+								const number = Number(result);
+								if (number > 0 && Number.isInteger(number)) {
+									this.querySelector("div").innerHTML = result;
+									await game.promises.saveConfig("limit_zhu", result, "identity");
+									break;
+								}
+							}
+							alert("请输入大于0的整数");
 						}
-						alert("请输入大于0的整数");
 					},
 				},
 				choice_zhong: {


### PR DESCRIPTION
resolve #3575 

由于Electron不支持`window.prompt`，导致一些使用`window.prompt`读取用户输入的地方均无法在Electron正常运行

现将这些地方改成无名杀自带的`game.prompt`和`game.promises.prompt`，以使得Electron正常运行

> 目前唯一留下的`window.prompt`会检测移动端和诗笺版接口，Electron段不会访问，故无修改