### PR TITLE
fix: 设置Vite appType为mpa，修复开发模式下切换模式时JSON加载失败

### DIFF
--- a/apps/core/vite.config.ts
+++ b/apps/core/vite.config.ts
@@ -7,6 +7,7 @@ const port = {
 };
 
 export default defineConfig({
+	appType: "mpa",
 	root: ".",
 	base: "./",
 	resolve: {


### PR DESCRIPTION
## 问题

开发模式(`pnpm dev`)下，每次切换游戏模式时都会出现"加载内容失败"错误：

```
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
at JSON.parse (<anonymous>)
at XMLHttpRequest.<anonymous> (noname/library/init/index.js:319:20)
```

点击确定后页面重新加载，第二次加载则正常。该问题在每次切换模式时均可复现。

## 原因

Vite默认`appType`为`spa`，会对所有未匹配到文件的请求返回`index.html`。游戏在页面reload期间通过XHR请求JSON资源时，若请求在Vite模块转换期间未命中静态文件，Vite会将HTML作为响应返回，导致`JSON.parse`解析失败。

## 修复

在`apps/core/vite.config.ts`中将`appType`设置为`mpa`。本项目不使用客户端路由，不需要SPA回退机制。修改后，不存在的文件请求将正确返回404而非HTML。

## 测试

- [x] 多次切换游戏模式（身份、国战、联机、战棋、挑战等），不再出现加载失败
- [x] 单机游戏功能正常
- [x] 联机功能正常（WebSocket服务器连接正常）
- [x] Fastify代理接口（checkFile、getFileList、readFileAsText等）正常工作
- [x] 所有静态资源（JS、CSS、JSON、字体）正常加载