### PR TITLE
feat: 令getIndex支持返回任意可迭代对象

### DIFF
--- a/apps/core/noname/library/element/gameEvent.ts
+++ b/apps/core/noname/library/element/gameEvent.ts
@@ -9,7 +9,7 @@ type triggerSkillTodo = {
 	skill: string;
 	player: Player;
 	priority: number;
-	indexedData?: Player | true;
+	indexedData?: any;
 };
 type triggerPlayerTodo = {
 	player: Player | "firstDo" | "lastDo";
@@ -360,61 +360,62 @@ export class GameEvent implements PromiseLike<void> {
 			const firstDo = evt.doingList.find(i => i.player === "firstDo");
 			const lastDo = evt.doingList.find(i => i.player === "lastDo");
 
-			skills.forEach(skill => {
+			for (const skill of skills) {
 				const info = lib.skill[skill];
 				if (!info.trigger) {
-					return;
+					continue;
 				}
 				if (
 					!Object.keys(info.trigger).some(i => {
-						if (Array.isArray(info.trigger[i])) {
+						if (Array.isArray(info.trigger?.[i])) {
 							return info.trigger[i].includes(evt.triggername);
 						}
-						return info.trigger[i] === evt.triggername;
+						return info.trigger?.[i] === evt.triggername;
 					})
 				) {
-					return;
+					continue;
 				}
 				let toadds: triggerSkillTodo[] = [];
+				const priority = get.priority(skill)
 				if (typeof info.getIndex === "function") {
-					const indexedResult = info.getIndex(evt.getTrigger(), player, evt.triggername);
-					if (Array.isArray(indexedResult)) {
-						indexedResult.forEach(indexedData => {
-							toadds.push({
-								skill: skill,
-								player: player,
-								priority: get.priority(skill),
-								indexedData,
-							});
-						});
-					} else if (typeof indexedResult === "number" && indexedResult > 0) {
+					const indexedResult = info.getIndex<any>(evt.getTrigger(), player, evt.triggername);
+					if (typeof indexedResult === "number") {
 						for (let i = 0; i < indexedResult; i++) {
 							toadds.push({
-								skill: skill,
-								player: player,
-								priority: get.priority(skill),
+								skill,
+								player,
+								priority,
 								indexedData: true,
+							});
+						}
+					} else if (indexedResult != null && typeof indexedResult !== "string" && typeof indexedResult[Symbol.iterator] === "function") {
+						for (const indexedData of indexedResult) {
+							toadds.push({
+								skill,
+								player,
+								priority,
+								indexedData,
 							});
 						}
 					}
 				} else {
 					toadds.push({
-						skill: skill,
-						player: player,
-						priority: get.priority(skill),
+						skill,
+						player,
+						priority,
 					});
 				}
 				const map = info.firstDo ? firstDo : info.lastDo ? lastDo : doing;
 				if (!map) {
-					return;
+					continue;
 				}
 				for (const toadd of toadds) {
 					if (!toadd.indexedData) {
 						if (map.doneList.some(i => i.skill === toadd.skill && i.player === toadd.player)) {
-							return;
+							continue;
 						}
 						if (map.todoList.some(i => i.skill === toadd.skill && i.player === toadd.player)) {
-							return;
+							continue;
 						}
 					}
 					map.todoList.add(toadd);
@@ -424,7 +425,7 @@ export class GameEvent implements PromiseLike<void> {
 				} else {
 					map.todoList.sort((a, b) => b.priority - a.priority);
 				}
-			});
+			};
 		}
 	}
 	removeTrigger(skills, player) {
@@ -537,26 +538,27 @@ export class GameEvent implements PromiseLike<void> {
 
 					const info = lib.skill[skill];
 					const list = info.firstDo ? firstDo.todoList : info.lastDo ? lastDo.todoList : this.todoList;
+					const priority = get.priority(skill);
 					if (typeof info.getIndex === "function") {
-						const indexedResult = info.getIndex(event, player, name);
-						if (Array.isArray(indexedResult)) {
-							indexedResult.forEach(indexedData => {
-								list.push({
-									skill: skill,
-									player: this.player,
-									priority: get.priority(skill),
-									indexedData,
-								});
-							});
-						} else if (typeof indexedResult === "number" && indexedResult > 0) {
+						const indexedResult = info.getIndex<any>(event, player, name);
+						if (typeof indexedResult === "number") {
 							for (let i = 0; i < indexedResult; i++) {
 								list.push({
-									skill: skill,
+									skill,
 									player: this.player,
-									priority: get.priority(skill),
+									priority,
 									indexedData: true,
 								});
 							}
+						} else if (indexedResult != null && typeof indexedResult !== "string" && typeof indexedResult[Symbol.iterator] === "function") {
+							for (const indexedData of indexedResult) {
+								list.push({
+									skill,
+									player: this.player,
+									priority,
+									indexedData,
+								});
+							};
 						}
 					} else {
 						list.push({

--- a/apps/core/typings/Skill.d.ts
+++ b/apps/core/typings/Skill.d.ts
@@ -1478,8 +1478,7 @@ declare interface Skill {
 	 * 而对于一些牌移动事件的技能而言，不仅要“多次发动”，每次发动时还都有不同的目标，
 	 * 比如伊籍的【急援】，可能会出现“同时将一些牌交给了多名角色”的情况。
 	 * 
-	 * 如果返回值为数组或任意可遍历对象，则会分别结算每个目标；目标将存放在`event.indexedData`中，供cost和content使用；
-	 * 如果返回值为数字，`event.indexedData`则会存放“现在是第x次发动该技能”，可用于简化一些情况。
+	 * 如果返回值为数组或任意可遍历对象，则会分别结算每个目标；目标将存放在`event.indexedData`中，供cost和content使用。
 	 */
 	getIndex?<T>(event: GameEvent, player: Player, triggername: string): number | Iterable<T>;
 

--- a/apps/core/typings/Skill.d.ts
+++ b/apps/core/typings/Skill.d.ts
@@ -1473,15 +1473,15 @@ declare interface Skill {
 	 * 
 	 * 现在，无名杀的“按点卖血”技能可以和OL线上一样，在同时触发多个技能时，自选技能的顺序了。
 	 * 
-	 * 用例见郭嘉【遗计】
+	 * 用例见郭嘉【遗计】。
 	 * 
-	 * 而对于一些牌移动事件的技能而言，不仅要“多次发动”，每次发动时还都有不同的目标。
+	 * 而对于一些牌移动事件的技能而言，不仅要“多次发动”，每次发动时还都有不同的目标，
+	 * 比如伊籍的【急援】，可能会出现“同时将一些牌交给了多名角色”的情况。
 	 * 
-	 * 比如伊籍的【急援】，可能会出现“同时将一些牌交给了多名角色”的情况
-	 * 
-	 * 如果返回值为数组，则会遍历数组，分别结算每个目标；目标将存放在`event.indexedData`中，供cost和content使用；
+	 * 如果返回值为数组或任意可遍历对象，则会分别结算每个目标；目标将存放在`event.indexedData`中，供cost和content使用；
+	 * 如果返回值为数字，`event.indexedData`则会存放“现在是第x次发动该技能”，可用于简化一些情况。
 	 */
-	getIndex?: (event, player, triggername) => number | any[];
+	getIndex?<T>(event: GameEvent, player: Player, triggername: string): number | Iterable<T>;
 
 	/**
 	 * 持恒技


### PR DESCRIPTION
或许你说得对，但无名杀是一款支持高度DIY的，基于GPL协议开源的卡牌游戏框架，因此在兼容性没啥影响甚至性能也没啥影响的情况下，将数组扩充至任意可迭代对象似乎并不是什么不应该的事。

不过目前仍会排除字符串类型。虽然从语义上来说，字符串也属于可迭代对象，这样的处理未必绝对合理，但考虑到许多针对`Iterable`的实现都会特意排除字符串，为了避免某些场景下有人曾在`getIndex`中返回字符串而导致兼容性问题，这里也一并将字符串排除在外。