### PR TITLE
fix: reset moyou trigger counter

### DIFF
--- a/apps/core/character/xianding/skill.js
+++ b/apps/core/character/xianding/skill.js
@@ -8168,7 +8168,9 @@ const skills = {
 			player: "useCardAfter",
 		},
 		filter(event, player) {
-			return player.countMark("dcsbmoyou_count") >= 2;
+			const used = player.getHistory("useCard", evt => !evt.skill || !evt.skill.startsWith("dcsbmoyou")).length;
+			const fired = player.getHistory("useSkill", evt => evt.skill == "dcsbmoyou").length;
+			return used - 2 * fired >= 2;
 		},
 		check: () => true,
 		async content(event, trigger, player) {


### PR DESCRIPTION
## Summary

谟猷 (`dcsbmoyou`) now re-offers its prompt on every subsequent card use after the player declines it, instead of only re-prompting once the player has accumulated another full pair of card uses.

## Why this matters

Issue #3814 reports that 谟猷's release timing does not match the official settlement. The skill should trigger after the player uses two cards; once that threshold is reached and the player declines, each later single card use should re-offer the prompt. The current code resets the use tally whenever the trigger resolves, so after a decline the prompt only reappears after two more cards are used.

The root cause is that eligibility was gated on a clearable `dcsbmoyou_count` mark (`countMark("dcsbmoyou_count") >= 2`). Because the threshold check works off that mark, a decline does not advance the player toward the next prompt in a way that matches play, and the cadence collapses to "every even number of cards" rather than "every card after the first decline". As the collaborator noted on the issue, the correct approach is to read from use history.

## Changes

`apps/core/character/xianding/skill.js`, `dcsbmoyou` filter only:

- Derive eligibility from the current turn's `useCard` history rather than the clearable mark.
- `used` = this turn's qualifying card uses (excluding cards used by 谟猷 itself, matching the existing `count` sub-skill filter).
- `fired` = this turn's count of `dcsbmoyou` resolutions (read from `useSkill` history, so only accepted activations count).
- Re-prompt when `used - 2 * fired >= 2`.

Both values come from the turn-scoped `getHistory`, so the cadence resets cleanly at the start of each turn. This is the same history-counting pattern already used by other skills in this pack (for example `dcsbmuwang`, `dcyinjun`). The `count` sub-skill and its intro display are left unchanged.

## Testing

- Traced the scenarios from the issue: use 2 cards then decline -> the next single card use re-prompts (and each one after); accept -> two more cards are required before the next prompt; cards used via 谟猷 itself are excluded; the counter does not leak across turns (history is turn-scoped).
- `node --check apps/core/character/xianding/skill.js` passes.
- Verified the changed lines are Prettier-clean against the repo config (the file's other Prettier warnings are pre-existing and untouched).

Fixes #3814

AI was used for assistance.
