### PR TITLE
fix: ignore rejected background music playback

### DIFF
--- a/apps/core/noname/init/cordova.js
+++ b/apps/core/noname/init/cordova.js
@@ -48,7 +48,7 @@ export default async function cordovaReady({ lib, game, get, _status, ui }) {
 		});
 		document.addEventListener("resume", () => {
 			if (ui.backgroundMusic && !isNaN(ui.backgroundMusic.duration)) {
-				ui.backgroundMusic.play();
+				Promise.resolve(ui.backgroundMusic.play()).catch(() => void 0);
 			}
 		});
 		document.addEventListener("backbutton", function () {

--- a/apps/core/noname/library/element/content.ts
+++ b/apps/core/noname/library/element/content.ts
@@ -1586,7 +1586,7 @@ export const Content: Record<string, ContentFuncByAll | ContentFuncsByAll> = {
 						ui.roundmenu.style.display = "";
 					}
 					if (ui.backgroundMusic && !isNaN(ui.backgroundMusic.duration)) {
-						ui.backgroundMusic.play();
+						Promise.resolve(ui.backgroundMusic.play()).catch(() => void 0);
 					}
 					hitsound_audio.remove();
 					resolve({
@@ -1821,7 +1821,7 @@ export const Content: Record<string, ContentFuncByAll | ContentFuncsByAll> = {
 					dialog.close();
 				}
 				if (ui.backgroundMusic && !isNaN(ui.backgroundMusic.duration)) {
-					ui.backgroundMusic.play();
+					Promise.resolve(ui.backgroundMusic.play()).catch(() => void 0);
 				}
 			},
 			event.videoId,

--- a/apps/core/noname/ui/create/index.js
+++ b/apps/core/noname/ui/create/index.js
@@ -2466,7 +2466,7 @@ export class Create {
 			lib.config.touchscreen ? "touchend" : "click",
 			() => {
 				if (!ui.backgroundMusic.played.length && lib.config.background_music != "music_off" && !isNaN(ui.backgroundMusic.duration)) {
-					ui.backgroundMusic.play();
+					Promise.resolve(ui.backgroundMusic.play()).catch(() => void 0);
 				}
 			},
 			{ once: true }


### PR DESCRIPTION
## Summary
- catch rejected background music playback promises
- prevent mobile browsers from surfacing autoplay NotAllowedError through the global error dialog

## Test
- pnpm -r lint