### PR TITLE
fix: 修复煌烛恢复装备栏时报错

### DIFF
--- a/apps/core/character/tw/skill.js
+++ b/apps/core/character/tw/skill.js
@@ -4649,20 +4649,24 @@ const skills = {
 				forced: true,
 				popup: false,
 				content() {
-					player.removeExtraEquip(event.name);
+					const skill = event.name;
 					player.unmarkAuto(
-						event.name,
-						player.getStorage(event.name).filter(name => trigger.slots.some(t => get.subtypes(name[2]).includes(t)))
+						skill,
+						player.getStorage(skill).filter(name => trigger.slots.some(t => get.subtypes(name[2]).includes(t)))
 					);
-					if (!player.getStorage(event.name).length) {
-						player.removeSkill(event.name);
+					const storage = player.getStorage(skill);
+					if (!storage.length) {
+						player.removeExtraEquip(skill);
+						player.removeSkill(skill);
 					} else {
+						player.addExtraEquip(
+							skill,
+							storage.map(name => name[2]),
+							true
+						);
 						player.addAdditionalSkill(
-							event.name,
-							player
-								.getStorage(equip)
-								.map(name => lib.card[name[2]]?.skills || [])
-								.flat()
+							skill,
+							storage.map(name => lib.card[name[2]]?.skills || []).flat()
 						);
 					}
 				},


### PR DESCRIPTION
修复幻曹昂〖煌烛〗在装备栏恢复时的报错问题。

原逻辑在 enableEquipEnd 触发后清理视为装备效果时，使用了未定义变量 equip，导致恢复装备栏时报错。

现在改为使用当前技能名 event.name 作为存储键，并在装备栏恢复后：
1. 移除对应副类别的视为装备记录；
2. 若没有剩余视为装备，则移除 twhuangzhu_equip 技能和额外装备效果；
3. 若仍有剩余视为装备，则重新添加剩余的视为装备及其附带技能。