### PR TITLE
fix: 修复【仁德】在无手牌时无法将装备区的牌交给其他角色

### DIFF
--- a/apps/core/character/sb/skill.js
+++ b/apps/core/character/sb/skill.js
@@ -7583,13 +7583,7 @@ const skills = {
 					list = [],
 					cards = [];
 				dialog.direct = true;
-				if (
-					event.type == "phase" &&
-					player.countCards("h") &&
-					game.hasPlayer(current => {
-						return !storage.includes(current) && current != player;
-					})
-				) {
+				if (event.type == "phase" && player.hasCard(() => true, "he") && game.hasPlayer(current => !storage.includes(current) && current != player)) {
 					dialog.add([[["give", "交给其他角色牌"]], "tdnodes"]);
 				}
 				if (player.countMark("sbrende") > 1 && !storage.includes("card")) {


### PR DESCRIPTION
resolve #3692 