### PR TITLE
feat: 添加一系列操控牌区的方法，重构已有牌区函数

### DIFF
--- a/apps/core/character/yijiang/skill.js
+++ b/apps/core/character/yijiang/skill.js
@@ -3104,28 +3104,29 @@ const skills = {
 		async content_choose(event, trigger, player) {
 			const { target } = event;
 
+			let resultIndex;
 			if (target.isHealthy()) {
-				return;
-			}
-
-			let index;
-			if (get.attitude(player, target) > 0) {
-				index = 1;
+				resultIndex = 0;
 			} else {
-				index = 0;
-			}
+				let index;
+				if (get.attitude(player, target) > 0) {
+					index = 1;
+				} else {
+					index = 0;
+				}
 
-			const chooseResult = await player
-				.chooseControlList({
-					list: ["令" + get.translation(target) + "失去1点体力，随机使用一张装备牌", "令" + get.translation(target) + "回复1点体力，弃置一张装备牌"],
-					forced: true,
-					ai(event, player) {
-						return get.event().index;
-					},
-				})
-				.set("index", index)
-				.forResult();
-			const resultIndex = chooseResult?.index || index;
+				const chooseResult = await player
+					.chooseControlList({
+						list: ["令" + get.translation(target) + "失去1点体力，随机使用一张装备牌", "令" + get.translation(target) + "回复1点体力，弃置一张装备牌"],
+						forced: true,
+						ai(event, player) {
+							return get.event().index;
+						},
+					})
+					.set("index", index)
+					.forResult();
+				resultIndex = chooseResult?.index || index;
+			}
 			let card = null;
 			if (resultIndex == 0) {
 				await target.loseHp();

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -1219,24 +1219,49 @@ export class Player extends HTMLDivElement {
 		return next;
 	}
 	/**
-	 * 获取角色所有的连接手牌
+	 * 返回玩家手牌中所有的连接手牌
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getConnectedCards`
+	 * 
+	 * @returns { Generator<Card> }
+	 */
+	*iterableGetConnectedCards() {
+		for (const card of this.iterableGetCards("h")) {
+			if (get.is.connectedCard(card)) {
+				yield card;
+			}
+		}
+	}
+	/**
+	 * 返回玩家手牌中所有的连接牌
+	 * 
+	 * @returns { Card[] }
 	 */
 	getConnectedCards() {
-		return this.getCards("h", card => get.is.connectedCard(card));
+		return Array.from(this.iterableGetConnectedCards());
 	}
 	/**
-	 * 获取角色所有的连接手牌数
-	 * @returns {number}
+	 * 返回玩家手牌中连接牌的数量
+	 * 
+	 * @returns { number }
 	 */
 	countConnectedCards() {
-		return this.getConnectedCards().length;
+		let count = 0;
+		for (const _ of this.iterableGetConnectedCards()) {
+			++count;
+		}
+		return count;
 	}
 	/**
-	 * 判断一名角色是否拥有连接手牌
-	 * @returns {boolean}
+	 * 判断玩家手牌中是否有连接牌
+	 * 
+	 * @returns { boolean }
 	 */
 	hasConnectedCards() {
-		return this.hasCard(card => get.is.connectedCard(card), "h");
+		for (const _ of this.iterableGetConnectedCards()) {
+			return true;
+		}
+		return false;
 	}
 	/**
 	 * 让一名角色明置一些手牌

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -1220,9 +1220,9 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中所有的连接手牌
-	 * 
+	 *
 	 * 该方法返回一个生成器，需要返回数组请使用`Player#getConnectedCards`
-	 * 
+	 *
 	 * @returns { Generator<Card> }
 	 */
 	*iterableGetConnectedCards() {
@@ -1234,7 +1234,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中所有的连接牌
-	 * 
+	 *
 	 * @returns { Card[] }
 	 */
 	getConnectedCards() {
@@ -1242,7 +1242,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中连接牌的数量
-	 * 
+	 *
 	 * @returns { number }
 	 */
 	countConnectedCards() {
@@ -1254,7 +1254,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 判断玩家手牌中是否有连接牌
-	 * 
+	 *
 	 * @returns { boolean }
 	 */
 	hasConnectedCards() {
@@ -1333,9 +1333,9 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中已明置的牌
-	 * 
+	 *
 	 * 该方法返回一个生成器，需要返回数组请使用`Player#getShownCards`
-	 * 
+	 *
 	 * @returns { Generator<Card> }
 	 */
 	*iterableGetShownCards() {
@@ -1347,7 +1347,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中已明置的牌
-	 * 
+	 *
 	 * @returns { Card[] }
 	 */
 	getShownCards() {
@@ -1355,7 +1355,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中已明置牌的数量
-	 * 
+	 *
 	 * @returns { number }
 	 */
 	countShownCards() {
@@ -1367,7 +1367,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 判断玩家手牌中存在已明置的牌
-	 * 
+	 *
 	 * @returns {boolean}
 	 */
 	hasShownCards() {
@@ -1378,9 +1378,9 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）
-	 * 
+	 *
 	 * 该方法返回一个生成器，需要返回数组请使用`Player#getKnownCards`
-	 * 
+	 *
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { Generator<Card> } 经过过滤后的牌的生成器
@@ -1402,7 +1402,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）
-	 * 
+	 *
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { Card[] } 经过过滤后的牌的数组
@@ -1412,7 +1412,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 判断玩家手牌是否全部被给定角色所知，默认为当前事件的角色（不存在则改为自身）
-	 * 
+	 *
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @returns { boolean }
 	 */
@@ -1447,7 +1447,7 @@ export class Player extends HTMLDivElement {
 	}
 	/**
 	 * 返回玩家手牌中被给定角色所知的牌的数量，默认为当前事件的角色（不存在则改为自身）
-	 * 
+	 *
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { number } 经过过滤后的牌的数量

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -5368,7 +5368,7 @@ export class Player extends HTMLDivElement {
 	 *
 	 * 该方法返回一个生成器，需要返回数组请使用`Player#getGainableCards`
 	 *
-	 * @param { Player } player - 进行弃置的角色
+	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
@@ -5383,7 +5383,7 @@ export class Player extends HTMLDivElement {
 	/**
 	 * 返回玩家的牌区中能被给定角色获得的牌，默认返回手牌区的牌
 	 *
-	 * @param { Player } player - 进行弃置的角色
+	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { Card[] } - 经过过滤后的牌的数组
@@ -5446,7 +5446,7 @@ export class Player extends HTMLDivElement {
 	/**
 	 * 返回玩家的牌区中能被给定角色获得的牌的数量，默认返回手牌区的牌的数量
 	 *
-	 * @param { Player } player - 进行弃置的角色
+	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
 	 * @returns { number } - 经过过滤后的牌的数量
@@ -5457,6 +5457,47 @@ export class Player extends HTMLDivElement {
 			++count;
 		}
 		return count;
+	}
+	/**
+	 * 判断玩家的牌区中是否有满足条件的牌，默认判断手牌区的牌
+	 *
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { boolean }
+	 */
+	hasCards(position, filter) {
+		for (const _ of this.iterableGetCards(position, filter)) {
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * 判断玩家的牌区中是否有能被给定角色弃置的牌，默认判断手牌区的牌
+	 *
+	 * @param { Player } player - 进行弃置的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { boolean }
+	 */
+	hasDiscardableCards(player, position, filter) {
+		for (const _ of this.iterableGetDiscardableCards(player, position, filter)) {
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * 判断玩家的牌区中是否有能被给定角色获得的牌，默认判断手牌区的牌
+	 *
+	 * @param { Player } player - 进行获取的角色
+	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { boolean }
+	 */
+	hasGainableCards(player, position, filter) {
+		for (const _ of this.iterableGetGainableCards(player, position, filter)) {
+			return true;
+		}
+		return false;
 	}
 	/**
 	 * 返回武将牌上原有的技能

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -10264,14 +10264,32 @@ export class Player extends HTMLDivElement {
 			this[storage.length > 0 ? "markSkill" : "unmarkSkill"](name);
 		}
 	}
+	/**
+	 * 获取置于武将牌上给定类型的牌（如【田】和【逆】）
+	 *
+	 * @param { string } tag - 需要获取牌的标签
+	 * @returns { Card[] }
+	 */
 	getExpansions(tag) {
 		return this.getCards("x", card => card.hasGaintag(tag));
 	}
+	/**
+	 * 获取置于武将牌上给定类型的牌的数量（如【田】和【逆】）
+	 *
+	 * @param { string } tag - 需要获取牌的标签
+	 * @returns { number }
+	 */
 	countExpansions(tag) {
-		return this.getExpansions(tag).length;
+		return this.countCards("x", card => card.hasGaintag(tag));
 	}
+	/**
+	 * 判断给定类型的牌是否置于武将牌上（如【田】和【逆】）
+	 *
+	 * @param { string } tag - 需要获取牌的标签
+	 * @returns { boolean }
+	 */
 	hasExpansions(tag) {
-		return this.countExpansions(tag) > 0;
+		return this.hasCards("x", card => card.hasGaintag(tag));
 	}
 	setStorage(name, value, mark) {
 		this.storage[name] = value;

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -1307,26 +1307,49 @@ export class Player extends HTMLDivElement {
 		return next;
 	}
 	/**
-	 * 获取角色所有的明置手牌
+	 * 返回玩家手牌中已明置的牌
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getShownCards`
+	 * 
+	 * @returns { Generator<Card> }
+	 */
+	*iterableGetShownCards() {
+		for (const card of this.iterableGetCards("h")) {
+			if (get.is.shownCard(card)) {
+				yield card;
+			}
+		}
+	}
+	/**
+	 * 返回玩家手牌中已明置的牌
+	 * 
+	 * @returns { Card[] }
 	 */
 	getShownCards() {
-		return this.getCards("h", card => {
-			return get.is.shownCard(card);
-		});
+		return Array.from(this.iterableGetShownCards());
 	}
 	/**
-	 * 获取角色所有的明置手牌数
-	 * @returns {number}
+	 * 返回玩家手牌中已明置牌的数量
+	 * 
+	 * @returns { number }
 	 */
 	countShownCards() {
-		return this.getShownCards().length;
+		let count = 0;
+		for (const _ of this.iterableGetShownCards()) {
+			++count;
+		}
+		return count;
 	}
 	/**
-	 * 判断一名角色是否拥有明置手牌
+	 * 判断玩家手牌中存在已明置的牌
+	 * 
 	 * @returns {boolean}
 	 */
 	hasShownCards() {
-		return this.hasCard(card => get.is.shownCard(card), "h");
+		for (const _ of this.iterableGetShownCards()) {
+			return true;
+		}
+		return false;
 	}
 	/**
 	 * 返回玩家手牌中被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -5233,8 +5233,8 @@ export class Player extends HTMLDivElement {
 					break;
 			}
 		}
-		// 只有同时要手牌和特殊牌时才需要区分 glows
-		const needGlowsCheck = !hasH || !hasS;
+		// 只请求 h 或 s 其中之一时，需要用 glows 区分普通手牌和特殊牌
+		const needGlowsCheck = hasH !== hasS;
 
 		// 一些简单的去重
 		let handDone = false;

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -1358,7 +1358,7 @@ export class Player extends HTMLDivElement {
 	 * 
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
+	 * @returns { Generator<Card> } 经过过滤后的牌的生成器
 	 */
 	*iterableGetKnownCards(other, filter) {
 		if (!other) {
@@ -1380,7 +1380,7 @@ export class Player extends HTMLDivElement {
 	 * 
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Card[] } - 经过过滤后的牌的数组
+	 * @returns { Card[] } 经过过滤后的牌的数组
 	 */
 	getKnownCards(other, filter) {
 		return Array.from(this.iterableGetKnownCards(other, filter));
@@ -1425,7 +1425,7 @@ export class Player extends HTMLDivElement {
 	 * 
 	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { number } - 经过过滤后的牌的数量
+	 * @returns { number } 经过过滤后的牌的数量
 	 */
 	countKnownCards(other, filter) {
 		let count = 0;
@@ -5196,7 +5196,7 @@ export class Player extends HTMLDivElement {
 	 *
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
+	 * @returns { Generator<Card> } 经过过滤后的牌的生成器
 	 */
 	*iterableGetCards(position, filter) {
 		if (typeof position != "string") {
@@ -5362,7 +5362,7 @@ export class Player extends HTMLDivElement {
 	 *
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Card[] } - 经过过滤后的牌的数组
+	 * @returns { Card[] } 经过过滤后的牌的数组
 	 */
 	getCards(position, filter) {
 		return Array.from(this.iterableGetCards(position, filter));
@@ -5375,7 +5375,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行弃置的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
+	 * @returns { Generator<Card> } 经过过滤后的牌的生成器
 	 */
 	*iterableGetDiscardableCards(player, position, filter) {
 		for (const card of this.iterableGetCards(position, filter)) {
@@ -5390,7 +5390,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行弃置的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Card[] } - 经过过滤后的牌的数组
+	 * @returns { Card[] } 经过过滤后的牌的数组
 	 */
 	getDiscardableCards(player, position, filter) {
 		return Array.from(this.iterableGetDiscardableCards(player, position, filter));
@@ -5403,7 +5403,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
+	 * @returns { Generator<Card> } 经过过滤后的牌的生成器
 	 */
 	*iterableGetGainableCards(player, position, filter) {
 		for (const card of this.iterableGetCards(position, filter)) {
@@ -5418,7 +5418,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { Card[] } - 经过过滤后的牌的数组
+	 * @returns { Card[] } 经过过滤后的牌的数组
 	 */
 	getGainableCards(player, position, filter) {
 		return Array.from(this.iterableGetGainableCards(player, position, filter));
@@ -5436,7 +5436,7 @@ export class Player extends HTMLDivElement {
 	 *
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { number } - 经过过滤后的牌的数量
+	 * @returns { number } 经过过滤后的牌的数量
 	 */
 	countCards(position, filter) {
 		let count = 0;
@@ -5466,7 +5466,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行弃置的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { number } - 经过过滤后的牌的数量
+	 * @returns { number } 经过过滤后的牌的数量
 	 */
 	countDiscardableCards(player, position, filter) {
 		let count = 0;
@@ -5481,7 +5481,7 @@ export class Player extends HTMLDivElement {
 	 * @param { Player } player - 进行获取的角色
 	 * @param { string } [position="h"] - 牌区，h:手牌区，e:装备区，j:判定区，x:扩展区，s:特殊区(木牛流马牌的位置)
 	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
-	 * @returns { number } - 经过过滤后的牌的数量
+	 * @returns { number } 经过过滤后的牌的数量
 	 */
 	countGainableCards(player, position, filter) {
 		let count = 0;

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -16250,4 +16250,4 @@ export class Player extends HTMLDivElement {
 	}
 }
 
-CacheContext.inject(Player.prototype, ["hasCard", "hasValueTarget", "getModableSkills", "getCardIndex", "countCards", "getSkills", "getUseValue", "canUse"]);
+CacheContext.inject(Player.prototype, ["hasCard", "hasCards", "hasDiscardableCards", "hasGainableCards", "hasConnectedCards", "hasShownCards", "hasKnownCards", "isAllCardsKnown", "hasValueTarget", "getModableSkills", "getCardIndex", "countCards", "countDiscardableCards", "countGainableCards", "countConnectedCards", "countShownCards", "countKnownCards", "getSkills", "getUseValue", "canUse"]);

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -1329,78 +1329,87 @@ export class Player extends HTMLDivElement {
 		return this.hasCard(card => get.is.shownCard(card), "h");
 	}
 	/**
-	 * 获取该角色被other所知的牌
-	 * @param { Player } [other]
-	 * @param { (card: Card) => boolean } [filter]
+	 * 返回玩家手牌中被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）
+	 * 
+	 * 该方法返回一个生成器，需要返回数组请使用`Player#getKnownCards`
+	 * 
+	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { Generator<Card> } - 经过过滤后的牌的生成器
 	 */
-	getKnownCards(other = _status.event.player, filter = card => true) {
+	*iterableGetKnownCards(other, filter) {
 		if (!other) {
 			if (other === null) {
-				console.trace(`getKnownCards的other参数不应传入null,可以用void 0或undefined占位`);
+				console.trace("other参数不应传入null，可以用void 0或undefined占位；后续版本可能将不再检查，请及时更改！");
+			} else if (other !== undefined) {
+				console.trace("other参数不应传入假值（如false、0和空字符串）后续版本可能会废除该兼容，请及时更改！");
 			}
-			other = _status.event.player || this;
+			other = get.player() || this;
 		}
-		if (!filter) {
-			if (other === null) {
-				console.trace(`getKnownCards的filter参数不应传入null,可以用void 0或undefined占位`);
+		for (const card of this.iterableGetCards("h", filter)) {
+			if (card.isKnownBy(other)) {
+				yield card;
 			}
-			filter = card => true;
 		}
-		return this.getCards("h", card => {
-			return card.isKnownBy(other) && filter(card);
-		});
 	}
 	/**
-	 * 判断此角色的手牌是否已经被看光了
-	 * @param { Player } [other]
+	 * 返回玩家手牌中被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）
+	 * 
+	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { Card[] } - 经过过滤后的牌的数组
 	 */
-	isAllCardsKnown(other = _status.event.player) {
-		if (!other) {
-			if (other === null) {
-				console.trace(`isAllCardsKnown的other参数不应传入null,可以用void 0或undefined占位`);
-			}
-			other = _status.event.player || this;
-		}
-		if (!other) {
-			other = this;
-		}
-		return (
-			this.countCards("h", card => {
-				return !card.isKnownBy(other);
-			}) == 0
-		);
+	getKnownCards(other, filter) {
+		return Array.from(this.iterableGetKnownCards(other, filter));
 	}
 	/**
-	 * 判断此角色是否有被知的牌。
-	 * @param { Player } [other]
-	 * @param { (card: Card) => boolean } [filter]
+	 * 判断玩家手牌是否全部被给定角色所知，默认为当前事件的角色（不存在则改为自身）
+	 * 
+	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
+	 * @returns { boolean }
 	 */
-	hasKnownCards(other = _status.event.player, filter = card => true) {
+	isAllCardsKnown(other) {
 		if (!other) {
 			if (other === null) {
-				console.trace(`hasKnownCards的other参数不应传入null,可以用void 0或undefined占位`);
+				console.trace("other参数不应传入null，可以用void 0或undefined占位；后续版本可能将不再检查，请及时更改！");
+			} else if (other !== undefined) {
+				console.trace("other参数不应传入假值（如false、0和空字符串）后续版本可能会废除该兼容，请及时更改！");
 			}
-			other = _status.event.player || this;
+			other = get.player() || this;
 		}
-		if (!filter) {
-			if (other === null) {
-				console.trace(`hasKnownCards的filter参数不应传入null,可以用void 0或undefined占位`);
+		for (const card of this.iterableGetCards("h")) {
+			if (!card.isKnownBy(other)) {
+				return false;
 			}
-			filter = card => true;
 		}
-		return (
-			this.countCards("h", card => {
-				return card.isKnownBy(other) && filter(card);
-			}) > 0
-		);
+		return true;
 	}
 	/**
-	 * 数此角色被知道的牌
-	 * @param { Player } [other]
-	 * @param { (card: Card) => boolean } [filter]
+	 * 判断玩家手牌中是否有被给定角色所知的牌，默认为当前事件的角色（不存在则改为自身）
+	 *
+	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { boolean }
+	 */
+	hasKnownCards(other, filter) {
+		for (const _ of this.iterableGetKnownCards(other, filter)) {
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * 返回玩家手牌中被给定角色所知的牌的数量，默认为当前事件的角色（不存在则改为自身）
+	 * 
+	 * @param { Player } [other] - 作为观测者的玩家（即以该玩家为原点观察）
+	 * @param { string | string[] | Record<string, any> | ((card: Card) => boolean) } [filter] - 过滤条件，可以是牌名、牌名数组、属性对象或过滤函数
+	 * @returns { number } - 经过过滤后的牌的数量
 	 */
 	countKnownCards(other, filter) {
-		return this.getKnownCards(other, filter).length;
+		let count = 0;
+		for (const _ of this.iterableGetKnownCards(other, filter)) {
+			++count;
+		}
+		return count;
 	}
 	/**
 	 * Execute the delay card effect


### PR DESCRIPTION
- 新增 `Player#hasCards(position, filter)`，用于短路判断玩家指定牌区是否存在符合条件的牌。
  - 同时新增 `Player#hasDiscardableCards(player, position, filter)` 和 `Player#hasGainableCards(player, position, filter)`。
- 新增 `Player#iterableGetConnectedCards()`、`Player#iterableGetShownCards()`、`Player#iterableGetKnownCards(other, filter)`，为连接牌、明置牌、已知牌提供生成器形式的遍历接口。
- 将连接牌、明置牌、已知牌相关方法重构为基于 `iterableGetCards` 的统一实现。
- 将 `countConnectedCards`、`countShownCards`、`countKnownCards` 改为直接遍历计数，避免先生成数组。
- 将 `hasConnectedCards`、`hasShownCards`、`hasKnownCards` 改为短路判断，找到第一张符合条件的牌后立即返回。
- 将 `countExpansions(tag)` 改为通过 `countCards("x", ...)` 统计。
- 将 `hasExpansions(tag)` 改为通过 `hasCards("x", ...)` 短路判断。
- 扩展 `CacheContext.inject` 缓存列表，加入新增的 `has*` 方法以及部分 `count*` 方法。
- 补充和规范 `Player` 牌区相关 API 的 JSDoc。
- 修正 `getGainableCards` / `iterableGetGainableCards` 等方法中“弃置/获取”的参数说明。
- 统一 JSDoc 返回类型格式，并清理新增注释中的尾随空格。
- 调整 `iterableGetCards` 中 `h` / `s` 牌区的 `glows` 检查判断表达式，使逻辑含义更清晰。
- 顺带 resolve #3745 
---

**注意**：本次更改使得已知牌相关的函数在判断`filter`时，会先走一遍是否符合`filter`，再判断是否已知；以前是先判断是否已知，再判断`filter`；这会导致现在提供给`filter`的函数会出现未知牌。如果原先代码中存在直接从`filter`中编写逻辑的情况，则会导致相关函数退化会`get/count/hasCards`，需要适配

---

> 为什么要新增`Player#hasCards`

因为至少有人苦`Player#hasCard`参数位置久矣，~~包括我~~，而且无名杀已经有多个`hasXXXCards`，能起到形式上的统一

> `Player#hasCard`后续会废除吗

不知道，但如果要废除的话，我个人认为得统一废除流程，即一个大版本提醒废除，一个大版本移入兼容模式，一个大版本删除；假设1.12版本要开始废除，则1.12打上`@deprecated`标签，1.13移入兼容模式，1.14正式移除

> 为啥没有虚拟牌的修改

因为跟虚拟牌有关的主观上有点力竭（？）考虑到暂时没直接操作虚拟牌的需求，等未来重搞装备时再考虑重构