### PR TITLE
Refactor card drawing logic in skill.js

### DIFF
--- a/apps/core/character/huicui/skill.js
+++ b/apps/core/character/huicui/skill.js
@@ -6746,8 +6746,6 @@ const skills = {
 			});
 			player.logSkill("dcyouzhan", targets);
 			for (const target of targets) {
-				let num = trigger.getl(target).cards2.length;
-				while (num > 0) {
 					const next = player.draw();
 					next.gaintag = ["dcyouzhan"];
 					await next;
@@ -6755,8 +6753,6 @@ const skills = {
 					target.addTempSkill("dcyouzhan_effect");
 					target.addMark("dcyouzhan_effect", 1, false);
 					target.addTempSkill("dcyouzhan_draw");
-					--num;
-				}
 			}
 		},
 		ai: {


### PR DESCRIPTION
Removed the loop that draws cards based on target's cards2 length.