### PR TITLE
fix: 修正势于吉「道转」技能提示文案错误（“与”→“或”）

### DIFF
--- a/apps/core/character/bingshi/skill.js
+++ b/apps/core/character/bingshi/skill.js
@@ -4576,7 +4576,7 @@ const skills = {
 			prompt(links, player) {
 				let prompt = "将你";
 				if (_status.currentPhase?.isIn() && _status.currentPhase !== player) {
-					prompt += "与" + get.translation(_status.currentPhase);
+					prompt += "或" + get.translation(_status.currentPhase);
 				}
 				prompt += "的一张牌置入弃牌堆，";
 				return '###道转###<div class="text center">' + prompt + "视为使用" + (get.translation(links[0][3]) || "") + "【" + get.translation(links[0][2]) + "】</div>";
@@ -4595,7 +4595,7 @@ const skills = {
 						const goon = _status.currentPhase?.isIn() && _status.currentPhase !== player;
 						let prompt = "将你";
 						if (goon) {
-							prompt += "与" + get.translation(_status.currentPhase);
+							prompt += "或" + get.translation(_status.currentPhase);
 						}
 						prompt += "的一张牌置入弃牌堆";
 						let dialog = ["道转：" + prompt];


### PR DESCRIPTION
势于吉「道转」技能描述为：
```
potdaozhuan_info: "每回合限一次，你可以将你或者当前回合角色的一张牌置入弃牌堆，视为使用一张基本牌（每轮每种牌名限一次）。若当前回合角色因此失去了牌，则本轮此技能失效。",
```

原提示文案为：
> 将你与[当前回合角色]的一张牌置入弃牌堆

根据技能描述，应当修改为：
> 将你**或**[当前回合角色]的一张牌置入弃牌堆