### PR TITLE
fix: 修正小虎【魅步】技能给【止息】未能持续一个回合的BUG

### DIFF
--- a/apps/core/character/mobile/skill.js
+++ b/apps/core/character/mobile/skill.js
@@ -13234,9 +13234,9 @@ const skills = {
 				var target = trigger.player;
 				var card = result.cards[0];
 				player.line(target, "green");
-				target.addTempSkills("mbzhixi", "phaseUseAfter");
+				target.addTempSkills("mbzhixi", "phaseEnd");
 				if (card.name != "sha" && !(get.type(card, "trick") == "trick" && get.color(card) == "black")) {
-					target.addTempSkill("new_meibu_range", "phaseUseAfter");
+					target.addTempSkill("new_meibu_range", "phaseEnd");
 					target.markAuto("new_meibu_range", player);
 				}
 				target.markSkillCharacter("mbmeibu", player, "魅步", "锁定技。出牌阶段，若你于此阶段使用过的牌数不小于X，你不能使用牌（X为你的体力值）；当你使用锦囊牌时，你结束此阶段。");


### PR DESCRIPTION
【魅步】给的【止息】只能持续一个出牌阶段而不是一整个回合与描述不符
导致面对【当先】类武将（拥有多个出牌阶段）乏力 