### PR TITLE
feat: support viewAs: () => "cardName"

### DIFF
--- a/apps/core/noname/ui/click/index.js
+++ b/apps/core/noname/ui/click/index.js
@@ -3116,8 +3116,11 @@ export class Click {
 			const skillInformation = get.info(gameEvent.skill),
 				viewAs = skillInformation.viewAs;
 			if (typeof viewAs == "function") {
-				const viewedAs = viewAs(result.cards, gameEvent.player);
+				let viewedAs = viewAs(result.cards, gameEvent.player);
 				if (viewedAs) {
+					if (typeof viewedAs == "string") {
+						viewedAs = { name: viewedAs };
+					}
 					result.card = get.autoViewAs(viewedAs);
 				}
 			} else if (viewAs) {

--- a/apps/core/typings/Skill.d.ts
+++ b/apps/core/typings/Skill.d.ts
@@ -902,7 +902,7 @@ declare interface Skill {
 	 * 
 	 * 【v1.9.102】扩展：可以使用函数式viewAs，目前核心支持使用地方：backup,ok;
 	 */
-	viewAs?: string | CardBaseUIData | ((cards: Card[], player: Player) => VCard | CardBaseUIData | null);
+	viewAs?: string | CardBaseUIData | ((cards: Card[], player: Player) => string | VCard | CardBaseUIData | null);
 	/**
 	 * 视为技按钮出现条件（即发动条件）
 	 * @param player 


### PR DESCRIPTION
#3627 中提到，函数式viewAs返回string类型，仅做了类型声明，未进行实现
这里实现了对string返回值的处理，并在类型定义中重新添加了string返回值，使函数式viewAs的返回值类型，是原本静态viewAs类型的超集