### PR TITLE
ci: 增加Release工作流，在push tag时自动打包并创建发行版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VER="${TAG#v}"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VER=$VER" >> "$GITHUB_ENV"
+
+      - name: Build core package
+        shell: bash
+        run: |
+          mkdir -p release
+          pnpm generateTestPack
+          cd output/testpack
+          7z a ../../release/noname.core.zip *
+
+      - name: Build full package
+        shell: bash
+        run: |
+          cd dist
+          7z a ../release/noname.full.zip *
+
+      - name: Build Windows installer
+        shell: bash
+        run: |
+          pnpm -F @noname/electron build:win
+          EXE="$(find output -maxdepth 1 -name '*.exe' | head -n 1)"
+          cp "$EXE" "release/noname.Setup.${VER}.exe"
+
+      - name: Create GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$TAG" \
+            "release/noname.core.zip" \
+            "release/noname.full.zip" \
+            "release/noname.Setup.${VER}.exe" \
+            --title "$TAG" \
+            --notes-file apps/core/game/updateLog.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,27 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          gh release create "$TAG" \
+          --title "$TAG" \
+          --notes-file apps/core/game/updateLog.md \
+          --draft
+
   build-packages:
     name: Build Packages
+    needs: create-release
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +46,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -44,17 +63,20 @@ jobs:
           cd ../../../dist
           7z a ../release/noname.full.zip *
 
-      - name: Upload Temporary Packages
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-packages
-          path: |
-            release/noname.core.zip
-            release/noname.full.zip
-          retention-days: 1
+      - name: Upload packages to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          gh release upload "$TAG" \
+          release/noname.core.zip \
+          release/noname.full.zip \
+          --clobber
 
   build-installer:
     name: Build Installer
+    needs: create-release
     runs-on: windows-latest
 
     steps:
@@ -71,7 +93,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -92,12 +114,16 @@ jobs:
           EXE="$(find output -maxdepth 1 -name '*.exe' | head -n 1)"
           cp "$EXE" "release/noname.Setup.${VER}.exe"
 
-      - name: Upload Temporary Installer
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-installer
-          path: release/*.exe
-          retention-days: 1
+      - name: Upload installer to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          gh release upload "$TAG" \
+          "release/noname.Setup.${VER}.exe" \
+          --clobber
 
   release:
     name: Release Version
@@ -110,22 +136,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Download Temporary Files
-        uses: actions/download-artifact@v7
-        with:
-          path: release
-          merge-multiple: true
-
-      - name: Create GitHub Release
+      - name: Publish GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
 
-          gh release create "$TAG" \
-            "release/noname.core.zip" \
-            "release/noname.full.zip" \
-            "release/noname.Setup.*.exe" \
-            --title "$TAG" \
-            --notes-file apps/core/game/updateLog.md
+          gh release edit "$TAG" --draft=false
+
+  cleanup-release:
+    name: Clean Draft When Failure
+    if: ${{ failure() }}
+    needs:
+      - create-release
+      - build-packages
+      - build-installer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete draft release on failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "$GITHUB_REF_NAME" --yes --cleanup-tag=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,52 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  build-packages:
+    name: Build Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core and full packages
+        shell: bash
+        run: |
+          mkdir -p release
+          pnpm generateTestPack
+
+          cd output/testpack
+          7z a ../../release/noname.core.zip *
+
+          cd ../../dist
+          7z a ../release/noname.full.zip *
+
+      - name: Upload Temporary Packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-packages
+          path: |
+            release/noname.core.zip
+            release/noname.full.zip
+          retention-days: 1
+
+  build-installer:
+    name: Build Installer
     runs-on: windows-latest
 
     steps:
@@ -34,40 +79,53 @@ jobs:
       - name: Prepare version
         shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VER="${TAG#v}"
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          VER="${GITHUB_REF_NAME#v}"
           echo "VER=$VER" >> "$GITHUB_ENV"
-
-      - name: Build core package
-        shell: bash
-        run: |
-          mkdir -p release
-          pnpm generateTestPack
-          cd output/testpack
-          7z a ../../release/noname.core.zip *
-
-      - name: Build full package
-        shell: bash
-        run: |
-          cd dist
-          7z a ../release/noname.full.zip *
 
       - name: Build Windows installer
         shell: bash
         run: |
+          mkdir -p release
+          pnpm build
+
           pnpm -F @noname/electron build:win
           EXE="$(find output -maxdepth 1 -name '*.exe' | head -n 1)"
           cp "$EXE" "release/noname.Setup.${VER}.exe"
+
+      - name: Upload Temporary Installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-installer
+          path: release/*.exe
+          retention-days: 1
+
+  release:
+    name: Release Version
+    runs-on: ubuntu-latest
+    needs:
+      - build-packages
+      - build-installer
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download Temporary Files
+        uses: actions/download-artifact@v7
+        with:
+          path: release
+          merge-multiple: true
 
       - name: Create GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          TAG="${GITHUB_REF_NAME}"
+
           gh release create "$TAG" \
             "release/noname.core.zip" \
             "release/noname.full.zip" \
-            "release/noname.Setup.${VER}.exe" \
+            "release/noname.Setup.*.exe" \
             --title "$TAG" \
             --notes-file apps/core/game/updateLog.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
         shell: bash
         run: |
           mkdir -p release
-          pnpm generateTestPack
+          pnpm build
 
-          cd output/testpack
-          7z a ../../release/noname.core.zip *
+          cd apps/core/dist
+          7z a ../../../release/noname.core.zip *
 
-          cd ../../dist
+          cd ../../../dist
           7z a ../release/noname.full.zip *
 
       - name: Upload Temporary Packages


### PR DESCRIPTION
为了避免上传悲剧，我们需要自动发版

理论上现在可以考虑macOS和linux下的版本构建，但我没接触过，暂时先不维护了