### PR TITLE
refactor(typings): 为Player.send添加类型定义，顺便改下ES6风格

### DIFF
--- a/apps/core/noname/library/element/client.js
+++ b/apps/core/noname/library/element/client.js
@@ -1,6 +1,18 @@
 import { _status, game, get, lib, ui } from "noname";
 import { security } from "@/util/sandbox.js";
 
+/**
+ * @typedef {import("../index.js").Library["message"]["client"]} ClientMsgs
+ */
+/**
+ * @template THIS
+ * @typedef {<P extends any[], K extends keyof ClientMsgs>(
+ * ...args:
+ * | [func: (...args: P) => any, ...P]
+ * | [msg: K , ...Parameters<ClientMsgs[K]>, ...any[]]
+ * ) => THIS
+ * } ClientSend
+ */
 export class Client {
 	/**
 	 * @param {import('../index.js').NodeWS | InstanceType<typeof import('ws').WebSocket> | Client} ws
@@ -34,6 +46,9 @@ export class Client {
 			}
 		}
 	}
+	/**
+	 * @type {ClientSend<this>}
+	 */
 	send() {
 		if (this.closed) {
 			return this;

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -399,6 +399,10 @@ export class Player extends HTMLDivElement {
 	 * @type {Map<string,HTMLDivElement>}
 	 */
 	tips;
+	/**
+	 * @type { import("./client.js").Client | undefined }
+	 */
+	ws;
 
 	/**
 	 * 添加视为装备
@@ -4145,11 +4149,15 @@ export class Player extends HTMLDivElement {
 			player.style.transform = "";
 		}, 100);
 	}
-	send() {
+	/**
+	 * @type { import("./client.js").ClientSend<this> }
+	 */
+	send(...args)
+	 {
 		if (!this.ws || this.ws.closed) {
 			return this;
 		}
-		this.ws.send.apply(this.ws, arguments);
+		this.ws.send(...args);
 		return this;
 	}
 	getId() {


### PR DESCRIPTION
在尝试了亿些类型体操之后，最终选择了这种方案
- 对于`player.send(func, ...args)`，现在可以根据传入的args，自动为func提示参数类型
- 对于`player.send(msg, ...args)`，args为msg所需的参数，同时后面连了any[]以适配少量仍在使用arguments获取参数的message
  - message有JSDoc类型定义 - 将提供完整类型提示
  - message仅有显式形参 - 可提供参数名进行提示
  - message无显式形参，内部使用arguments处理参数 - 无法提示，但不会报类型错误