### PR TITLE
build: 使会编译的武将包会在编译时复制源码到dist/src中

### DIFF
--- a/apps/core/scripts/build.ts
+++ b/apps/core/scripts/build.ts
@@ -42,6 +42,10 @@ for (const file of readdirSync(charaDist)) {
 		// 依照vite入口规范，使用相对于根目录的路径作为输入
 		// 后续可直接用于vite的input配置，无需再进行路径转换
 		charaInputs[file] = `character/${file}/index.${ts ? "ts" : "js"}`;
+		staticModules.push({
+			src: `character/${file}`,
+			dest: "src/character",
+		});
 		continue;
 	}
 	// 剩下的武将包未完成进行异步化，可能仍然存在step content，故直接复制


### PR DESCRIPTION
考虑到现在部分武将包已被编译，打包后的文件不再是源码，故将已经从step content转换成async content的武将包的源码如同noname一样复制到dist/src中