### PR TITLE
build: 重构编译脚本；统一武将包/卡牌包/模式的编译过程

### DIFF
--- a/apps/core/scripts/build.ts
+++ b/apps/core/scripts/build.ts
@@ -17,7 +17,7 @@ const root = join(import.meta.dirname, "..");
 async function main() {
 	/**
 	 * 编译目标
-	 * 
+	 *
 	 * 目前无名杀的目标为`Chromium >= 91 || Safari >=16.4.0`
 	 */
 	const target = ["chrome91", "safari16.4"];
@@ -51,7 +51,7 @@ async function main() {
 
 	/**
 	 * 需要脱离本体单独输出的包体，无名杀中即为武将包、卡牌包和模式
-	 * 
+	 *
 	 * Individual译为“个体”，不过此处只是找个后续不太用得上的单词
 	 * 
 	 * `false`表示暂未存在可以构建的文件，后续会直接复制

--- a/apps/core/scripts/build.ts
+++ b/apps/core/scripts/build.ts
@@ -8,11 +8,23 @@ import jit from "@noname/jit";
 import { moderned_characters } from "../game/config.json";
 const root = join(import.meta.dirname, "..");
 
+/**
+ * 构建脚本入口。
+ *
+ * 负责收集本体构建需要复制的静态资源、各类单独构建包体的入口，
+ * 然后依次执行本体构建和包体构建。
+ */
 async function main() {
-	// 编译目标，目前无名杀的目标为Chromium >= 91 || Safari >=16.4.0
+	/**
+	 * 编译目标
+	 * 
+	 * 目前无名杀的目标为`Chromium >= 91 || Safari >=16.4.0`
+	 */
 	const target = ["chrome91", "safari16.4"];
 
-	// 无名杀所使用的导入映射（import map，翻译来源MDN）
+	/**
+	 * 无名杀所使用的导入映射（import map，翻译来源MDN）
+	 */
 	const importMap: Record<string, string> = {
 		noname: "/noname.js",
 		vue: "vue/dist/vue.esm-browser.js",
@@ -21,7 +33,9 @@ async function main() {
 		// jszip: "jszip",
 	};
 
-	// 编译过程需要直接复制的文件
+	/**
+	 * 本体编译过程需要直接复制的文件
+	 */
 	const staticModules: Target[] = [
 		// { src: "character", dest: "" },
 		// { src: "card", dest: "" },
@@ -35,7 +49,13 @@ async function main() {
 		{ src: "noname.js", dest: "src" },
 	];
 
-	// 需要单独构建的包体，false表示暂未存在可以构建的文件，后续会直接复制
+	/**
+	 * 需要脱离本体单独输出的包体，无名杀中即为武将包、卡牌包和模式
+	 * 
+	 * Individual译为“个体”，不过此处只是找个后续不太用得上的单词
+	 * 
+	 * `false`表示暂未存在可以构建的文件，后续会直接复制
+	 */
 	const individuals: Record<IndividualType, false | IndividualContent[]> = {
 		character: [],
 		mode: [{ name: "identity", index: "mode/identity.js", moderned: false }],
@@ -72,7 +92,7 @@ async function main() {
 	// 编译无名杀本体
 	await buildSelf(target, importMap, staticModules);
 
-	// 编译单独包体
+	// 编译脱离本体单独输出的包体
 	for (const [type, content] of Object.entries(individuals)) {
 		if (content === false) {
 			continue;
@@ -84,7 +104,7 @@ async function main() {
 			input[name] = index;
 		}
 
-		// 构建需要单独复制的文件
+		// 获取需要单独复制的文件
 		const copies: Target[] = [];
 		for (const file of readdirSync(join(root, type))) {
 			if (getEntryName(file) in input) {
@@ -98,6 +118,13 @@ async function main() {
 	}
 }
 
+/**
+ * 构建无名杀本体。
+ *
+ * @param target Vite/Rollup的浏览器编译目标
+ * @param importMap 写入最终产物的导入映射
+ * @param copies 本体构建阶段需要直接复制到dist的文件
+ */
 async function buildSelf(target: string | string[], importMap: Record<string, string>, copies: Target[]) {
 	// 继承vite.config.ts
 	// 合并会导致开发服务器依赖失效
@@ -133,6 +160,15 @@ async function buildSelf(target: string | string[], importMap: Record<string, st
 	});
 }
 
+/**
+ * 构建需要脱离本体单独输出的包体。
+ *
+ * @param type 包体类型，同时也是输出目录名
+ * @param target Vite/Rollup的浏览器编译目标
+ * @param input Rollup入口配置，key会成为最终输出文件名
+ * @param importMap 用于决定哪些依赖在单独构建时保持外部引用
+ * @param copies 单独构建阶段需要原样复制的同类包体
+ */
 async function buildIndividual(type: string, target: string | string[], input: Record<string, string>, importMap: Record<string, string>, copies: Target[]) {
 	await build({
 		build: {
@@ -164,16 +200,30 @@ async function buildIndividual(type: string, target: string | string[], input: R
 	});
 }
 
-function getEntryName(file: string) {
+/**
+ * 从顶层文件或目录名中取得可与Rollup入口配置对比的入口名。
+ *
+ * @example
+ * getEntryName("identity.js") // "identity"
+ * getEntryName("guozhan") // "guozhan"
+ */
+function getEntryName(file: string): string {
 	return file.replace(/\.(js|ts)$/, "");
 }
 
+/** 支持按包体维度处理的目录类型。 */
 type IndividualType = "character" | "card" | "mode";
 
+/** 单个需要独立构建的包体配置。 */
 interface IndividualContent {
+	/** 包体名称，同时作为 Rollup input 的 key 使用。 */
 	name: string;
+	/** 包体入口文件，使用相对于 apps/core 的路径。 */
 	index: string;
+	/** 是否属于已经现代化为目录入口的包体。 */
 	moderned: boolean;
 }
 
-await main();
+if (import.meta.main) {
+	await main();
+}

--- a/apps/core/scripts/build.ts
+++ b/apps/core/scripts/build.ts
@@ -1,7 +1,6 @@
 import { build } from "vite";
-import { join } from "path";
-import { moveSync } from "fs-extra/esm";
-import { existsSync, readdirSync, rmdirSync } from "fs";
+import { join, dirname } from "path";
+import { existsSync, readdirSync } from "fs";
 import { Target, viteStaticCopy } from "vite-plugin-static-copy";
 import generateImportMap from "./vite-plugin-importmap";
 import jit from "@noname/jit";
@@ -9,110 +8,172 @@ import jit from "@noname/jit";
 import { moderned_characters } from "../game/config.json";
 const root = join(import.meta.dirname, "..");
 
-const target = ["chrome91", "safari16.4"];
-const importMap: Record<string, string> = {
-	noname: "/noname.js",
-	vue: "vue/dist/vue.esm-browser.js",
-	"pinyin-pro": "pinyin-pro",
-	dedent: "dedent",
-	// jszip: "jszip",
-};
+async function main() {
+	// 编译目标，目前无名杀的目标为Chromium >= 91 || Safari >=16.4.0
+	const target = ["chrome91", "safari16.4"];
 
-const staticModules: Target[] = [
-	// { src: "character", dest: "" },
-	{ src: "card", dest: "" },
-	{ src: "mode", dest: "" },
-	{ src: "layout", dest: "" },
-	{ src: "font", dest: "" },
-	{ src: "theme", dest: "" },
-	{ src: "game", dest: "" },
-	{ src: "noname", dest: "src" },
-	{ src: "typings", dest: "src" },
-	{ src: "noname.js", dest: "src" },
-];
+	// 无名杀所使用的导入映射（import map，翻译来源MDN）
+	const importMap: Record<string, string> = {
+		noname: "/noname.js",
+		vue: "vue/dist/vue.esm-browser.js",
+		"pinyin-pro": "pinyin-pro",
+		dedent: "dedent",
+		// jszip: "jszip",
+	};
 
-const charaDist = join(root, "character");
-const charaInputs: Record<string, string> = {};
-const charaCopys: Target[] = [];
-for (const file of readdirSync(charaDist)) {
-	if (moderned_characters.includes(file)) {
-		// 考虑后续可能存在的ts版本，优先使用ts文件
-		const ts = existsSync(join(charaDist, file, "index.ts"));
-		// 依照vite入口规范，使用相对于根目录的路径作为输入
-		// 后续可直接用于vite的input配置，无需再进行路径转换
-		charaInputs[file] = `character/${file}/index.${ts ? "ts" : "js"}`;
-		staticModules.push({
-			src: `character/${file}`,
-			dest: "src/character",
+	// 编译过程需要直接复制的文件
+	const staticModules: Target[] = [
+		// { src: "character", dest: "" },
+		// { src: "card", dest: "" },
+		// { src: "mode", dest: "" },
+		{ src: "layout", dest: "" },
+		{ src: "font", dest: "" },
+		{ src: "theme", dest: "" },
+		{ src: "game", dest: "" },
+		{ src: "noname", dest: "src" },
+		{ src: "typings", dest: "src" },
+		{ src: "noname.js", dest: "src" },
+	];
+
+	// 需要单独构建的包体，false表示暂未存在可以构建的文件，后续会直接复制
+	const individuals: Record<IndividualType, false | IndividualContent[]> = {
+		character: [],
+		mode: [{ name: "identity", index: "mode/identity.js", moderned: false }],
+		card: false,
+	};
+
+	// #3446 - 通过moderned_characters配置更新character内容
+	for (const name of moderned_characters) {
+		let index = `character/${name}/index.ts`
+		if (!existsSync(join(root, index))) {
+			index = `character/${name}/index.js`;
+		}
+		(<IndividualContent[]>individuals.character).push({
+			name,
+			index,
+			moderned: true,
 		});
-		continue;
 	}
-	// 剩下的武将包未完成进行异步化，可能仍然存在step content，故直接复制
-	// 此外，该过程也会将位于character文件夹的单文件复制过去
-	charaCopys.push({ src: `character/${file}`, dest: "" });
+
+	// 将单独构建的包体全部复制到dist/src中，直接复制的包体直接复制
+	for (const [type, content] of Object.entries(individuals)) {
+		if (content === false) {
+			staticModules.push({ src: type, dest: "" });
+			continue;
+		}
+
+		for (const { index, moderned } of content) {
+			const src = moderned ? dirname(index) : index;
+			const dest = `src/${type}`;
+			staticModules.push({ src, dest });
+		}
+	}
+
+	// 编译无名杀本体
+	await buildSelf(target, importMap, staticModules);
+
+	// 编译单独包体
+	for (const [type, content] of Object.entries(individuals)) {
+		if (content === false) {
+			continue;
+		}
+
+		// 构建vite编译输入
+		const input: Record<string, string> = {};
+		for (const { name, index } of content) {
+			input[name] = index;
+		}
+
+		// 构建需要单独复制的文件
+		const copies: Target[] = [];
+		for (const file of readdirSync(join(root, type))) {
+			if (getEntryName(file) in input) {
+				continue;
+			}
+
+			copies.push({ src: `${type}/${file}`, dest: "" });
+		}
+
+		await buildIndividual(type, target, input, importMap, copies);
+	}
 }
 
-// 打包无名杀本体
-// 继承vite.config.ts
-// 合并会导致开发服务器依赖失效
-await build({
-	build: {
-		target,
-		sourcemap: false,
-		minify: false,
-		rollupOptions: {
-			preserveEntrySignatures: "strict",
-			treeshake: false,
-			external: ["vue"],
-			input: {
-				index: "index.html",
-				noname: "noname.js",
-			},
-			output: {
-				preserveModules: true, // 保留文件结构
-				preserveModulesRoot: "./",
+async function buildSelf(target: string | string[], importMap: Record<string, string>, copies: Target[]) {
+	// 继承vite.config.ts
+	// 合并会导致开发服务器依赖失效
+	await build({
+		build: {
+			target,
+			sourcemap: false,
+			minify: false,
+			rollupOptions: {
+				preserveEntrySignatures: "strict",
+				treeshake: false,
+				external: ["vue"],
+				input: {
+					index: "index.html",
+					noname: "noname.js",
+				},
+				output: {
+					preserveModules: true, // 保留文件结构
+					preserveModulesRoot: "./",
 
-				// 去掉 hash
-				entryFileNames: "[name].js", // 入口文件
-				chunkFileNames: "[name].js", // 代码分块
-				assetFileNames: "[name][extname]", // 静态资源
-			},
-			onwarn(warning, warn) {
-				if (warning.code === "CYCLIC_CROSS_CHUNK_REEXPORT") return;
-				warn(warning);
+					// 去掉 hash
+					entryFileNames: "[name].js", // 入口文件
+					chunkFileNames: "[name].js", // 代码分块
+					assetFileNames: "[name][extname]", // 静态资源
+				},
+				onwarn(warning, warn) {
+					if (warning.code === "CYCLIC_CROSS_CHUNK_REEXPORT") return;
+					warn(warning);
+				},
 			},
 		},
-	},
-	plugins: [viteStaticCopy({ targets: staticModules }), generateImportMap(importMap), jit()],
-});
+		plugins: [viteStaticCopy({ targets: copies }), generateImportMap(importMap), jit()],
+	});
+}
 
-// 打包武将包
-// 由于武将包拥有更多的“外部包”，且最终需要打包成单文件，因此需要单独构建
-await build({
-	build: {
-		target,
-		sourcemap: false,
-		minify: false,
-		outDir: `dist/character`,
-		rollupOptions: {
-			preserveEntrySignatures: "strict",
-			treeshake: true,
-			external: Object.keys(importMap),
-			input: charaInputs,
-			output: {
-				preserveModules: false,
-				preserveModulesRoot: "./",
+async function buildIndividual(type: string, target: string | string[], input: Record<string, string>, importMap: Record<string, string>, copies: Target[]) {
+	await build({
+		build: {
+			target,
+			sourcemap: false,
+			minify: false,
+			outDir: `dist/${type}`,
+			rollupOptions: {
+				preserveEntrySignatures: "strict",
+				treeshake: true,
+				external: Object.keys(importMap),
+				input,
+				output: {
+					preserveModules: false,
+					preserveModulesRoot: "./",
 
-				// 去掉 hash
-				entryFileNames: "[name].js", // 入口文件
-				chunkFileNames: "[name].js", // 代码分块
-				assetFileNames: "[name][extname]", // 静态资源
-			},
-			onwarn(warning, warn) {
-				if (warning.code === "CYCLIC_CROSS_CHUNK_REEXPORT") return;
-				warn(warning);
+					// 去掉 hash
+					entryFileNames: "[name].js", // 入口文件
+					chunkFileNames: "[name].js", // 代码分块
+					assetFileNames: "[name][extname]", // 静态资源
+				},
+				onwarn(warning, warn) {
+					if (warning.code === "CYCLIC_CROSS_CHUNK_REEXPORT") return;
+					warn(warning);
+				},
 			},
 		},
-	},
-	plugins: [viteStaticCopy({ targets: charaCopys })],
-});
+		plugins: [viteStaticCopy({ targets: copies })],
+	});
+}
+
+function getEntryName(file: string) {
+	return file.replace(/\.(js|ts)$/, "");
+}
+
+type IndividualType = "character" | "card" | "mode";
+
+interface IndividualContent {
+	name: string;
+	index: string;
+	moderned: boolean;
+}
+
+await main();

--- a/apps/core/scripts/build.ts
+++ b/apps/core/scripts/build.ts
@@ -33,6 +33,7 @@ const staticModules: Target[] = [
 
 const charaDist = join(root, "character");
 const charaInputs: Record<string, string> = {};
+const charaCopys: Target[] = [];
 for (const file of readdirSync(charaDist)) {
 	if (moderned_characters.includes(file)) {
 		// 考虑后续可能存在的ts版本，优先使用ts文件
@@ -48,7 +49,7 @@ for (const file of readdirSync(charaDist)) {
 	}
 	// 剩下的武将包未完成进行异步化，可能仍然存在step content，故直接复制
 	// 此外，该过程也会将位于character文件夹的单文件复制过去
-	staticModules.push({ src: `character/${file}`, dest: "character" });
+	charaCopys.push({ src: `character/${file}`, dest: "" });
 }
 
 // 打包无名杀本体
@@ -92,8 +93,7 @@ await build({
 		target,
 		sourcemap: false,
 		minify: false,
-		// 由于outDir会被清空，因此先输出到临时目录，待打包完成后再移动到最终目录
-		outDir: `dist/character/.tmp`,
+		outDir: `dist/character`,
 		rollupOptions: {
 			preserveEntrySignatures: "strict",
 			treeshake: true,
@@ -114,12 +114,5 @@ await build({
 			},
 		},
 	},
+	plugins: [viteStaticCopy({ targets: charaCopys })],
 });
-// 移动武将包打包结果
-const distChara = join(root, "dist/character");
-const tmp = join(distChara, ".tmp");
-for (const file of readdirSync(tmp)) {
-	moveSync(join(tmp, file), join(distChara, file));
-}
-// 现在tmp目录应该为空，如果仍有文件说明存在异常情况，使用rmdirSync而非rmSync以即使发现问题
-rmdirSync(tmp);


### PR DESCRIPTION
由于身份模式已经重写了所有的step content，因此身份模式成为了第一个可编译的文件，为了防止content未编译导致使用vite特性无法被生产环境使用的惨状，于是增加模式的编译流程。

因为后续卡牌包必然也将得到编译，且武将包、卡牌包和模式的编译过程几乎一致，于是重构了编译脚本，使得三者都走同一个编译过程，且使整个编译脚本更加可读（大概）

本次重构优化了编译文件和非编译文件的流程，即将需要复制的文件放在编译包体时的build配置中，因此不再需要.tmp作为临时目录，也省去了后续的移动工作；同时，由于目前卡牌包暂未重写step content，因此卡牌包仍直接复制粘贴

最后顺手用了并非最新最热的`import.meta.main`，Node.js版本最低要求v24.2.0/v22.18.0，希望大家都能用上最新最热的Node.js，~~当然想用Deno.js和Bun.js也不是不行~~
