### PR TITLE
refactor: 重构`Player#getCards`相关方式遍历方法，优化参数命名

### DIFF
--- a/apps/core/noname/get/index.js
+++ b/apps/core/noname/get/index.js
@@ -4137,14 +4137,16 @@ else if (entry[1] !== void 0) stringifying[key] = JSON.stringify(entry[1]);*/
 	}
 	/**
 	 * 遍历子元素
-	 * @param {HTMLElement} node
+	 * @param {...HTMLElement} elements
 	 * @returns {Iterable<HTMLElement>} 迭代器
 	 */
-	*iterableChildNodes(node) {
-		for (let i = 0; i < arguments.length; i++) {
-			let arg = arguments[i];
-			for (let j = 0; j < arg.childElementCount; j++) {
-				yield arg.childNodes[j];
+	*iterableChildNodes(...elements) {
+		for (const element of elements) {
+			for (let i = 0; i < element.childElementCount; ++i) {
+				const current = element.childNodes[i];
+				if (current instanceof HTMLElement) {
+					yield current;
+				}
 			}
 		}
 	}

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -5258,41 +5258,60 @@ export class Player extends HTMLDivElement {
 		return Array.from(this.iterableGetCards(position, filter));
 	}
 	/**
-	 * @param { Player } player
-	 * @param { string } [arg1]
-	 * @param { string } [arg2]
-	 * @returns { Generator<Card, void, unknown> }
+	 * 返回玩家的牌区中能被给定角色弃置的牌，默认返回手牌区的牌
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getDiscardableCards`
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Iterable<Card> } - 经过过滤后的牌的生成器
 	 */
-	*iterableGetDiscardableCards(player, arg1, arg2) {
-		for (let card of this.iterableGetCards(arg1, arg2)) {
+	*iterableGetDiscardableCards(player, position, filter) {
+		for (const card of this.iterableGetCards(position, filter)) {
 			if (lib.filter.canBeDiscarded(card, player, this)) {
 				yield card;
 			}
 		}
 	}
-	getDiscardableCards(player, arg1, arg2) {
-		return Array.from(this.iterableGetDiscardableCards(player, arg1, arg2));
+	/**
+	 * 返回玩家的牌区中能被给定角色弃置的牌，默认返回手牌区的牌
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Card[] } - 经过过滤后的牌的数组
+	 */
+	getDiscardableCards(player, position, filter) {
+		return Array.from(this.iterableGetDiscardableCards(player, position, filter));
 	}
 	/**
-	 * @param {Parameters<lib['filter']['canBeGained']>[1]} player
-	 * @param {Parameters<this['iterableGetCards']>[0]} arg1
-	 * @param {Parameters<this['iterableGetCards']>[1]} arg2
+	 * 返回玩家的牌区中能被给定角色获得的牌，默认返回手牌区的牌
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getGainableCards`
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Iterable<Card> } - 经过过滤后的牌的生成器
 	 */
-	*iterableGetGainableCards(player, arg1, arg2) {
-		for (let card of this.iterableGetCards(arg1, arg2)) {
+	*iterableGetGainableCards(player, position, filter) {
+		for (const card of this.iterableGetCards(position, filter)) {
 			if (lib.filter.canBeGained(card, player, this)) {
 				yield card;
 			}
 		}
 	}
 	/**
-	 *
-	 * @param {Parameters<this['iterableGetGainableCards']>[0]} player
-	 * @param {Parameters<this['iterableGetGainableCards']>[1]} [arg1]
-	 * @param {Parameters<this['iterableGetGainableCards']>[2]} [arg2]
+	 * 返回玩家的牌区中能被给定角色获得的牌，默认返回手牌区的牌
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Card[] } - 经过过滤后的牌的数组
 	 */
-	getGainableCards(player, arg1, arg2) {
-		return Array.from(this.iterableGetGainableCards(player, arg1, arg2));
+	getGainableCards(player, position, filter) {
+		return Array.from(this.iterableGetGainableCards(player, position, filter));
 	}
 	getGainableSkills(func) {
 		var list = [];
@@ -5331,16 +5350,35 @@ export class Player extends HTMLDivElement {
 		}
 		return -1;
 	}
-	countDiscardableCards(player, arg1, arg2) {
-		return this.getDiscardableCards(player, arg1, arg2).length;
+	/**
+	 * 返回玩家的牌区中能被给定角色弃置的牌的数量，默认返回手牌区的牌的数量
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { number } - 经过过滤后的牌的数量
+	 */
+	countDiscardableCards(player, position, filter) {
+		let count = 0;
+		for (const _ of this.iterableGetDiscardableCards(player, position, filter)) {
+			++count;
+		}
+		return count;
 	}
 	/**
-	 * @param {Parameters<this['getGainableCards']>[0]} player
-	 * @param {Parameters<this['getGainableCards']>[1]} [arg1]
-	 * @param {Parameters<this['getGainableCards']>[2]} [arg2]
+	 * 返回玩家的牌区中能被给定角色获得的牌的数量，默认返回手牌区的牌的数量
+	 * 
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { number } - 经过过滤后的牌的数量
 	 */
-	countGainableCards(player, arg1, arg2) {
-		return this.getGainableCards(player, arg1, arg2).length;
+	countGainableCards(player, position, filter) {
+		let count = 0;
+		for (const _ of this.iterableGetGainableCards(player, position, filter)) {
+			++count;
+		}
+		return count;
 	}
 	/**
 	 * 返回武将牌上原有的技能

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -5159,13 +5159,17 @@ export class Player extends HTMLDivElement {
 		return count;
 	}
 	/**
-	 * @param { string } [arg1='h']
-	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [arg2]
-	 * @returns { Iterable<Card> }
+	 * 返回玩家的牌区中的牌，默认返回手牌区的牌
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getCards`
+	 * 
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Iterable<Card> } - 经过过滤后的牌的生成器
 	 */
-	*iterableGetCards(arg1, arg2) {
-		if (typeof arg1 != "string") {
-			arg1 = "h";
+	*iterableGetCards(position, filter) {
+		if (typeof position != "string") {
+			position = "h";
 		}
 		const getCardName = card => {
 			if (card.parentNode == this.node.judges) {
@@ -5175,74 +5179,83 @@ export class Player extends HTMLDivElement {
 			}
 			return get.name(card);
 		};
-		let filter = card => true;
-		if (arg2) {
-			if (typeof arg2 == "string") {
-				filter = card => getCardName(card) == arg2;
-			} else if (Array.isArray(arg2)) {
-				filter = card => arg2.includes(getCardName(card));
-			} else if (typeof arg2 == "object") {
-				filter = card => {
-					for (let j in arg2) {
-						var value;
-						if (j == "type" || j == "subtype" || j == "color" || j == "suit" || j == "number") {
-							value = get[j](card);
-						} else if (j == "name") {
+		let filterCard = _ => true;
+		if (filter) {
+			if (typeof filter == "string") {
+				filterCard = card => getCardName(card) == filter;
+			} else if (Array.isArray(filter)) {
+				filterCard = card => filter.includes(getCardName(card));
+			} else if (typeof filter == "object") {
+				filterCard = card => {
+					for (const key in filter) {
+						let value;
+						if (key == "type" || key == "subtype" || key == "color" || key == "suit" || key == "number") {
+							value = get[key](card);
+						} else if (key == "name") {
 							value = getCardName(card);
 						} else {
-							value = card[j];
+							value = card[key];
 						}
-						if ((typeof arg2[j] == "string" && value != arg2[j]) || (Array.isArray(arg2[j]) && !arg2[j].includes(value))) {
+						if ((typeof filter[key] == "string" && value != filter[key]) || (Array.isArray(filter[key]) && !filter[key].includes(value))) {
 							return false;
 						}
 					}
 					return true;
 				};
-			} else if (typeof arg2 == "function") {
-				filter = arg2;
+			} else if (typeof filter == "function") {
+				filterCard = filter;
 			}
 		}
-		for (let i = 0; i < arg1.length; i++) {
-			if (arg1[i] == "h") {
-				for (let card of get.iterableChildNodes(this.node.handcards1, this.node.handcards2)) {
-					if (!card.classList.contains("removing") && !card.classList.contains("glows") && filter(card)) {
-						yield card;
+
+		for (const pos of position) {
+			switch (pos) {
+				case "h":
+					for (const card of get.iterableChildNodes(this.node.handcards1, this.node.handcards2)) {
+						if (!card.classList.contains("removing") && !card.classList.contains("glows") && filterCard(card)) {
+							yield card;
+						}
 					}
-				}
-			} else if (arg1[i] == "s") {
-				for (let card of get.iterableChildNodes(this.node.handcards1, this.node.handcards2)) {
-					if (!card.classList.contains("removing") && card.classList.contains("glows") && filter(card)) {
-						yield card;
+					break;
+				case "s":
+					for (const card of get.iterableChildNodes(this.node.handcards1, this.node.handcards2)) {
+						if (!card.classList.contains("removing") && card.classList.contains("glows") && filterCard(card)) {
+							yield card;
+						}
 					}
-				}
-			} else if (arg1[i] == "e") {
-				for (let card of get.iterableChildNodes(this.node.equips)) {
-					if (!card.classList.contains("removing") && !card.classList.contains("feichu") && !card.classList.contains("emptyequip") && filter(card)) {
-						yield card;
+					break;
+				case "e":
+					for (const card of get.iterableChildNodes(this.node.equips)) {
+						if (!card.classList.contains("removing") && !card.classList.contains("feichu") && !card.classList.contains("emptyequip") && filterCard(card)) {
+							yield card;
+						}
 					}
-				}
-			} else if (arg1[i] == "j") {
-				for (let card of get.iterableChildNodes(this.node.judges)) {
-					if (!card.classList.contains("removing") && !card.classList.contains("feichu") && filter(card)) {
-						yield card;
+					break;
+				case "j":
+					for (const card of get.iterableChildNodes(this.node.judges)) {
+						if (!card.classList.contains("removing") && !card.classList.contains("feichu") && filterCard(card)) {
+							yield card;
+						}
 					}
-				}
-			} else if (arg1[i] == "x") {
-				for (let card of get.iterableChildNodes(this.node.expansions)) {
-					if (!card.classList.contains("removing") && filter(card)) {
-						yield card;
+					break;
+				case "x":
+					for (const card of get.iterableChildNodes(this.node.expansions)) {
+						if (!card.classList.contains("removing") && filterCard(card)) {
+							yield card;
+						}
 					}
-				}
+					break;
 			}
 		}
 	}
 	/**
-	 * @param { string } [arg1='h']
-	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [arg2]
-	 * @returns { Card[] }
+	 * 返回玩家的牌区中的牌，默认返回手牌区的牌
+	 * 
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { Card[] } - 经过过滤后的牌的数组
 	 */
-	getCards(arg1, arg2) {
-		return Array.from(this.iterableGetCards(arg1, arg2));
+	getCards(position, filter) {
+		return Array.from(this.iterableGetCards(position, filter));
 	}
 	/**
 	 * @param { Player } player
@@ -5290,13 +5303,16 @@ export class Player extends HTMLDivElement {
 		return list;
 	}
 	/**
-	 * @param { Parameters<typeof this['iterableGetCards']>[0] } [arg1]
-	 * @param { Parameters<typeof this['iterableGetCards']>[1] } [arg2]
+	 * 返回玩家的牌区中满足条件的牌的数量，默认返回手牌区的牌的数量
+	 * 
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、属性对象或过滤函数
+	 * @returns { number } - 经过过滤后的牌的数量
 	 */
-	countCards(arg1, arg2) {
+	countCards(position, filter) {
 		let count = 0;
-		for (let item of this.iterableGetCards(arg1, arg2)) {
-			count++;
+		for (const _ of this.iterableGetCards(position, filter)) {
+			++count;
 		}
 		return count;
 	}
@@ -13537,15 +13553,16 @@ export class Player extends HTMLDivElement {
 		}
 		return count > _status.event.getRand("mayHaveShan" + hs + this.playerid);
 	}
-	hasCard(name, position) {
-		if (typeof name == "function") {
-			for (let card of this.iterableGetCards(position, name)) {
-				return true;
-			}
-		} else {
-			if (this.countCards(position, name)) {
-				return true;
-			}
+	/**
+	 * 返回玩家是否有某(种牌名的)牌
+	 * 
+	 * @param { string | Record<string, any> | ((card: Card) => boolean) } pattern - 牌名/牌属性/筛选函数
+	 * @param { string } [position] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @returns { boolean }
+	 */
+	hasCard(pattern, position) {
+		for (const _ of this.iterableGetCards(position, pattern)) {
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
- 将 `Player#(iterable)get/countXXXCards` 的参数 arg1/arg2 重命名为 position/filter
- 完善 JSDoc 注释，明确各牌区含义（手牌/装备/判定/扩展/特殊）
- 简化 hasCard 方法实现，统一使用 iterableGetCards 迭代
- 优化 countDiscardableCards/countGainableCards 实现