### PR TITLE
fix: 修复崔芙绣阁和友诸葛亮演策问题

### DIFF
--- a/apps/core/character/mobile/skill.js
+++ b/apps/core/character/mobile/skill.js
@@ -6416,11 +6416,30 @@ const skills = {
 					return get.skillInfoTranslation("mbweizhuang_xiugex", player);
 				},
 				async precontent(event, trigger, player) {
-					const name = event.result.card?.name,
+					let name = event.result.card?.name,
+						nature = event.result.card?.nature,
 						cards = event.result.cards;
+					if (name == "sha" && get.subtype(cards[0], player) == "equip1") {
+						const parent = event.getParent();
+						const list = [null].concat(lib.inpile_nature).filter(nature => {
+							const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
+							if (nature) {
+								vcard.nature = nature;
+							}
+							return parent.filterCard(new lib.element.VCard(vcard), player, parent);
+						});
+						if (list.length > 1) {
+							const result = await player
+								.chooseControl(list.map(nature => nature || "普通杀"))
+								.set("prompt", "绣阁：请选择视为使用的【杀】")
+								.forResult();
+							nature = result.control == "普通杀" ? null : result.control;
+						} else {
+							nature = list[0];
+						}
+					}
 					player.addTempSkill("mbweizhuang_blocker");
 					player.markAuto("mbweizhuang_blocker", name);
-					//delete event.result.skill;
 					event.getParent().addCount = false;
 					const count = get
 						.info("mbweizhuang")
@@ -6435,7 +6454,11 @@ const skills = {
 						player.logSkill("mbweizhuang_xiuge", null, null, null, [index]);
 						await player.modedDiscard(cards);
 					}
-					event.result.card = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+					const vcard = { name: name, isCard: true, storage: { wzxiuge: true } };
+					if (nature) {
+						vcard.nature = nature;
+					}
+					event.result.card = new lib.element.VCard(vcard);
 					event.result.cards = [];
 					player
 						.when("useCardAfter")
@@ -10561,6 +10584,9 @@ const skills = {
 			}
 			return true;
 		},
+		check(event, player) {
+			return event.name != "roundStart";
+		},
 		round: 1,
 		popup: false,
 		logAudio: index => (typeof index === "number" ? "friendyance" + index + ".mp3" : 1),
@@ -10583,7 +10609,13 @@ const skills = {
 					const player = get.player();
 					return typeof player.storage.friendyance !== "number" || player.hasMark("friendyance");
 				})
-				.set("ai", button => (button.link == "minigame" ? 2 : 1))
+				.set("ai", button => {
+					const trigger = get.event().getTrigger();
+					if (trigger?.name == "roundStart") {
+						return 0;
+					}
+					return button.link == "minigame" ? 2 : 1;
+				})
 				.forResult();
 			event.result = {
 				bool: result.bool,
@@ -10628,7 +10660,7 @@ const skills = {
 				.set("ai", () => get.rand(0, 1))
 				.forResult();
 			const type = lib.inpile.map(c => get.type2(c)).unique();
-			const color = Object.keys(lib.color);
+			const color = Object.keys(lib.color).filter(color => color != "none");
 			const list = [];
 			if (control === "颜色预测") {
 				list.addArray(color);
@@ -10750,14 +10782,14 @@ const skills = {
 							}
 						} else {
 							player.logSkill("friendyance", null, null, null, [trueArr.length === storage[3] ? 7 : 6]);
-							const choice = storage[2] == "color" ? Object.keys(lib.color) : lib.inpile.map(name => get.type2(name)).unique();
+							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color != "none") : lib.inpile.map(name => get.type2(name)).unique();
 							const control =
 								choice.length > 1
 									? (
 											await player
 												.chooseControl(choice)
 												.set("ai", () => {
-													return get.event().controls.remove("none").randomGet();
+													return get.event().controls.randomGet();
 												})
 												.set("prompt", `请选择获得牌的条件`)
 												.forResult()

--- a/apps/core/character/mobile/skill.js
+++ b/apps/core/character/mobile/skill.js
@@ -6400,10 +6400,10 @@ const skills = {
 				log: false,
 				check(card) {
 					const player = get.player();
-					if (_status.event.type == "phase") {
+					if (_status.event.type === "phase") {
 						const name = ["sha", "shan", "tao", "jiu"][get.subtype(card, player)?.slice(5) - 1];
 						if (name) {
-							const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+							const vcard = get.autoViewAs({ name: name, isCard: true, storage: { wzxiuge: true } });
 							if (player.getUseValue(vcard) > 0) {
 								return 14 - get.value(card);
 							}
@@ -6416,31 +6416,36 @@ const skills = {
 					return get.skillInfoTranslation("mbweizhuang_xiugex", player);
 				},
 				async precontent(event, trigger, player) {
-					let name = event.result.card?.name,
-						nature = event.result.card?.nature,
-						cards = event.result.cards;
-					if (name == "sha" && get.subtype(cards[0], player) == "equip1") {
-						const parent = event.getParent();
+					const name = event.result.card?.name;
+					let nature = event.result.card?.nature;
+					const cards = event.result.cards;
+					const parent = event.getParent();
+					if (parent == null) {
+						return;
+					}
+					if (name === "sha" && get.subtype(cards[0], player) === "equip1") {
 						const list = [null].concat(lib.inpile_nature).filter(nature => {
 							const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
 							if (nature) {
 								vcard.nature = nature;
 							}
-							return parent.filterCard(new lib.element.VCard(vcard), player, parent);
+							return parent.filterCard(get.autoViewAs(vcard), player, parent);
 						});
 						if (list.length > 1) {
 							const result = await player
-								.chooseControl(list.map(nature => nature || "普通杀"))
-								.set("prompt", "绣阁：请选择视为使用的【杀】")
+								.chooseControl({
+									prompt: "绣阁：请选择视为使用的【杀】",
+									controls: list.map(nature => nature || "普通杀"),
+								})
 								.forResult();
-							nature = result.control == "普通杀" ? null : result.control;
+							nature = result.control === "普通杀" ? null : result.control;
 						} else {
 							nature = list[0];
 						}
 					}
 					player.addTempSkill("mbweizhuang_blocker");
 					player.markAuto("mbweizhuang_blocker", name);
-					event.getParent().addCount = false;
+					parent.addCount = false;
 					const count = get
 						.info("mbweizhuang")
 						.getFaceupCards(player)
@@ -6452,21 +6457,24 @@ const skills = {
 					} else {
 						const index = ["sha", "jiu", "tao", "shan"].indexOf(name) + 3;
 						player.logSkill("mbweizhuang_xiuge", null, null, null, [index]);
-						await player.modedDiscard(cards);
+						await player.modedDiscard({ cards });
 					}
 					const vcard = { name: name, isCard: true, storage: { wzxiuge: true } };
 					if (nature) {
 						vcard.nature = nature;
 					}
-					event.result.card = new lib.element.VCard(vcard);
+					event.result.card = get.autoViewAs(vcard);
 					event.result.cards = [];
 					player
 						.when("useCardAfter")
-						.filter(evt => evt.getParent() == event.getParent())
+						.filter(evt => evt.getParent() === event.getParent())
 						.step(async (event, trigger, player) => {
 							const card = get.cardPile(card => get.suit(card) == get.suit(cards[0]));
 							if (card) {
-								await player.gain(card, "gain2");
+								await player.gain({
+									cards: [card],
+									animate: "gain2",
+								});
 							}
 						});
 				},
@@ -10584,8 +10592,8 @@ const skills = {
 			}
 			return true;
 		},
-		check(event, player) {
-			return event.name != "roundStart";
+		check(event, player, name) {
+			return name !== "roundStart";
 		},
 		round: 1,
 		popup: false,
@@ -10610,12 +10618,13 @@ const skills = {
 					return typeof player.storage.friendyance !== "number" || player.hasMark("friendyance");
 				})
 				.set("ai", button => {
-					const trigger = get.event().getTrigger();
-					if (trigger?.name == "roundStart") {
+					const { triggername } = get.event();
+					if (triggername === "roundStart") {
 						return 0;
 					}
-					return button.link == "minigame" ? 2 : 1;
+					return button.link === "minigame" ? 2 : 1;
 				})
+				.set("triggername", event.triggername)
 				.forResult();
 			event.result = {
 				bool: result.bool,
@@ -10660,7 +10669,7 @@ const skills = {
 				.set("ai", () => get.rand(0, 1))
 				.forResult();
 			const type = lib.inpile.map(c => get.type2(c)).unique();
-			const color = Object.keys(lib.color).filter(color => color != "none");
+			const color = Object.keys(lib.color).filter(color => color !== "none");
 			const list = [];
 			if (control === "颜色预测") {
 				list.addArray(color);
@@ -10782,7 +10791,7 @@ const skills = {
 							}
 						} else {
 							player.logSkill("friendyance", null, null, null, [trueArr.length === storage[3] ? 7 : 6]);
-							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color != "none") : lib.inpile.map(name => get.type2(name)).unique();
+							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color !== "none") : lib.inpile.map(name => get.type2(name)).unique();
 							const control =
 								choice.length > 1
 									? (

--- a/apps/core/character/mobile/skill.js
+++ b/apps/core/character/mobile/skill.js
@@ -2,6 +2,1247 @@ import { lib, game, ui, get, ai, _status } from "noname";
 
 /** @type { importCharacterConfig["skill"] } */
 const skills = {
+	//界周妃
+	reliangyin: {
+		audio: 2,
+		trigger: {
+			global: ["addToExpansionAfter", "loseAsyncAfter", "gainAfter"],
+		},
+		getIndex(event, player) {
+			if (event.name == "loseAsync") {
+				if (event.type == "addToExpansion") {
+					return 1;
+				}
+				if (event.type == "gain") {
+					const xs = game.filterPlayer2(() => true, void 0, true).flatMap(target => target => event.getl(target)?.xs || []);
+					return game
+						.filterPlayer2(
+							target => {
+								return event.getg(target)?.containsSome(...xs);
+							},
+							void 0,
+							true
+						)
+						.sortBySeat();
+				}
+			}
+			if (event.name == "gain") {
+				return game.hasPlayer2(target => event.getl(target)?.xs?.length, true) ? 1 : 0;
+			}
+			return 1;
+		},
+		filter(event, player) {
+			return true;
+		},
+		async cost(event, trigger, player) {
+			const funcName = trigger.name == "gain" || trigger.type == "gain" ? "discard" : "draw";
+			console.log(funcName);
+			event.result = await player
+				.chooseTarget({
+					prompt: get.prompt(event.skill),
+					prompt2: `令一名角色${funcName == "discard" ? "弃置" : "摸"}一张牌`,
+					filterTarget(card, player, target) {
+						return get.event().funcName == "discard" ? target.hasDiscardableCards(target, "he") : true;
+					},
+					ai(target) {
+						const { funcName, player } = get.event();
+						return get.effect(target, { name: funcName == "discard" ? "guohe_copy2" : "draw" }, player, player);
+					},
+				})
+				.set("funcName", funcName)
+				.forResult();
+			event.result.cost_data ??= {};
+			event.result.cost_data.funcName = funcName;
+		},
+		async content(event, trigger, player) {
+			const {
+				cost_data: { funcName },
+				targets: [target],
+			} = event;
+			if (funcName == "discard") {
+				await target.chooseToDiscard({ forced: true, position: "he" });
+			} else {
+				await target.draw();
+			}
+		},
+		group: "reliangyin_end",
+		subSkill: {
+			end: {
+				audio: "reliangyin",
+				trigger: {
+					global: "roundEnd",
+				},
+				filter(event, player) {
+					const targets = player
+						.getRoundHistory("useSkill", evt => evt.skill == "reliangyin")
+						.flatMap(evt => evt.targets)
+						.unique();
+					return game.countPlayer(target => !targets.includes(target)) == 1 || targets.length == 1;
+				},
+				async cost(event, trigger, player) {
+					const targets = player
+						.getRoundHistory("useSkill", evt => evt.skill == "reliangyin")
+						.flatMap(evt => evt.targets)
+						.unique();
+					let funcName;
+					let target;
+					if (targets.length == 1) {
+						funcName = "recover";
+						target = targets[0];
+					} else {
+						funcName = "loseHp";
+						target = game.findPlayer(target => !targets.includes(target));
+					}
+					event.result = await player
+						.chooseBool({
+							prompt: get.prompt(event.skill, target),
+							prompt2: `令其${funcName == "recover" ? "回复" : "失去"}一点体力`,
+							chioce: (() => {
+								if (funcName == "recover") {
+									return get.recoverEffect(target, player, player) > 0;
+								}
+								return get.effect(target, { name: "losehp" }, player, player) > 0;
+							})(),
+						})
+						.forResult();
+					event.result.cost_data ??= {};
+					event.result.targets = [target];
+					event.result.cost_data.funcName = funcName;
+				},
+				async content(event, trigger, player) {
+					const {
+						cost_data: { funcName },
+						targets: [target],
+					} = event;
+					await target[funcName]();
+				},
+			},
+		},
+	},
+	rekongsheng: {
+		audio: 2,
+		trigger: {
+			player: ["phaseZhunbeiBegin", "recoverEnd", "loseHpEnd"],
+		},
+		filter(event, player) {
+			return _status.currentPhase?.hasCards("he");
+		},
+		logTarget: () => _status.currentPhase,
+		async cost(event, trigger, player) {
+			const target = _status.currentPhase;
+			if (target == player) {
+				event.result = await player
+					.chooseCard({
+						prompt: get.prompt2(event.skill, target),
+						position: "he",
+						selectCard: [1, Infinity],
+						ai(card) {
+							const player = get.player();
+							if (get.position(card) == "e") {
+								return 1 - get.value(card);
+							}
+							if (card.name == "shan" || card.name == "du" || !player.hasValueTarget(card)) {
+								return 1;
+							}
+							return 4 - get.value(card);
+						},
+					})
+					.forResult();
+			} else {
+				event.result = await player
+					.choosePlayerCard({
+						prompt: get.prompt2(event.skill, target),
+						position: "he",
+						selectButton: [1, Infinity],
+						target,
+						ai(button) {
+							const att = get.attitude(get.player(), get.event().target);
+							if (att < 0) {
+								return get.buttonValue(button);
+							}
+							return 0;
+						},
+					})
+					.forResult();
+			}
+		},
+		intro: {
+			content: "expansion",
+			markcount: "expansion",
+		},
+		async content(event, trigger, player) {
+			const {
+				targets: [target],
+				cards,
+			} = event;
+			await target.addToExpansion({ cards, animate: "give", source: target, gaintag: [event.name] });
+			player
+				.when({ global: "phaseJieshuBegin" })
+				.filter(evt => {
+					return evt.player == target;
+				})
+				.then(async (event, trigger, player) => {
+					if (!target.hasExpansions("rekongsheng")) {
+						return;
+					}
+					const cards = target.getExpansions("rekongsheng").filter(card => {
+						return player.hasUseTarget(card, void 0, false) || (get.info(card).notarget && lib.filter.cardEnabled(card, player));
+					});
+					if (cards.length) {
+						const result = await player
+							.chooseButton({
+								createDialog: [`箜声：请选择要使用的牌`, cards],
+								ai(button) {
+									return get.player().getUseValue(button.link);
+								},
+							})
+							.forResult();
+						if (result?.bool) {
+							const { links } = result;
+							await player.chooseUseTarget({ card: links[0], addCount: false });
+						}
+					}
+					await target.gain({ cards: target.getExpansions("rekongsheng"), animate: "gain2" });
+				});
+		},
+	},
+	//界严颜
+	rejuzhan: {
+		audio: 2,
+		init(player, skill) {
+			player.addSkill(skill + "_mark");
+		},
+		onremove(player, skill) {
+			player.removeSkill(skill + "_mark");
+		},
+		zhuanhuanji: true,
+		mark: true,
+		marktext: "☯",
+		intro: {
+			markcount(storage, player, skill) {
+				return player.countMark(skill + "_yang") + "/" + player.countMark(skill + "_yin");
+			},
+			content(storage, player) {
+				return "转换技，" + (!storage ? "当你或者此状态下第三次有角色成为【杀】的目标后，你可以与此【杀】的使用者各摸一张牌，然后其本回合不能对你使用牌" : "当你或者此状态下第三次有角色使用【杀】指定目标后，你可以获得此【杀】的目标角色一张牌，然后你本回合不能对其使用牌") + "。乘势：你于出牌阶段内使用【杀】的次数+1，且此【杀】结算完毕后，你获得之。";
+			},
+		},
+		trigger: {
+			global: ["useCardToTargeted", "useCardToPlayered"],
+		},
+		filter(event, player, name) {
+			if (event.card.name !== "sha") {
+				return false;
+			}
+			if (name == "useCardToPlayered") {
+				return player.storage.rejuzhan && (event.player == player || player.countMark("rejuzhan_yin") == 3) && event.target.hasGainableCards(player, "he");
+			}
+			return !player.storage.rejuzhan && (event.target == player || player.countMark("rejuzhan_yang") == 3);
+		},
+		logTarget: (event, player, name) => (name == "useCardToTargeted" ? event.player : event.target),
+		check: () => true,
+		async content(event, trigger, player) {
+			const {
+				targets: [target],
+			} = event;
+			const suffix = !player.storage[event.name] ? "yang" : "yin";
+			player.changeZhuanhuanji(event.name);
+			let isChengshi = false;
+			if (event.triggername == "useCardToTargeted") {
+				await game.asyncDraw([player, target]);
+				target.addTempSkill(event.name + "_debuff");
+				target.markAuto(event.name + "_debuff", player);
+				if (trigger.target == player && player.countMark(`${event.name}_${suffix}`) == 3) {
+					isChengshi = true;
+				}
+			} else {
+				await player.gainPlayerCard({ target, position: "he", forced: true });
+				player.addTempSkill(event.name + "_debuff");
+				player.markAuto(event.name + "_debuff", target);
+				if (trigger.player == player && player.countMark(`${event.name}_${suffix}`) == 3) {
+					isChengshi = true;
+				}
+			}
+			if (isChengshi) {
+				player.addSkill(event.name + "_sha");
+				player.addMark(event.name + "_sha", 1, false);
+				player
+					.when({ global: "useCardAfter" })
+					.filter(evt => evt.card == trigger.card)
+					.then(async (event, trigger, player) => {
+						const cards = trigger.cards?.filterInD("od");
+						if (cards?.length) {
+							await player.gain({ cards, animate: "gain2" });
+						}
+					});
+			}
+		},
+		subSkill: {
+			sha: {
+				charlotte: true,
+				marktext: "杀",
+				onremove: true,
+				intro: {
+					content: "出杀次数+#",
+				},
+				mod: {
+					cardUsable(card, player, num) {
+						if (get.name(card) == "sha") {
+							return num + player.countMark("rejuzhan_sha");
+						}
+					},
+				},
+			},
+			debuff: {
+				charlotte: true,
+				onremove: true,
+				intro: {
+					content: "你不能对$使用牌",
+				},
+				mod: {
+					playerEnabled(card, player, target) {
+						if (player.getStorage("rejuzhan_debuff").includes(target)) {
+							return false;
+						}
+					},
+				},
+			},
+			mark: {
+				charlotte: true,
+				silent: true,
+				trigger: {
+					global: ["useCardToTargeted", "useCardToPlayered"],
+				},
+				filter(event, player, name) {
+					if (event.card.name !== "sha") {
+						return false;
+					}
+					if (name == "useCardToPlayered") {
+						return player.storage.rejuzhan;
+					}
+					return !player.storage.rejuzhan;
+				},
+				async content(event, trigger, player) {
+					if (event.triggername == "useCardToPlayered") {
+						player.addMark("rejuzhan_yin", 1, false);
+					} else {
+						player.addMark("rejuzhan_yang", 1, false);
+					}
+					player.markSkill("rejuzhan");
+				},
+			},
+		},
+	},
+	//高翔
+	mbgxchiyuan: {
+		audio: 2,
+		enable: "phaseUse",
+		usable: 1,
+		filterCard: true,
+		selectCard: 1,
+		filterTarget(card, player, target) {
+			return target != player && target.hp < player.hp;
+		},
+		selectTarget: 1,
+		filter(event, player) {
+			return game.hasPlayer(target => get.info("mbgxchiyuan")?.filterTarget?.(void 0, player, target));
+		},
+		lose: false,
+		discard: false,
+		delay: false,
+		async content(event, trigger, player) {
+			const { cards, target } = event;
+			await player.give(cards, target);
+			const virtualSha = get.autoViewAs({ name: "sha", isCard: true });
+			const targets = game.filterPlayer(targetx => {
+				return targetx.inRange(target) && player.canUse(virtualSha, targetx, false, false);
+			});
+			if (!targets.length) {
+				return;
+			}
+			const result = await player
+				.chooseTarget({
+					prompt: `驰援：请选择攻击范围内包含${get.translation(target)}的一名角色，视为对其使用一张【杀】`,
+					filterTarget(card, player, target) {
+						return get.event().targets.includes(target);
+					},
+					forced: true,
+				})
+				.set("targets", targets)
+				.forResult();
+			if (!result?.targets?.length) {
+				return;
+			}
+			const useEvent = player.useCard({ card: virtualSha, targets: result.targets, addCount: false });
+			await useEvent;
+			const damaged = game.hasPlayer2(target => target.hasHistory("damage", evt => evt.card === useEvent.card), true);
+			if (damaged) {
+				await target.recover();
+			} else {
+				await game.doAsyncInOrder(useEvent.targets, async shaUser => {
+					if (shaUser.canUse(virtualSha, player, false, false)) {
+						return shaUser.useCard({ card: virtualSha, targets: [player], addCount: false });
+					}
+				});
+			}
+		},
+		ai: {
+			order: 8,
+			result: {
+				target(player, target) {
+					if (target.hp < player.hp) {
+						const att = get.attitude(player, target);
+						if (att > 0) {
+							const shaTargets = game.filterPlayer(t => t != player && t.inRange(target) && get.effect(t, { name: "sha", isCard: true }, player, player) > 0);
+							if (shaTargets.length) {
+								return att;
+							}
+						}
+					}
+					return 0;
+				},
+			},
+		},
+	},
+	mberdi: {
+		audio: 2,
+		trigger: { player: "phaseJieshuBegin" },
+		filter(event, player) {
+			return game.hasPlayer(target => target != player && target.countCards("h") > player.countCards("h"));
+		},
+		async cost(event, trigger, player) {
+			event.result = await player
+				.chooseTarget({
+					prompt: get.prompt2(event.skill),
+					filterTarget(card, player, target) {
+						return target != player && target.countCards("h") > player.countCards("h");
+					},
+					ai(target) {
+						return -get.attitude(get.player(), target) * (114514 - target.countCards("h"));
+					},
+				})
+				.forResult();
+		},
+		async content(event, trigger, player) {
+			const target = event.targets[0];
+			await player.loseHp();
+			await player.draw();
+			const discardMap = await game.chooseAnyOL([player, target], get.info(event.name).chooseToDiscard, []).forResult();
+			const playerResult = discardMap.get(player);
+			const targetResult = discardMap.get(target);
+			const playerCount = playerResult?.cards?.length || 0;
+			const targetCount = targetResult?.cards?.length || 0;
+			for (const targetx of [player, target]) {
+				const result = discardMap.get(targetx);
+				if (result?.bool && result.cards?.length) {
+					await targetx.modedDiscard(result.cards);
+				}
+			}
+			if (playerCount > targetCount) {
+				await player.recover();
+				await target.damage();
+			} else if (playerCount < targetCount) {
+				await player.draw(targetCount);
+			}
+		},
+		/**
+		 *
+		 * @param { Player } player
+		 * @param { number } eventId
+		 * @returns { GameEvent }
+		 */
+		chooseToDiscard(player, eventId) {
+			const next = player.chooseToDiscard({
+				prompt: "饵敌：请弃置任意张手牌",
+				selectCard: [1, player.countCards("h")],
+				position: "h",
+				chooseonly: true,
+				forced: true,
+			});
+			next.set("id", eventId);
+			next.set("_global_waiting", true);
+			return next;
+		},
+	},
+	//崔琰毛玠
+	mbzhengbi: {
+		audio: 2,
+		intro: {
+			content: "可选择的角色+#",
+		},
+		trigger: {
+			player: "phaseZhunbeiBegin",
+		},
+		filter(event, player) {
+			return game.hasPlayer(target => target != player);
+		},
+		async cost(event, trigger, player) {
+			event.result = await player
+				.chooseTarget({
+					prompt: get.prompt2(event.skill),
+					filterTarget(card, player, target) {
+						return target != player && target.hasCards("hej");
+					},
+					selectTarget: [1, 1 + player.countMark(event.skill)],
+					ai(target) {
+						const player = get.player();
+						const storage = player.getStorage("mbzhengbi_used");
+						const att = get.attitude(player, target);
+						if (att > 0) {
+							if (!storage.includes(target) || target.hasCards("j")) {
+								return 114515 - target.countCards("hej");
+							}
+							return 0;
+						}
+						return 114514 - target.countCards("hej");
+					},
+				})
+				.forResult();
+		},
+		async content(event, trigger, player) {
+			const { targets } = event;
+			await game.doAsyncInOrder(targets, async target => {
+				const result = await target
+					.chooseControl({
+						prompt: `征辟：请选择令${get.translation(player)}获得的牌数`,
+						controls: [1, 2, 3].map(i => i.toString()),
+						choice: get.attitude(player, target) > 0 ? 2 : 0,
+					})
+					.forResult();
+				const { index } = result;
+				if (typeof index == "number") {
+					if (index + 1 == 3 && !player.getStorage(event.name + "_used").includes(target)) {
+						player.addMark(event.name, 1, false);
+						player.markAuto(event.name + "_used", target);
+					}
+					await player.gainPlayerCard({ target, position: "hej", selectButton: index + 1, forced: true });
+					await player.chooseToGive({ target, position: "he", forced: true, selectCard: index + 1 });
+				}
+			});
+		},
+	},
+	mbfengying: {
+		audio: 2,
+		limited: true,
+		skillAnimation: true,
+		animationColor: "thunder",
+		enable: "phaseUse",
+		filterTarget: true,
+		async content(event, trigger, player) {
+			const { target, name } = event;
+			player.awakenSkill(name);
+			const targets = game.filterPlayer(i => target.inRange(i));
+			await game.doAsyncInOrder(targets, async source => {
+				if (source.hasCards("hs", card => lib.filter.targetEnabled2(get.autoViewAs({ name: "wuzhong" }, [card]), source, target))) {
+					await source
+						.chooseToUse({ forced: true })
+						.set("openskilldialog", `奉迎：将一张手牌当做【无中生有】对${get.translation(target)}使用`)
+						.set("norestore", true)
+						.set("_backupevent", `${event.name}_backup`)
+						.set("custom", {
+							add: {},
+							replace: { window() {} },
+						})
+						.backup(`${event.name}_backup`)
+						.set("targetRequired", true)
+						.set("complexTarget", true)
+						.set("complexSelect", true)
+						.set("pre_target", target);
+				}
+			});
+			if (target.isMaxMaxHp()) {
+				player.addTempSkill(event.name + "_effect");
+			}
+		},
+		ai: {
+			order: 10,
+			result: {
+				target(player, target) {
+					if (target.isMaxMaxHp()) {
+						return 2 + game.countPlayer(i => target.inRange(i));
+					}
+					return game.countPlayer(i => target.inRange(i));
+				},
+			},
+		},
+		subSkill: {
+			effect: {
+				audio: "mbfengying",
+				charlotte: true,
+				forced: true,
+				trigger: {
+					global: "phaseEnd",
+				},
+				async content(event, trigger, player) {
+					player.removeSkill(event.name);
+					player.insertPhase();
+				},
+				mark: true,
+				intro: {
+					content: "当前回合结束时获得一个额外回合",
+				},
+			},
+			backup: {
+				viewAs: {
+					name: "wuzhong",
+				},
+				filterCard: true,
+				position: "hs",
+				selectCard: 1,
+				check(card) {
+					return 6 - get.value(card);
+				},
+				filterTarget(card, player, target) {
+					if (target != get.event().pre_target) {
+						return false;
+					}
+					return lib.filter.targetEnabled2.call(this, card, player, target);
+				},
+				log: false,
+			},
+		},
+	},
+	//钟繇
+	mbzuoding: {
+		audio: "zuoding",
+		trigger: { global: "useCardToPlayered" },
+		filter(event, player) {
+			if (event.getParent()?.triggeredTargets3.length > 1) {
+				return false;
+			}
+			return get.suit(event.card) == "spade" && event.targets?.length > 0 && event.player != player && event.player.isPhaseUsing() && [player, ...event.targets].some(target => !target.hasHistory("damage", evt => evt.num > 0 && evt.getParent("phaseUse") == event.getParent("phaseUse")));
+		},
+		async cost(event, trigger, player) {
+			event.result = await player
+				.chooseTarget({
+					prompt: get.prompt(event.skill),
+					prompt2: "令一名目标角色摸一张牌",
+					filterTarget(card, player, target) {
+						return get.event().targets.includes(target);
+					},
+					ai(target) {
+						return get.attitude(get.event().player, target);
+					},
+				})
+				.set("targets", trigger.targets)
+				.forResult();
+		},
+		logTarget: "targets",
+		async content(event, trigger, player) {
+			await event.targets[0].draw();
+		},
+		ai: {
+			expose: 0.2,
+		},
+	},
+	//兀突骨
+	mbranshang: {
+		audio: "ranshang",
+		trigger: { player: "damageEnd" },
+		filter(event, player) {
+			return event.hasNature("fire");
+		},
+		forced: true,
+		async content(event, trigger, player) {
+			player.addMark(event.name, trigger.num);
+		},
+		intro: {
+			name2: "燃",
+			content: "mark",
+		},
+		ai: {
+			neg: true,
+			effect: {
+				target(card, player, target, current) {
+					if (card.name == "sha") {
+						if (game.hasNature(card, "fire") || player.hasSkill("zhuque_skill")) {
+							return 2;
+						}
+					}
+					if (get.tag(card, "fireDamage") && current < 0) {
+						return 2;
+					}
+				},
+			},
+		},
+		group: "mbranshang_loseHp",
+		subSkill: {
+			loseHp: {
+				audio: "ranshang",
+				trigger: { player: "phaseJieshuBegin" },
+				forced: true,
+				filter(event, player) {
+					return player.countMark("mbranshang") > 0;
+				},
+				async content(event, trigger, player) {
+					await player.loseHp(player.countMark("mbranshang"));
+					if (player.countMark("mbranshang") >= player.getDamagedHp()) {
+						await player.loseMaxHp({ num: 2 });
+						await player.draw(2);
+					}
+				},
+			},
+		},
+	},
+	mbhanyong: {
+		audio: "hanyong",
+		trigger: {
+			player: "useCard",
+		},
+		filter(event, player) {
+			return event.targets?.length > 1 && player.isDamaged();
+		},
+		async cost(event, trigger, player) {
+			const { card, targets } = trigger;
+			const result = await player
+				.chooseControl({
+					prompt: get.prompt2(event.skill),
+					choiceList: [`摸一张牌`, `令${get.translation(card)}造成的伤害+1`, `背水！获得一个“燃”`],
+					controls: ["选项一", "选项二", "背水！", "cancel2"],
+					choice: (() => {
+						if (!get.is.damageCard(card)) {
+							return 0;
+						}
+						if (targets.reduce((sum, target) => sum + get.effect(target, card, player, player), 0) > 0) {
+							return 1;
+						}
+						return 0;
+					})(),
+				})
+				.forResult();
+			if (result.control !== "cancel2") {
+				event.result = {
+					bool: true,
+					cost_data: { index: result.index },
+				};
+			}
+		},
+		async content(event, trigger, player) {
+			const {
+				cost_data: { index },
+			} = event;
+			if (index % 2 == 0) {
+				await player.draw();
+			}
+			if (index > 0) {
+				game.log(trigger.card, "的基础伤害+1");
+				trigger.baseDamage++;
+			}
+			if (index == 2) {
+				player.addMark("mbranshang");
+			}
+		},
+	},
+	//程昱
+	mbshefu: {
+		audio: "shefu",
+		onremove(player, skill) {
+			delete player.storage[skill];
+			const cards = player.getExpansions(skill);
+			if (cards.length) {
+				player.loseToDiscardpile({ cards });
+			}
+		},
+		intro: {
+			content: "cards",
+			mark(dialog, storage, player) {
+				const cards = storage.map(arr => arr[1]);
+				const names = storage.map(arr => arr[0]);
+				dialog.addAuto(cards);
+				if (player.isUnderControl(true)) {
+					const { buttons } = dialog;
+					buttons.forEach((button, index) => ui.create.cardTempName(get.autoViewAs({ name: names[index] }), button));
+				}
+			},
+		},
+		trigger: {
+			player: "phaseJieshuBegin",
+		},
+		getList(player, exclude) {
+			return get.inpileVCardList(info => {
+				if (!["basic", "trick"].includes(info[0]) || (exclude && exclude == info[2])) {
+					return false;
+				}
+				if (info[2] == "sha" && info[3]) {
+					return false;
+				}
+				return !player.getStorage("mbshefu").some(arr => arr[0] == info[2]);
+			});
+		},
+		filter(event, player) {
+			return get.info("mbshefu").getList(player).length > 0 && player.hasCards("he");
+		},
+		async cost(event, trigger, player) {
+			const result = await player
+				.chooseButton({
+					createDialog: [get.prompt2(event.skill), [get.info(event.skill).getList(player), "vcard"]],
+					ai(button) {
+						const { rand } = get.event();
+						switch (button.link[2]) {
+							case "sha":
+								return 5 + rand[1];
+							case "tao":
+								return 4 + rand[2];
+							case "shan":
+								return 4.5 + rand[4];
+							case "wuzhong":
+								return 4 + rand[5];
+							case "shunshou":
+								return 3 + rand[6];
+							case "nanman":
+								return 2 + rand[7];
+							case "wanjian":
+								return 2 + rand[8];
+							default:
+								return rand[0];
+						}
+					},
+				})
+				.set("rand", [Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random()])
+				.forResult();
+			if (result?.bool && result.links?.length) {
+				const {
+					links: [link],
+				} = result;
+				event.result = {
+					bool: true,
+					cost_data: link[2],
+				};
+			}
+		},
+		async content(event, trigger, player) {
+			const { cost_data: name } = event;
+			const result = await player.chooseCard({ position: "he", prompt: "设伏：选择一张牌作为“伏兵”", forced: true }).forResult();
+			const { cards } = result;
+			if (cards?.length) {
+				await player.addToExpansion({ cards, source: player, animate: "give", gaintag: [event.name] });
+				if (player.getExpansions(event.name).includes(cards[0])) {
+					player.markAuto(event.name, [[name, cards[0]]]);
+				}
+			}
+		},
+		group: "mbshefu_exclude",
+		subSkill: {
+			exclude: {
+				audio: "shefu",
+				trigger: {
+					global: ["useCard"],
+				},
+				filter(event, player) {
+					if (_status.currentPhase == player || event.player == player || event.all_excluded) {
+						return false;
+					}
+					return player.getStorage("mbshefu").some(arr => arr[0] == get.name(event.card));
+				},
+				logTarget: "player",
+				prompt2(event, player) {
+					return `移去“伏兵”令其${event.targets?.length ? `对${get.translation(event.targets)}` : ""}使用的${get.translation(event.card)}无效`;
+				},
+				check(event, player) {
+					const { card, player: target, targets } = event;
+					const name = get.name(card);
+					let effect = 0;
+					if (name == "wuxie" || name == "shan") {
+						if (get.attitude(player, target) < -1) {
+							effect = -1;
+						}
+					} else if (targets?.length) {
+						for (let i = 0; i < targets.length; i++) {
+							effect += get.effect(targets[i], card, target, player);
+						}
+					}
+					if (effect < 0) {
+						if (name == "sha") {
+							if (targets[0] == player) {
+								return !player.countCards("h", "shan");
+							} else {
+								return targets[0].hp == 1 || (targets[0].countCards("h") <= 2 && targets[0].hp <= 2);
+							}
+						} else {
+							return true;
+						}
+					}
+					return false;
+				},
+				async content(event, trigger, player) {
+					const { card } = trigger;
+					const {
+						targets: [target],
+					} = event;
+					const name = get.name(card);
+					const skill = "mbshefu";
+					/**@type {[string, Card][]} */
+					const storage = player.getStorage(skill);
+					const index = storage.findIndex(arr => arr[0] == name);
+					if (index !== -1) {
+						console.log(index);
+						console.log(storage[index]);
+						const list = storage[index].slice();
+						storage.splice(index, 1);
+						player.setStorage(skill, storage, true);
+						await player.loseToDiscardpile({ cards: [list[1]] });
+						game.log(card, "被无效了");
+						trigger.targets.length = 0;
+						trigger.all_excluded = true;
+						const vcardList = get.info(skill).getList(player, name);
+						if (vcardList.length && player.hasCards("he")) {
+							const result = await player
+								.chooseButton({
+									createDialog: ["设伏：你可以再放置一个“伏兵”", [vcardList, "vcard"]],
+									ai(button) {
+										const { rand } = get.event();
+										switch (button.link[2]) {
+											case "sha":
+												return 5 + rand[1];
+											case "tao":
+												return 4 + rand[2];
+											case "shan":
+												return 4.5 + rand[4];
+											case "wuzhong":
+												return 4 + rand[5];
+											case "shunshou":
+												return 3 + rand[6];
+											case "nanman":
+												return 2 + rand[7];
+											case "wanjian":
+												return 2 + rand[8];
+											default:
+												return rand[0];
+										}
+									},
+								})
+								.set("rand", [Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random()])
+								.forResult();
+							if (result?.bool && result.links?.length) {
+								const {
+									links: [link],
+								} = result;
+								const name = link[2];
+								const result2 = await player.chooseCard({ position: "he", prompt: "设伏：选择一张牌作为“伏兵”", forced: true }).forResult();
+								const { cards } = result2;
+								if (cards?.length) {
+									await player.addToExpansion({ cards, source: player, animate: "give", gaintag: [skill] });
+									if (player.getExpansions(skill).includes(cards[0])) {
+										player.markAuto(skill, [[name, cards[0]]]);
+									}
+								}
+							}
+						}
+					}
+				},
+			},
+		},
+	},
+	mbbenyu: {
+		audio: "benyu",
+		trigger: {
+			player: "damageEnd",
+		},
+		filter(event, player) {
+			if (!event.source?.isIn()) {
+				return false;
+			}
+			const targetNum = event.source.countCards("h");
+			const playerNum = player.countCards("h");
+			const delta = playerNum - targetNum;
+			return delta < 0 ? playerNum < Math.min(5, targetNum) : true;
+		},
+		logTarget: "source",
+		async cost(event, trigger, player) {
+			const target = trigger.source;
+			const targetNum = target.countCards("h");
+			const sgn = Math.sign(player.countCards("h") - targetNum);
+			if (sgn <= 0) {
+				event.result = await player
+					.chooseBool({
+						prompt: get.prompt(event.skill, target),
+						prompt2: sgn == 0 ? "令其技能失效直到你下回合开始" : `你将手牌摸至${Math.min(5, targetNum)}`,
+						choice: sgn == 0 ? get.attitude(player, target) <= 0 : true,
+					})
+					.forResult();
+			} else {
+				event.result = await player
+					.chooseToDiscard({
+						prompt: get.prompt(event.skill, target),
+						prompt2: `弃置至少${get.cnNumber(targetNum + 1)}张牌对其造成一点伤害`,
+						selectCard: [targetNum + 1, Infinity],
+						ai(card) {
+							const { player, target, num } = get.event();
+							if (ui.selected.cards.length >= num) {
+								return -1;
+							}
+							if (get.damageEffect(target, player, player) > 0 && (get.value(card, player) < 0 || num <= 2)) {
+								return 8 - get.value(card);
+							}
+							return -1;
+						},
+						chooseonly: true,
+						allowChooseAll: true,
+					})
+					.set("target", target)
+					.set("num", targetNum + 1)
+					.forResult();
+			}
+			event.result.cost_data ??= {};
+			event.result.cost_data.sgn = sgn;
+		},
+		async content(event, trigger, player) {
+			const {
+				cost_data: { sgn },
+				cards,
+				targets: [target],
+			} = event;
+			if (sgn < 0) {
+				await player.drawTo(Math.min(5, target.countCards("h")));
+			} else if (sgn == 0) {
+				target.addAdditionalSkill(`${event.name}_${player.playerid}`, "baiban");
+				player.addTempSkill(`${event.name}_clear`, { player: "phaseBeginStart" });
+			} else {
+				await player.modedDiscard({ cards });
+				await target.damage();
+			}
+		},
+		subSkill: {
+			clear: {
+				charlotte: true,
+				onremove(player, skill) {
+					game.players.forEach(target => target.removeAdditionalSkill("mbbenyu_" + player.playerid));
+				},
+			},
+		},
+	},
+	//董白
+	mblianzhu: {
+		audio: "lianzhu",
+		enable: "phaseUse",
+		usable: 1,
+		filterCard: true,
+		filterTarget: lib.filter.notMe,
+		lose: false,
+		discard: false,
+		delay: false,
+		async content(event, trigger, player) {
+			const {
+				cards: [card],
+				target,
+			} = event;
+			await player.showCards(card);
+			player.addTempSkill(event.name + "_effect", "phaseChange");
+			target.addTempSkill(event.name + "_mark", "phaseChange");
+			const next = player.give(card, target);
+			next.gaintag.add(event.name);
+			await next;
+			/**@type { Player | null } */
+			let targetx = target;
+			while (targetx && targetx != player) {
+				const prevPlayer = targetx.getPrevious();
+				/** @type { Partial<Result> } */
+				let result;
+				if (!targetx.hasCards("he", cardx => cardx != card)) {
+					result = { bool: false };
+				} else {
+					result = await targetx
+						.chooseToGive({
+							prompt: `连诛：交给${get.translation(player)}一张不为${get.translation(card)}的牌${prevPlayer ? `然后将连诛牌交给${get.translation(prevPlayer)}` : ""}，否则其摸两张牌`,
+							target: player,
+							filterCard(card, player) {
+								// @ts-ignore
+								return card !== get.event().card;
+							},
+							position: "he",
+							ai(card) {
+								return 5.5 - get.value(card);
+							},
+						})
+						.set("card", card)
+						.forResult();
+				}
+				if (result?.bool) {
+					if (prevPlayer) {
+						prevPlayer.addTempSkill(event.name + "_mark", "phaseChange");
+						const next = targetx.give(card, prevPlayer);
+						next.gaintag.add(event.name);
+						await next;
+					}
+					targetx = prevPlayer;
+				} else {
+					await player.draw(2);
+					break;
+				}
+			}
+		},
+		ai: {
+			order: 8,
+			result: {
+				target(player, target) {
+					if (target == player.getPrevious()) {
+						return 1;
+					}
+				},
+			},
+		},
+		subSkill: {
+			mark: {
+				init(player, skill) {
+					player.addTip(skill, "连诛");
+				},
+				onremove(player, skill) {
+					player.removeGaintag("mblianzhu");
+					player.removeTip(skill);
+				},
+				charlotte: true,
+				firstDo: true,
+				silent: true,
+				trigger: {
+					player: "loseEnd",
+					global: ["loseAsyncEnd", "equipEnd", "gainEnd", "addToExpansionEnd", "addJudgeEnd"],
+				},
+				filter(event, player) {
+					const cards = event.getl?.(player)?.hs;
+					const map = event.getl?.(player)?.gaintag_map;
+					return cards.some(i => map[i.cardid]?.includes("mblianzhu")) && !player.hasCards("h", card => card.hasGaintag("mblianzhu"));
+				},
+				async content(event, trigger, player) {
+					player.removeSkill(event.name);
+				},
+			},
+			effect: {
+				charlotte: true,
+				audio: "mblianzhu",
+				mod: {
+					cardUsableTarget(card, player, target) {
+						if (target.hasCards("h", card => card.hasGaintag("mblianzhu"))) {
+							return true;
+						}
+					},
+					targetInRange(card, player, target) {
+						if (target.hasCards("h", card => card.hasGaintag("mblianzhu"))) {
+							return true;
+						}
+					},
+				},
+				trigger: {
+					source: "damageSource",
+				},
+				filter(event, player) {
+					return event.player.isIn() && event.player.hasCards("h", card => card.hasGaintag("mblianzhu"));
+				},
+				prompt2: "获得其连诛牌",
+				check: () => true,
+				logTarget: "player",
+				async content(event, trigger, player) {
+					const cards = event.targets[0].getCards("h", card => card.hasGaintag("mblianzhu"));
+					player.addTempSkill("mblianzhu_mark", "phaseChange");
+					await player.gain({ cards, animate: "giveAuto", source: event.targets[0], gaintag: ["mblianzhu"] });
+				},
+			},
+		},
+	},
+	mbxiahui: {
+		audio: "xiahui",
+		mod: {
+			ignoredHandcard(card, player) {
+				if (get.color(card) == "black") {
+					return true;
+				}
+			},
+			cardDiscardable(card, player, name) {
+				if (name == "phaseDiscard" && get.color(card) == "black") {
+					return false;
+				}
+			},
+		},
+		trigger: {
+			global: "gainAfter",
+			player: "loseAsyncAfter",
+		},
+		forced: true,
+		popup: false,
+		filter(event, player) {
+			if (event.name == "loseAsync") {
+				if (event.type != "gain") {
+					return false;
+				}
+				return game.hasPlayer(function (current) {
+					if (current == player) {
+						return false;
+					}
+					const hs = current.getCards("h"),
+						cards = event.getl(player).cards2;
+					const cardsx = event.getg(current);
+					for (const i of cardsx) {
+						if (i.hasGaintag("mblianzhu")) {
+							return true;
+						}
+						if (hs.includes(i) && cards.includes(i) && get.color(i, player) == "black") {
+							return true;
+						}
+					}
+					return false;
+				});
+			}
+			if (event.player != player) {
+				const hs = event.player.getCards("h");
+				const evt = event.getl(player);
+				return (
+					evt?.cards2?.filter(function (card) {
+						return card.hasGaintag("mblianzhu") || (hs.includes(card) && get.color(card, player) == "black");
+					}).length > 0
+				);
+			}
+			return false;
+		},
+		async content(event, trigger, player) {
+			const cards = trigger.getl(player).cards2;
+			game.filterPlayer().forEach(function (current) {
+				if (current == player) {
+					return;
+				}
+				const hs = current.getCards("h"),
+					cardsx = trigger.getg(current).filter(function (card) {
+						return hs.includes(card) && (card.hasGaintag("mblianzhu") || (cards.includes(card) && get.color(card, player) == "black"));
+					});
+				if (cardsx.length > 0) {
+					current.addSkill("mbxiahui_effect");
+					current.addGaintag(cardsx, "mbxiahui_effect");
+				}
+			});
+		},
+		subSkill: {
+			effect: {
+				mark: true,
+				intro: {
+					content: "不能使用、打出或弃置标记牌",
+				},
+				mod: {
+					cardDiscardable(card, player) {
+						if (card.hasGaintag("mbxiahui_effect")) {
+							return false;
+						}
+					},
+					cardEnabled2(card, player) {
+						if (get.itemtype(card) == "card" && card.hasGaintag("mbxiahui_effect")) {
+							return false;
+						}
+					},
+				},
+				trigger: {
+					player: "changeHp",
+				},
+				forced: true,
+				popup: false,
+				charlotte: true,
+				filter(event) {
+					return event.changedHp < 0;
+				},
+				async content(event, trigger, player) {
+					player.removeSkill(event.name);
+				},
+				onremove(player, skill) {
+					player.removeGaintag(skill);
+				},
+			},
+		},
+	},
 	// 诸葛果
 	mbqirang: {
 		audio: 2,
@@ -125,8 +1366,9 @@ const skills = {
 					}
 				}
 			}
+			player.storage.mbshanjia = num;
 			if (num > 0) {
-				player.addMark("mbshanjia", num, false);
+				player.markSkill("mbshanjia");
 			}
 		},
 		async content(event, trigger, player) {
@@ -2537,18 +3779,14 @@ const skills = {
 		audio: 4,
 		trigger: { player: "useCardAfter" },
 		filter(event, player) {
-			if (!event.targets?.length) {
-				return false;
-			}
-			return get.is.damageCard(event.card);
+			return get.is.damageCard(event.card) && event.targets?.some(target => target !== player);
 		},
 		async cost(event, trigger, player) {
 			event.result = await player
 				.chooseTarget({
 					prompt: get.prompt2(event.skill),
 					filterTarget(card, player, target) {
-						const trigger = get.event().getTrigger();
-						return trigger.targets?.includes(target);
+						return get.event().targets.includes(target);
 					},
 					ai(target) {
 						const player = get.player();
@@ -2561,6 +3799,10 @@ const skills = {
 						return 10 / target.countCards("he");
 					},
 				})
+				.set(
+					"targets",
+					trigger.targets.filter(target => target !== player)
+				)
 				.forResult();
 		},
 		async content(event, trigger, player) {
@@ -2579,7 +3821,7 @@ const skills = {
 				return num;
 			};
 			const list = [
-				//["useCard", `对${get.translation(player)}使用一张${get.translation(trigger.card.name)}`],
+				["useCard", `对${get.translation(player)}使用一张非转化且非虚拟的【${get.translation(trigger.card.name)}】`],
 				["discard", `弃置${get.cnNumber(getNum(player, target))}张牌`],
 				["damage", `${get.translation(player)}对你造成1点伤害`],
 			];
@@ -2587,7 +3829,7 @@ const skills = {
 				.map(info => info[0])
 				.filter(info => {
 					switch (info) {
-						/*case "useCard": {
+						case "useCard": {
 							return (
 								target.countCards("hs", card => {
 									if (get.name(card) != trigger.card.name) {
@@ -2596,7 +3838,7 @@ const skills = {
 									return target.canUse(card, player);
 								}) > 0
 							);
-						}*/
+						}
 						case "discard": {
 							const num = getNum(player, target);
 							return target.countDiscardableCards(target, "he") >= num;
@@ -2618,20 +3860,20 @@ const skills = {
 								ai(button) {
 									const { player, getNum } = get.event(),
 										trigger = get.event().getTrigger();
-									/*if (button.link == "useCard") {
-									const cards = player.getCards("hs", card => {
+									if (button.link == "useCard") {
+										const cards = player.getCards("hs", card => {
 											if (get.name(card) != trigger.card.name) {
 												return false;
 											}
 											return player.canUse(card, trigger.player);
-										}),
-										check = card => get.effect(trigger.player, card, player, player);
-									return check(cards.maxBy(check));
-								}*/
+										});
+										const check = card => get.effect(trigger.player, card, player, player);
+										return cards.length ? check(cards.maxBy(check)) : 0;
+									}
 									if (button.link == "discard") {
 										return get.effect(player, { name: "guohe_copy2" }, player, player) / getNum;
 									}
-									return get.damageEffect(player, player, player);
+									return get.damageEffect(player, trigger.player, player);
 								},
 							})
 							.set("getNum", getNum(player, target))
@@ -2645,21 +3887,10 @@ const skills = {
 				return;
 			}
 			const type = result.links[0];
-			//next = { skill: name, type: type, event: event };
-			game.log(target, "选择了", `#y${list.find(info => info[0] == type)?.[1]}`);
-			/*player.getHistory("custom").push(next);
-			if (
-				!player.hasHistory("custom", evt => {
-					if (evt.skill != name || evt.type != type) {
-						return false;
-					}
-					return evt.event != event;
-				})
-			) {
-				await player.draw();
-			}*/
+			const index = ["useCard", "discard", "damage"].indexOf(type);
+			game.log(player, "选择了", "#g【荡势】", "的", "#y选项" + get.cnNumber(index + 1, true));
 			switch (type) {
-				/*case "useCard": {
+				case "useCard": {
 					await target
 						.chooseToUse({
 							filterCard(card, player, event) {
@@ -2668,7 +3899,7 @@ const skills = {
 								}
 								return lib.filter.filterCard.apply(this, arguments);
 							},
-							prompt: `荡势：对${get.translation(player)}使用一张${get.translation(trigger.card.name)}`,
+							prompt: `荡势：对${get.translation(player)}使用一张非转化且非虚拟的【${get.translation(trigger.card.name)}】`,
 							addCount: false,
 							forced: true,
 							filterTarget(card, player, target) {
@@ -2682,20 +3913,34 @@ const skills = {
 						.set("complexTarget", true)
 						.set("cardx", trigger.card.name)
 						.set("sourcex", player);
-					return;
-				}*/
+					break;
+				}
 				case "discard": {
 					const num = Math.min(target.countDiscardableCards(target, "he"), getNum(player, target));
 					target.addMark(`${name}_count`, 1, false);
 					target.addTempSkill(`${name}_count`, "roundStart");
 					if (num > 0) {
-						await target.chooseToDiscard({ position: "he", forced: true, selectCard: num });
+						await target.chooseToDiscard({ position: "he", forced: true, selectCard: num, allowChooseAll: true });
 					}
-					return;
+					break;
 				}
 				default: {
 					await target.damage();
-					return;
+				}
+			}
+			const bool = !player.getStorage("hefeidangshi_choices").includes(type);
+			if (bool) {
+				for (const name of lib.phaseName) {
+					const evt = event.getParent(name);
+					if (!evt || evt.name != name) {
+						continue;
+					}
+					player.addTempSkill("hefeidangshi_choices", name + "After");
+					player.markAuto("hefeidangshi_choices", [type]);
+					await player.draw();
+					player.addTempSkill("hefeidangshi_effect", name + "After");
+					player.addMark("hefeidangshi_effect", 1, false);
+					break;
 				}
 			}
 		},
@@ -2707,15 +3952,27 @@ const skills = {
 			effect: {
 				charlotte: true,
 				onremove: true,
-				intro: {
-					content: "出杀次数+#",
-				},
+				intro: { content: "本阶段出杀次数+#" },
 				mod: {
 					cardUsable(card, player, num) {
 						if (card.name == "sha") {
 							return num + player.countMark("hefeidangshi_effect");
 						}
 					},
+				},
+			},
+			choices: {
+				charlotte: true,
+				onremove: true,
+				marktext: "势",
+				intro: {
+					content: (storage, player) =>
+						`本阶段【荡势】已执行选项：${storage
+							.map(item => {
+								const index = ["useCard", "discard", "damage"].indexOf(item);
+								return `选项${get.cnNumber(index + 1, true)}`;
+							})
+							.join("、")}`,
 				},
 			},
 		},
@@ -4506,36 +5763,14 @@ const skills = {
 	//手杀崔令仪
 	mbcaiqiu: {
 		audio: 4,
-		logAudio(event, player) {
-			if (event.name == "useCard") {
-				return ["mbcaiqiu3.mp3", "mbcaiqiu4.mp3"];
-			}
-			return 2;
-		},
-		trigger: {
-			global: ["roundStart", "useCardAfter"],
-		},
+		logAudio: () => 2,
+		trigger: { global: "roundStart" },
 		filter(event, player) {
-			if (event.name == "useCard") {
-				return (
-					event.player != player &&
-					player.getRoundHistory("gain", evt => {
-						if (evt.getParent().name != "mbcaiqiu") {
-							return false;
-						}
-						return evt.cards?.length && evt.cards.some(card => card.name == event.card.name);
-					}).length > 0
-				);
-			}
 			return game.countPlayer2(() => true, true) > 0;
 		},
 		forced: true,
 		locked: false,
 		async content(event, trigger, player) {
-			if (trigger?.name == "useCard") {
-				await player.loseHp();
-				return;
-			}
 			const cards = get.cards(
 				game.countPlayer2(() => true, true),
 				true
@@ -4545,7 +5780,7 @@ const skills = {
 				.set("ai", button => {
 					const player = get.player();
 					//只要贪不死就往死里贪
-					if (game.countPlayer(() => true) > player.hp && ["sha", "shan"].includes(button.link.name)) {
+					if (player.hp <= 1 && ["sha", "shan"].includes(button.link.name)) {
 						return 0;
 					}
 					return 1;
@@ -4554,6 +5789,31 @@ const skills = {
 			if (result?.bool && result.links?.length) {
 				await player.gain(result.links, "draw");
 			}
+		},
+		group: "mbcaiqiu_effect",
+		subSkill: {
+			effect: {
+				audio: "mbcaiqiu",
+				logAudio: () => ["mbcaiqiu3.mp3", "mbcaiqiu4.mp3"],
+				trigger: { global: "useCardAfter" },
+				filter(event, player) {
+					return (
+						event.player != player &&
+						player.hasRoundHistory("gain", evt => {
+							if (evt.getParent().name != "mbcaiqiu") {
+								return false;
+							}
+							return evt.cards?.length && evt.cards.some(card => card.name == event.card.name);
+						})
+					);
+				},
+				round: 1,
+				forced: true,
+				locked: false,
+				async content(event, trigger, player) {
+					await player.loseHp();
+				},
+			},
 		},
 	},
 	mbxishang: {
@@ -5071,28 +6331,19 @@ const skills = {
 						if (player.getStorage("mbweizhuang_blocker").includes(name)) {
 							return false;
 						}
+						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+						if (!event.filterCard(vcard, player, event)) {
+							return false;
+						}
 						const subtype = `equip${list.indexOf(name) + 1}`;
-						if (
-							!player.countCards("he", card => {
+						return (
+							player.countCards("he", card => {
 								if (get.subtype(card) != subtype) {
 									return false;
 								}
 								return count >= 4 || lib.filter.cardDiscardable(card, player, "mbweizhuang");
-							})
-						) {
-							return false;
-						}
-						if (name == "sha") {
-							return [null].concat(lib.inpile_nature).some(nature => {
-								const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
-								if (nature) {
-									vcard.nature = nature;
-								}
-								return event.filterCard(new lib.element.VCard(vcard), player, event);
-							});
-						}
-						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
-						return event.filterCard(vcard, player, event);
+							}) > 0
+						);
 					});
 				},
 				viewAs(cards, player) {
@@ -5132,21 +6383,14 @@ const skills = {
 						if (player.getStorage("mbweizhuang_blocker").includes(name)) {
 							continue;
 						}
-						const subtype = `equip${list.indexOf(name) + 1}`;
-						if (subtype != get.subtype(card, player)) {
+						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+						if (!filter(vcard, player, event)) {
 							continue;
 						}
-						if (name == "sha") {
-							return [null].concat(lib.inpile_nature).some(nature => {
-								const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
-								if (nature) {
-									vcard.nature = nature;
-								}
-								return filter(new lib.element.VCard(vcard), player, event);
-							});
+						const subtype = `equip${list.indexOf(name) + 1}`;
+						if (subtype == get.subtype(card, player)) {
+							return true;
 						}
-						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
-						return filter(vcard, player, event);
 					}
 					return false;
 				},
@@ -5156,23 +6400,11 @@ const skills = {
 				log: false,
 				check(card) {
 					const player = get.player();
-					if (_status.event.type == "phase") {
-						const subtype = get.subtype(card, player);
-						const name = ["sha", "shan", "tao", "jiu"][subtype?.slice(5) - 1];
+					if (_status.event.type === "phase") {
+						const name = ["sha", "shan", "tao", "jiu"][get.subtype(card, player)?.slice(5) - 1];
 						if (name) {
-							let value = 0;
-							if (name == "sha") {
-								for (const nature of [null].concat(lib.inpile_nature)) {
-									const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
-									if (nature) {
-										vcard.nature = nature;
-									}
-									value = Math.max(value, player.getUseValue(vcard));
-								}
-							} else {
-								value = player.getUseValue({ name: name, isCard: true, storage: { wzxiuge: true } });
-							}
-							if (value > 0) {
+							const vcard = get.autoViewAs({ name: name, isCard: true, storage: { wzxiuge: true } });
+							if (player.getUseValue(vcard) > 0) {
 								return 14 - get.value(card);
 							}
 						}
@@ -5184,42 +6416,36 @@ const skills = {
 					return get.skillInfoTranslation("mbweizhuang_xiugex", player);
 				},
 				async precontent(event, trigger, player) {
-					let name = event.result.card?.name,
-						nature = event.result.card?.nature,
-						cards = event.result.cards;
-					if (name == "sha" && get.subtype(cards[0], player) == "equip1") {
-						const parent = event.getParent();
+					const name = event.result.card?.name;
+					let nature = event.result.card?.nature;
+					const cards = event.result.cards;
+					const parent = event.getParent();
+					if (parent == null) {
+						return;
+					}
+					if (name === "sha" && get.subtype(cards[0], player) === "equip1") {
 						const list = [null].concat(lib.inpile_nature).filter(nature => {
 							const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
 							if (nature) {
 								vcard.nature = nature;
 							}
-							return parent.filterCard(new lib.element.VCard(vcard), player, parent);
+							return parent.filterCard(get.autoViewAs(vcard), player, parent);
 						});
 						if (list.length > 1) {
 							const result = await player
-								.chooseControl(list.map(nature => nature || "普通杀"))
-								.set("prompt", "绣阁：请选择视为使用的【杀】")
-								.set("ai", () => {
-									const player = get.player();
-									return get
-										.event()
-										.controls.slice()
-										.sort((a, b) => {
-											const cardA = { name: "sha", nature: a == "普通杀" ? null : a };
-											const cardB = { name: "sha", nature: b == "普通杀" ? null : b };
-											return player.getUseValue(cardB) - player.getUseValue(cardA);
-										})[0];
+								.chooseControl({
+									prompt: "绣阁：请选择视为使用的【杀】",
+									controls: list.map(nature => nature || "普通杀"),
 								})
 								.forResult();
-							nature = result.control == "普通杀" ? null : result.control;
+							nature = result.control === "普通杀" ? null : result.control;
 						} else {
 							nature = list[0];
 						}
 					}
 					player.addTempSkill("mbweizhuang_blocker");
 					player.markAuto("mbweizhuang_blocker", name);
-					event.getParent().addCount = false;
+					parent.addCount = false;
 					const count = get
 						.info("mbweizhuang")
 						.getFaceupCards(player)
@@ -5231,21 +6457,24 @@ const skills = {
 					} else {
 						const index = ["sha", "jiu", "tao", "shan"].indexOf(name) + 3;
 						player.logSkill("mbweizhuang_xiuge", null, null, null, [index]);
-						await player.modedDiscard(cards);
+						await player.modedDiscard({ cards });
 					}
 					const vcard = { name: name, isCard: true, storage: { wzxiuge: true } };
 					if (nature) {
 						vcard.nature = nature;
 					}
-					event.result.card = new lib.element.VCard(vcard);
+					event.result.card = get.autoViewAs(vcard);
 					event.result.cards = [];
 					player
 						.when("useCardAfter")
-						.filter(evt => evt.getParent() == event.getParent())
+						.filter(evt => evt.getParent() === event.getParent())
 						.step(async (event, trigger, player) => {
 							const card = get.cardPile(card => get.suit(card) == get.suit(cards[0]));
 							if (card) {
-								await player.gain(card, "gain2");
+								await player.gain({
+									cards: [card],
+									animate: "gain2",
+								});
 							}
 						});
 				},
@@ -5713,15 +6942,18 @@ const skills = {
 		filter(event, player) {
 			return game.roundNumber < 3 || player.hasSkill("mblingfa", null, false, false);
 		},
-		prompt2(event, player) {
+		async cost(event, trigger, player) {
 			switch (game.roundNumber) {
-				case 1:
-					return "本轮其他角色使用【杀】时，其需弃置一张牌，否则你对其造成1点伤害";
-				case 2:
-					return "本轮其他角色使用【桃】结算结束后，其需交给你一张牌，否则你对其造成1点伤害";
+				case 1: {
+					event.result = await player.chooseBool(get.prompt(event.skill), "本轮其他角色使用【杀】时，其需弃置一张牌，否则你对其造成1点伤害").forResult();
+					break;
+				}
+				case 2: {
+					event.result = await player.chooseBool(get.prompt(event.skill), "本轮其他角色使用【桃】结算结束后，其需交给你一张牌，否则你对其造成1点伤害").forResult();
+					break;
+				}
 				default: {
-					const skills = lib.skill["mblingfa"].derivation.filter(i => !player.hasSkill(i, null, false, false));
-					return `失去【${get.translation("mblingfa")}】${skills.length > 0 ? `并获得${skills.map(i => `【${get.translation(i)}】`).join("、")}` : ""}`;
+					event.result = { bool: true };
 				}
 			}
 		},
@@ -5751,21 +6983,21 @@ const skills = {
 				},
 				forced: true,
 				logTarget: "player",
-				content() {
-					"step 0";
-					game.delayx();
-					trigger.player
+				async content(event, trigger, player) {
+					await game.delayx();
+					const target = event.targets[0];
+					const result = await target
 						.chooseToDiscard("he", "令法：弃置一张牌，或受到来自" + get.translation(player) + "的1点伤害")
-						.set("goon", get.damageEffect(trigger.player, player, trigger.player) < 0)
+						.set("goon", get.damageEffect(target, player, target) < 0)
 						.set("ai", function (card) {
 							if (!_status.event.goon) {
 								return 0;
 							}
 							return 8 - get.value(card);
-						});
-					"step 1";
-					if (!result.bool) {
-						trigger.player.damage();
+						})
+						.forResult();
+					if (!result?.bool) {
+						await target.damage();
 					}
 				},
 				mark: true,
@@ -5781,23 +7013,21 @@ const skills = {
 				},
 				forced: true,
 				logTarget: "player",
-				content() {
-					"step 0";
-					game.delayx();
-					trigger.player
-						.chooseCard("he", "令法：交给" + get.translation(player) + "一张牌，否则受到来自其的1点伤害")
-						.set("goon", get.damageEffect(trigger.player, player, trigger.player) < 0)
+				async content(event, trigger, player) {
+					await game.delayx();
+					const target = event.targets[0];
+					const result = await target
+						.chooseToGive("he", player, "令法：交给" + get.translation(player) + "一张牌，否则受到来自其的1点伤害")
+						.set("goon", get.damageEffect(target, player, target) < 0)
 						.set("ai", function (card) {
 							if (!_status.event.goon) {
 								return 0;
 							}
 							return 8 - get.value(card);
-						});
-					"step 1";
-					if (!result.bool) {
-						trigger.player.damage();
-					} else {
-						trigger.player.give(result.cards, player);
+						})
+						.forResult();
+					if (!result?.bool) {
+						await target.damage();
 					}
 				},
 				mark: true,
@@ -6156,7 +7386,7 @@ const skills = {
 							.set("createDialog", [`###许身###令一名令你回复过体力的角色获得【${get.translation(skill)}】`, [[skill], "skill"]])
 							.set("filterTarget", (card, player, target) => {
 								const { targetx } = get.event();
-								return targetx.includes(target);
+								return targetx?.includes(target);
 							})
 							.set("ai", target => {
 								const { gainSkill: skill, player } = get.event();
@@ -6182,6 +7412,9 @@ const skills = {
 			},
 		},
 	},
+	wusheng_re_baosanniang: { audio: 1 },
+	zhiman_re_baosanniang: { audio: 1 },
+	dangxian_re_baosanniang: { audio: 1 },
 	mbzhennan: {
 		audio: "xinfu_zhennan",
 		trigger: { global: "useCardToPlayered" },
@@ -7230,10 +8463,11 @@ const skills = {
 		},
 		ai: {
 			order(item, player) {
-				let num = player.countCards("h"),
-					sha = player.countCards("h", "sha");
-				if (player.countCards("hs", card => get.tag(card, "draw"))) {
-					return 1;
+				let sha = player.countCards("hs", card => card.name == "sha" && player.hasUseTarget("sha", true, true));
+				if (!sha.length) {
+					return 0.5;
+				} else if (player.countCards("hs", card => get.tag(card, "draw"))) {
+					return 0;
 				} else if (!game.hasPlayer(target => target != player && get.attitude(player, target) < 0 && lib.skill.mbjinzu.ai.result.target(player, target) < 0)) {
 					return 0;
 				}
@@ -7241,18 +8475,23 @@ const skills = {
 			},
 			result: {
 				target(player, target) {
-					if (!target.countCards("h")) {
-						if (target.hasSkillTag("filterDamage", null, { player })) {
+					if (!target.hasCards("h")) {
+						let sha = player.countCards("hs", card => card.name == "sha" && player.hasUseTarget("sha", true, true));
+						if (!sha.length) {
 							return 0;
-						} else if (!player.countCards("h", "sha")) {
+						} else if (target.hasSkillTag("filterDamage", null, { player })) {
+							return 0;
+						} else if (!player.hasCards("h", "sha")) {
 							return 0;
 						} else if (!player.canUse("sha", target, undefined, true)) {
 							return 0;
 						} else if (get.effect(target, { name: "sha" }, player, player) < 0) {
 							return 0;
+						} else if (player.hasHistory("useSkill", evt => evt.skill == "mbanxian") && !player.canUse("sha", target, true, true)) {
+							return 0;
 						}
 					}
-					return target.countCards("h") ? -1 : -0.5;
+					return -1;
 				},
 			},
 		},
@@ -8472,7 +9711,7 @@ const skills = {
 			await game.delayx();
 			await player.viewHandcards(target);
 			// 基本牌名
-			const names = lib.inpile.filter(name => get.type(name) === "basic");
+			let names = lib.inpile.filter(name => get.type(name) === "basic");
 			// 共同拥有的牌名
 			const allNames = player
 				.getCards("h", card => target.hasCards("h", { name: get.name(card) }))
@@ -8489,49 +9728,44 @@ const skills = {
 				return !target.hasCards("h", { name: info[2] });
 			});
 			const goon = list.length > 0;
-			if (!goon && !allNames.length) {
-				return;
-			}
-			let result;
-			if (!goon) {
-				result = { index: 1 };
-			} else if (!allNames.length) {
-				result = { index: 0 };
-			} else {
-				const listx = names.filter(name => !target.hasCards("h", { name }));
-				result = await player
-					.chooseControl()
-					.set("choiceList", [`视为使用两张${listx.map(name => `【${get.translation(name)}】`).join("、")}${listx.length > 1 ? "中的牌" : ""}（不计入次数且无次数限制）`, `将你与其手牌中的${allNames.map(name => `【${get.translation(name)}】`).join("、")}替换为牌堆中等量的【杀】且你的这些牌不计入手牌上限直到你的结束阶段`])
-					.set("ai", () => {
-						const {
-							player,
-							list: [target, names, allNames],
-						} = get.event();
-						const list = get
-							.inpileVCardList(info => {
-								if (info[0] !== "basic") {
-									return false;
-								}
-								if (info[3]) {
-									return false;
-								}
-								return !target.hasCards("h", { name: info[2] });
-							})
-							.filter(info => player.hasUseTarget(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), true, false));
-						return Math.max(...list.map(info => player.getUseValue(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), false))) >
-							(() => {
-								let sum = 0;
-								sum += target.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, target), 0);
-								sum -= player.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, player), 0);
-								return sum;
-							})() *
-								Math.sign(get.attitude(player, target))
-							? 0
-							: 1;
-					})
-					.set("list", [target, names, allNames])
-					.forResult();
-			}
+			const listx = names.filter(name => !target.hasCards("h", { name }));
+			const choiceList = [];
+			choiceList.push(goon ? `视为使用两张${listx.map(name => `【${get.translation(name)}】`).join("、")}${listx.length > 1 ? "中的牌" : ""}（不计入次数且无次数限制）` : "视为使用空气");
+			choiceList.push(allNames.length ? `将你与其手牌中的${allNames.map(name => `【${get.translation(name)}】`).join("、")}替换为牌堆中等量的【杀】且你的这些牌不计入手牌上限直到你的结束阶段` : "替换空气");
+			let result = await player
+				.chooseControl()
+				.set("choiceList", choiceList)
+				.set("ai", () => {
+					const {
+						player,
+						goon,
+						list: [target, names, allNames],
+					} = get.event();
+					const list = get
+						.inpileVCardList(info => {
+							if (info[0] !== "basic") {
+								return false;
+							}
+							if (info[3]) {
+								return false;
+							}
+							return !target.hasCards("h", { name: info[2] });
+						})
+						.filter(info => player.hasUseTarget(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), true, false));
+					return Math.max(...list.map(info => player.getUseValue(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), false))) >
+						(() => {
+							let sum = 0;
+							sum += target.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, target), 0);
+							sum -= player.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, player), 0);
+							return sum;
+						})() *
+							Math.sign(get.attitude(player, target))
+						? 0
+						: 1;
+				})
+				.set("list", [target, names, allNames])
+				.set("goon", goon)
+				.forResult();
 			if (result?.index === 0) {
 				const used = [];
 				for (let i = 0; i < 2; i++) {
@@ -8567,6 +9801,7 @@ const skills = {
 							[player, cards[0]],
 							[target, cards[1]],
 						],
+						position: ui.cardPile,
 					})
 					.setContent("loseToDiscardpileMultiple");
 				let gains = [[], []];
@@ -8603,6 +9838,7 @@ const skills = {
 					}
 				}
 			}
+			names = names.filter(name => !target.storage?.["mbzengou_debuff"]?.[name]);
 			if (names.length && target.isIn()) {
 				const choose =
 					names.length > 1
@@ -9357,7 +10593,7 @@ const skills = {
 			return true;
 		},
 		check(event, player, name) {
-			return name != "roundStart";
+			return name !== "roundStart";
 		},
 		round: 1,
 		popup: false,
@@ -9382,11 +10618,13 @@ const skills = {
 					return typeof player.storage.friendyance !== "number" || player.hasMark("friendyance");
 				})
 				.set("ai", button => {
-					if (event.triggername == "roundStart") {
+					const { triggername } = get.event();
+					if (triggername === "roundStart") {
 						return 0;
 					}
-					return button.link == "minigame" ? 2 : 1;
+					return button.link === "minigame" ? 2 : 1;
 				})
+				.set("triggername", event.triggername)
 				.forResult();
 			event.result = {
 				bool: result.bool,
@@ -9431,7 +10669,7 @@ const skills = {
 				.set("ai", () => get.rand(0, 1))
 				.forResult();
 			const type = lib.inpile.map(c => get.type2(c)).unique();
-			const color = Object.keys(lib.color).filter(color => color != "none");
+			const color = Object.keys(lib.color).filter(color => color !== "none");
 			const list = [];
 			if (control === "颜色预测") {
 				list.addArray(color);
@@ -9553,7 +10791,7 @@ const skills = {
 							}
 						} else {
 							player.logSkill("friendyance", null, null, null, [trueArr.length === storage[3] ? 7 : 6]);
-							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color != "none") : lib.inpile.map(name => get.type2(name)).unique();
+							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color !== "none") : lib.inpile.map(name => get.type2(name)).unique();
 							const control =
 								choice.length > 1
 									? (
@@ -9990,51 +11228,27 @@ const skills = {
 				if (!cards.length) {
 					return;
 				}
-				const result =
-					cards.length > 1
-						? await player
-								.chooseButtonTarget({
-									createDialog: [`博鉴：请选择要分配的牌`, cards],
-									selectButton: [1, Infinity],
-									forced: true,
-									filterTarget: true,
-									ai1(button) {
-										return get.value(button.link);
-									},
-									canHidden: true,
-									ai2(target) {
-										const player = get.player();
-										const card = ui.selected.buttons[0].link;
-										if (card) {
-											return get.value(card, target) * get.attitude(player, target);
-										}
-										return 1;
-									},
-								})
-								.forResult()
-						: await player
-								.chooseTarget(`博鉴：令一名角色获得${get.translation(cards)}`, true)
-								.set("ai", target => {
-									const { player, enemy } = get.event();
-									const att = get.attitude(player, target);
-									if (enemy) {
-										return -att;
-									} else if (att > 0) {
-										return att / (1 + target.countCards("h"));
-									} else {
-										return att / 100;
-									}
-								})
-								.set("enemy", get.value(cards[0], player, "raw") < 0)
-								.forResult();
+				const result = await player
+					.chooseButtonTarget({
+						createDialog: [`博鉴：请将其中一张牌交给一名角色`, cards],
+						forced: true,
+						filterTarget: true,
+						ai1(button) {
+							return get.value(button.link);
+						},
+						canHidden: true,
+						ai2(target) {
+							const player = get.player();
+							const card = ui.selected.buttons[0].link;
+							if (card) {
+								return get.value(card, target) * get.attitude(player, target);
+							}
+							return 1;
+						},
+					})
+					.forResult();
 				if (result?.bool) {
-					let links;
-					if (!result.links?.length) {
-						links = cards.slice();
-					} else {
-						links = result.links;
-					}
-					await result.targets[0].gain(links, "gain2");
+					await result.targets[0].gain(result.links, "gain2");
 				}
 			}
 		},
@@ -13498,17 +14712,24 @@ const skills = {
 			//let num = get.mode() == "identity" ? 3 : 4;
 			let num = 3;
 			const history = game.getAllGlobalHistory("everything");
+			let index;
 			for (let i = history.length - 1; i >= 0; i--) {
 				const evt = history[i];
 				if (evt.name == "jieyu" && evt.player == player) {
 					if (!event || evt != event) {
+						index = i;
 						break;
 					}
 				}
-				if (evt.name == "useCard" && evt.player != player && evt.targets && evt.targets.includes(player) && get.tag(evt.card, "damage")) {
-					num--;
-					if (num == 1) {
-						break;
+			}
+			if (index) {
+				for (let i = index + 1; i < history.length; i++) {
+					const evt = history[i];
+					if (evt.name == "useCard" && evt.player != player && evt.targets?.includes(player) && get.is.damageCard(evt.card)) {
+						num--;
+						if (num == 1) {
+							break;
+						}
 					}
 				}
 			}
@@ -14386,6 +15607,7 @@ const skills = {
 		},
 		subSkill: {
 			target: {
+				audio: "twruilian",
 				onremove: true,
 				intro: { content: "已选择$" },
 				trigger: { global: "phaseEnd" },
@@ -21649,7 +22871,7 @@ const skills = {
 						num = get.event().getParent().num;
 					let att = get.attitude(player, target);
 					if (num <= 1) {
-						return -att * target.countCards("h");
+						return -att * (target.countCards("h") + 0.1);
 					}
 					if (num == 2) {
 						if (target.hasJudge("lebu")) {
@@ -28745,7 +29967,7 @@ const skills = {
 						return false;
 					}
 					const source = evt.targets[0];
-					return event.changedHp < 0 && event.getParent().source == source && evt.getParent(3).player == source;
+					return event.changedHp < 0 && event.getParent().source == source && event.getParent(3).player == source;
 				},
 				forced: true,
 				popup: false,

--- a/apps/core/character/mobile/skill.js
+++ b/apps/core/character/mobile/skill.js
@@ -2,1247 +2,6 @@ import { lib, game, ui, get, ai, _status } from "noname";
 
 /** @type { importCharacterConfig["skill"] } */
 const skills = {
-	//界周妃
-	reliangyin: {
-		audio: 2,
-		trigger: {
-			global: ["addToExpansionAfter", "loseAsyncAfter", "gainAfter"],
-		},
-		getIndex(event, player) {
-			if (event.name == "loseAsync") {
-				if (event.type == "addToExpansion") {
-					return 1;
-				}
-				if (event.type == "gain") {
-					const xs = game.filterPlayer2(() => true, void 0, true).flatMap(target => target => event.getl(target)?.xs || []);
-					return game
-						.filterPlayer2(
-							target => {
-								return event.getg(target)?.containsSome(...xs);
-							},
-							void 0,
-							true
-						)
-						.sortBySeat();
-				}
-			}
-			if (event.name == "gain") {
-				return game.hasPlayer2(target => event.getl(target)?.xs?.length, true) ? 1 : 0;
-			}
-			return 1;
-		},
-		filter(event, player) {
-			return true;
-		},
-		async cost(event, trigger, player) {
-			const funcName = trigger.name == "gain" || trigger.type == "gain" ? "discard" : "draw";
-			console.log(funcName);
-			event.result = await player
-				.chooseTarget({
-					prompt: get.prompt(event.skill),
-					prompt2: `令一名角色${funcName == "discard" ? "弃置" : "摸"}一张牌`,
-					filterTarget(card, player, target) {
-						return get.event().funcName == "discard" ? target.hasDiscardableCards(target, "he") : true;
-					},
-					ai(target) {
-						const { funcName, player } = get.event();
-						return get.effect(target, { name: funcName == "discard" ? "guohe_copy2" : "draw" }, player, player);
-					},
-				})
-				.set("funcName", funcName)
-				.forResult();
-			event.result.cost_data ??= {};
-			event.result.cost_data.funcName = funcName;
-		},
-		async content(event, trigger, player) {
-			const {
-				cost_data: { funcName },
-				targets: [target],
-			} = event;
-			if (funcName == "discard") {
-				await target.chooseToDiscard({ forced: true, position: "he" });
-			} else {
-				await target.draw();
-			}
-		},
-		group: "reliangyin_end",
-		subSkill: {
-			end: {
-				audio: "reliangyin",
-				trigger: {
-					global: "roundEnd",
-				},
-				filter(event, player) {
-					const targets = player
-						.getRoundHistory("useSkill", evt => evt.skill == "reliangyin")
-						.flatMap(evt => evt.targets)
-						.unique();
-					return game.countPlayer(target => !targets.includes(target)) == 1 || targets.length == 1;
-				},
-				async cost(event, trigger, player) {
-					const targets = player
-						.getRoundHistory("useSkill", evt => evt.skill == "reliangyin")
-						.flatMap(evt => evt.targets)
-						.unique();
-					let funcName;
-					let target;
-					if (targets.length == 1) {
-						funcName = "recover";
-						target = targets[0];
-					} else {
-						funcName = "loseHp";
-						target = game.findPlayer(target => !targets.includes(target));
-					}
-					event.result = await player
-						.chooseBool({
-							prompt: get.prompt(event.skill, target),
-							prompt2: `令其${funcName == "recover" ? "回复" : "失去"}一点体力`,
-							chioce: (() => {
-								if (funcName == "recover") {
-									return get.recoverEffect(target, player, player) > 0;
-								}
-								return get.effect(target, { name: "losehp" }, player, player) > 0;
-							})(),
-						})
-						.forResult();
-					event.result.cost_data ??= {};
-					event.result.targets = [target];
-					event.result.cost_data.funcName = funcName;
-				},
-				async content(event, trigger, player) {
-					const {
-						cost_data: { funcName },
-						targets: [target],
-					} = event;
-					await target[funcName]();
-				},
-			},
-		},
-	},
-	rekongsheng: {
-		audio: 2,
-		trigger: {
-			player: ["phaseZhunbeiBegin", "recoverEnd", "loseHpEnd"],
-		},
-		filter(event, player) {
-			return _status.currentPhase?.hasCards("he");
-		},
-		logTarget: () => _status.currentPhase,
-		async cost(event, trigger, player) {
-			const target = _status.currentPhase;
-			if (target == player) {
-				event.result = await player
-					.chooseCard({
-						prompt: get.prompt2(event.skill, target),
-						position: "he",
-						selectCard: [1, Infinity],
-						ai(card) {
-							const player = get.player();
-							if (get.position(card) == "e") {
-								return 1 - get.value(card);
-							}
-							if (card.name == "shan" || card.name == "du" || !player.hasValueTarget(card)) {
-								return 1;
-							}
-							return 4 - get.value(card);
-						},
-					})
-					.forResult();
-			} else {
-				event.result = await player
-					.choosePlayerCard({
-						prompt: get.prompt2(event.skill, target),
-						position: "he",
-						selectButton: [1, Infinity],
-						target,
-						ai(button) {
-							const att = get.attitude(get.player(), get.event().target);
-							if (att < 0) {
-								return get.buttonValue(button);
-							}
-							return 0;
-						},
-					})
-					.forResult();
-			}
-		},
-		intro: {
-			content: "expansion",
-			markcount: "expansion",
-		},
-		async content(event, trigger, player) {
-			const {
-				targets: [target],
-				cards,
-			} = event;
-			await target.addToExpansion({ cards, animate: "give", source: target, gaintag: [event.name] });
-			player
-				.when({ global: "phaseJieshuBegin" })
-				.filter(evt => {
-					return evt.player == target;
-				})
-				.then(async (event, trigger, player) => {
-					if (!target.hasExpansions("rekongsheng")) {
-						return;
-					}
-					const cards = target.getExpansions("rekongsheng").filter(card => {
-						return player.hasUseTarget(card, void 0, false) || (get.info(card).notarget && lib.filter.cardEnabled(card, player));
-					});
-					if (cards.length) {
-						const result = await player
-							.chooseButton({
-								createDialog: [`箜声：请选择要使用的牌`, cards],
-								ai(button) {
-									return get.player().getUseValue(button.link);
-								},
-							})
-							.forResult();
-						if (result?.bool) {
-							const { links } = result;
-							await player.chooseUseTarget({ card: links[0], addCount: false });
-						}
-					}
-					await target.gain({ cards: target.getExpansions("rekongsheng"), animate: "gain2" });
-				});
-		},
-	},
-	//界严颜
-	rejuzhan: {
-		audio: 2,
-		init(player, skill) {
-			player.addSkill(skill + "_mark");
-		},
-		onremove(player, skill) {
-			player.removeSkill(skill + "_mark");
-		},
-		zhuanhuanji: true,
-		mark: true,
-		marktext: "☯",
-		intro: {
-			markcount(storage, player, skill) {
-				return player.countMark(skill + "_yang") + "/" + player.countMark(skill + "_yin");
-			},
-			content(storage, player) {
-				return "转换技，" + (!storage ? "当你或者此状态下第三次有角色成为【杀】的目标后，你可以与此【杀】的使用者各摸一张牌，然后其本回合不能对你使用牌" : "当你或者此状态下第三次有角色使用【杀】指定目标后，你可以获得此【杀】的目标角色一张牌，然后你本回合不能对其使用牌") + "。乘势：你于出牌阶段内使用【杀】的次数+1，且此【杀】结算完毕后，你获得之。";
-			},
-		},
-		trigger: {
-			global: ["useCardToTargeted", "useCardToPlayered"],
-		},
-		filter(event, player, name) {
-			if (event.card.name !== "sha") {
-				return false;
-			}
-			if (name == "useCardToPlayered") {
-				return player.storage.rejuzhan && (event.player == player || player.countMark("rejuzhan_yin") == 3) && event.target.hasGainableCards(player, "he");
-			}
-			return !player.storage.rejuzhan && (event.target == player || player.countMark("rejuzhan_yang") == 3);
-		},
-		logTarget: (event, player, name) => (name == "useCardToTargeted" ? event.player : event.target),
-		check: () => true,
-		async content(event, trigger, player) {
-			const {
-				targets: [target],
-			} = event;
-			const suffix = !player.storage[event.name] ? "yang" : "yin";
-			player.changeZhuanhuanji(event.name);
-			let isChengshi = false;
-			if (event.triggername == "useCardToTargeted") {
-				await game.asyncDraw([player, target]);
-				target.addTempSkill(event.name + "_debuff");
-				target.markAuto(event.name + "_debuff", player);
-				if (trigger.target == player && player.countMark(`${event.name}_${suffix}`) == 3) {
-					isChengshi = true;
-				}
-			} else {
-				await player.gainPlayerCard({ target, position: "he", forced: true });
-				player.addTempSkill(event.name + "_debuff");
-				player.markAuto(event.name + "_debuff", target);
-				if (trigger.player == player && player.countMark(`${event.name}_${suffix}`) == 3) {
-					isChengshi = true;
-				}
-			}
-			if (isChengshi) {
-				player.addSkill(event.name + "_sha");
-				player.addMark(event.name + "_sha", 1, false);
-				player
-					.when({ global: "useCardAfter" })
-					.filter(evt => evt.card == trigger.card)
-					.then(async (event, trigger, player) => {
-						const cards = trigger.cards?.filterInD("od");
-						if (cards?.length) {
-							await player.gain({ cards, animate: "gain2" });
-						}
-					});
-			}
-		},
-		subSkill: {
-			sha: {
-				charlotte: true,
-				marktext: "杀",
-				onremove: true,
-				intro: {
-					content: "出杀次数+#",
-				},
-				mod: {
-					cardUsable(card, player, num) {
-						if (get.name(card) == "sha") {
-							return num + player.countMark("rejuzhan_sha");
-						}
-					},
-				},
-			},
-			debuff: {
-				charlotte: true,
-				onremove: true,
-				intro: {
-					content: "你不能对$使用牌",
-				},
-				mod: {
-					playerEnabled(card, player, target) {
-						if (player.getStorage("rejuzhan_debuff").includes(target)) {
-							return false;
-						}
-					},
-				},
-			},
-			mark: {
-				charlotte: true,
-				silent: true,
-				trigger: {
-					global: ["useCardToTargeted", "useCardToPlayered"],
-				},
-				filter(event, player, name) {
-					if (event.card.name !== "sha") {
-						return false;
-					}
-					if (name == "useCardToPlayered") {
-						return player.storage.rejuzhan;
-					}
-					return !player.storage.rejuzhan;
-				},
-				async content(event, trigger, player) {
-					if (event.triggername == "useCardToPlayered") {
-						player.addMark("rejuzhan_yin", 1, false);
-					} else {
-						player.addMark("rejuzhan_yang", 1, false);
-					}
-					player.markSkill("rejuzhan");
-				},
-			},
-		},
-	},
-	//高翔
-	mbgxchiyuan: {
-		audio: 2,
-		enable: "phaseUse",
-		usable: 1,
-		filterCard: true,
-		selectCard: 1,
-		filterTarget(card, player, target) {
-			return target != player && target.hp < player.hp;
-		},
-		selectTarget: 1,
-		filter(event, player) {
-			return game.hasPlayer(target => get.info("mbgxchiyuan")?.filterTarget?.(void 0, player, target));
-		},
-		lose: false,
-		discard: false,
-		delay: false,
-		async content(event, trigger, player) {
-			const { cards, target } = event;
-			await player.give(cards, target);
-			const virtualSha = get.autoViewAs({ name: "sha", isCard: true });
-			const targets = game.filterPlayer(targetx => {
-				return targetx.inRange(target) && player.canUse(virtualSha, targetx, false, false);
-			});
-			if (!targets.length) {
-				return;
-			}
-			const result = await player
-				.chooseTarget({
-					prompt: `驰援：请选择攻击范围内包含${get.translation(target)}的一名角色，视为对其使用一张【杀】`,
-					filterTarget(card, player, target) {
-						return get.event().targets.includes(target);
-					},
-					forced: true,
-				})
-				.set("targets", targets)
-				.forResult();
-			if (!result?.targets?.length) {
-				return;
-			}
-			const useEvent = player.useCard({ card: virtualSha, targets: result.targets, addCount: false });
-			await useEvent;
-			const damaged = game.hasPlayer2(target => target.hasHistory("damage", evt => evt.card === useEvent.card), true);
-			if (damaged) {
-				await target.recover();
-			} else {
-				await game.doAsyncInOrder(useEvent.targets, async shaUser => {
-					if (shaUser.canUse(virtualSha, player, false, false)) {
-						return shaUser.useCard({ card: virtualSha, targets: [player], addCount: false });
-					}
-				});
-			}
-		},
-		ai: {
-			order: 8,
-			result: {
-				target(player, target) {
-					if (target.hp < player.hp) {
-						const att = get.attitude(player, target);
-						if (att > 0) {
-							const shaTargets = game.filterPlayer(t => t != player && t.inRange(target) && get.effect(t, { name: "sha", isCard: true }, player, player) > 0);
-							if (shaTargets.length) {
-								return att;
-							}
-						}
-					}
-					return 0;
-				},
-			},
-		},
-	},
-	mberdi: {
-		audio: 2,
-		trigger: { player: "phaseJieshuBegin" },
-		filter(event, player) {
-			return game.hasPlayer(target => target != player && target.countCards("h") > player.countCards("h"));
-		},
-		async cost(event, trigger, player) {
-			event.result = await player
-				.chooseTarget({
-					prompt: get.prompt2(event.skill),
-					filterTarget(card, player, target) {
-						return target != player && target.countCards("h") > player.countCards("h");
-					},
-					ai(target) {
-						return -get.attitude(get.player(), target) * (114514 - target.countCards("h"));
-					},
-				})
-				.forResult();
-		},
-		async content(event, trigger, player) {
-			const target = event.targets[0];
-			await player.loseHp();
-			await player.draw();
-			const discardMap = await game.chooseAnyOL([player, target], get.info(event.name).chooseToDiscard, []).forResult();
-			const playerResult = discardMap.get(player);
-			const targetResult = discardMap.get(target);
-			const playerCount = playerResult?.cards?.length || 0;
-			const targetCount = targetResult?.cards?.length || 0;
-			for (const targetx of [player, target]) {
-				const result = discardMap.get(targetx);
-				if (result?.bool && result.cards?.length) {
-					await targetx.modedDiscard(result.cards);
-				}
-			}
-			if (playerCount > targetCount) {
-				await player.recover();
-				await target.damage();
-			} else if (playerCount < targetCount) {
-				await player.draw(targetCount);
-			}
-		},
-		/**
-		 *
-		 * @param { Player } player
-		 * @param { number } eventId
-		 * @returns { GameEvent }
-		 */
-		chooseToDiscard(player, eventId) {
-			const next = player.chooseToDiscard({
-				prompt: "饵敌：请弃置任意张手牌",
-				selectCard: [1, player.countCards("h")],
-				position: "h",
-				chooseonly: true,
-				forced: true,
-			});
-			next.set("id", eventId);
-			next.set("_global_waiting", true);
-			return next;
-		},
-	},
-	//崔琰毛玠
-	mbzhengbi: {
-		audio: 2,
-		intro: {
-			content: "可选择的角色+#",
-		},
-		trigger: {
-			player: "phaseZhunbeiBegin",
-		},
-		filter(event, player) {
-			return game.hasPlayer(target => target != player);
-		},
-		async cost(event, trigger, player) {
-			event.result = await player
-				.chooseTarget({
-					prompt: get.prompt2(event.skill),
-					filterTarget(card, player, target) {
-						return target != player && target.hasCards("hej");
-					},
-					selectTarget: [1, 1 + player.countMark(event.skill)],
-					ai(target) {
-						const player = get.player();
-						const storage = player.getStorage("mbzhengbi_used");
-						const att = get.attitude(player, target);
-						if (att > 0) {
-							if (!storage.includes(target) || target.hasCards("j")) {
-								return 114515 - target.countCards("hej");
-							}
-							return 0;
-						}
-						return 114514 - target.countCards("hej");
-					},
-				})
-				.forResult();
-		},
-		async content(event, trigger, player) {
-			const { targets } = event;
-			await game.doAsyncInOrder(targets, async target => {
-				const result = await target
-					.chooseControl({
-						prompt: `征辟：请选择令${get.translation(player)}获得的牌数`,
-						controls: [1, 2, 3].map(i => i.toString()),
-						choice: get.attitude(player, target) > 0 ? 2 : 0,
-					})
-					.forResult();
-				const { index } = result;
-				if (typeof index == "number") {
-					if (index + 1 == 3 && !player.getStorage(event.name + "_used").includes(target)) {
-						player.addMark(event.name, 1, false);
-						player.markAuto(event.name + "_used", target);
-					}
-					await player.gainPlayerCard({ target, position: "hej", selectButton: index + 1, forced: true });
-					await player.chooseToGive({ target, position: "he", forced: true, selectCard: index + 1 });
-				}
-			});
-		},
-	},
-	mbfengying: {
-		audio: 2,
-		limited: true,
-		skillAnimation: true,
-		animationColor: "thunder",
-		enable: "phaseUse",
-		filterTarget: true,
-		async content(event, trigger, player) {
-			const { target, name } = event;
-			player.awakenSkill(name);
-			const targets = game.filterPlayer(i => target.inRange(i));
-			await game.doAsyncInOrder(targets, async source => {
-				if (source.hasCards("hs", card => lib.filter.targetEnabled2(get.autoViewAs({ name: "wuzhong" }, [card]), source, target))) {
-					await source
-						.chooseToUse({ forced: true })
-						.set("openskilldialog", `奉迎：将一张手牌当做【无中生有】对${get.translation(target)}使用`)
-						.set("norestore", true)
-						.set("_backupevent", `${event.name}_backup`)
-						.set("custom", {
-							add: {},
-							replace: { window() {} },
-						})
-						.backup(`${event.name}_backup`)
-						.set("targetRequired", true)
-						.set("complexTarget", true)
-						.set("complexSelect", true)
-						.set("pre_target", target);
-				}
-			});
-			if (target.isMaxMaxHp()) {
-				player.addTempSkill(event.name + "_effect");
-			}
-		},
-		ai: {
-			order: 10,
-			result: {
-				target(player, target) {
-					if (target.isMaxMaxHp()) {
-						return 2 + game.countPlayer(i => target.inRange(i));
-					}
-					return game.countPlayer(i => target.inRange(i));
-				},
-			},
-		},
-		subSkill: {
-			effect: {
-				audio: "mbfengying",
-				charlotte: true,
-				forced: true,
-				trigger: {
-					global: "phaseEnd",
-				},
-				async content(event, trigger, player) {
-					player.removeSkill(event.name);
-					player.insertPhase();
-				},
-				mark: true,
-				intro: {
-					content: "当前回合结束时获得一个额外回合",
-				},
-			},
-			backup: {
-				viewAs: {
-					name: "wuzhong",
-				},
-				filterCard: true,
-				position: "hs",
-				selectCard: 1,
-				check(card) {
-					return 6 - get.value(card);
-				},
-				filterTarget(card, player, target) {
-					if (target != get.event().pre_target) {
-						return false;
-					}
-					return lib.filter.targetEnabled2.call(this, card, player, target);
-				},
-				log: false,
-			},
-		},
-	},
-	//钟繇
-	mbzuoding: {
-		audio: "zuoding",
-		trigger: { global: "useCardToPlayered" },
-		filter(event, player) {
-			if (event.getParent()?.triggeredTargets3.length > 1) {
-				return false;
-			}
-			return get.suit(event.card) == "spade" && event.targets?.length > 0 && event.player != player && event.player.isPhaseUsing() && [player, ...event.targets].some(target => !target.hasHistory("damage", evt => evt.num > 0 && evt.getParent("phaseUse") == event.getParent("phaseUse")));
-		},
-		async cost(event, trigger, player) {
-			event.result = await player
-				.chooseTarget({
-					prompt: get.prompt(event.skill),
-					prompt2: "令一名目标角色摸一张牌",
-					filterTarget(card, player, target) {
-						return get.event().targets.includes(target);
-					},
-					ai(target) {
-						return get.attitude(get.event().player, target);
-					},
-				})
-				.set("targets", trigger.targets)
-				.forResult();
-		},
-		logTarget: "targets",
-		async content(event, trigger, player) {
-			await event.targets[0].draw();
-		},
-		ai: {
-			expose: 0.2,
-		},
-	},
-	//兀突骨
-	mbranshang: {
-		audio: "ranshang",
-		trigger: { player: "damageEnd" },
-		filter(event, player) {
-			return event.hasNature("fire");
-		},
-		forced: true,
-		async content(event, trigger, player) {
-			player.addMark(event.name, trigger.num);
-		},
-		intro: {
-			name2: "燃",
-			content: "mark",
-		},
-		ai: {
-			neg: true,
-			effect: {
-				target(card, player, target, current) {
-					if (card.name == "sha") {
-						if (game.hasNature(card, "fire") || player.hasSkill("zhuque_skill")) {
-							return 2;
-						}
-					}
-					if (get.tag(card, "fireDamage") && current < 0) {
-						return 2;
-					}
-				},
-			},
-		},
-		group: "mbranshang_loseHp",
-		subSkill: {
-			loseHp: {
-				audio: "ranshang",
-				trigger: { player: "phaseJieshuBegin" },
-				forced: true,
-				filter(event, player) {
-					return player.countMark("mbranshang") > 0;
-				},
-				async content(event, trigger, player) {
-					await player.loseHp(player.countMark("mbranshang"));
-					if (player.countMark("mbranshang") >= player.getDamagedHp()) {
-						await player.loseMaxHp({ num: 2 });
-						await player.draw(2);
-					}
-				},
-			},
-		},
-	},
-	mbhanyong: {
-		audio: "hanyong",
-		trigger: {
-			player: "useCard",
-		},
-		filter(event, player) {
-			return event.targets?.length > 1 && player.isDamaged();
-		},
-		async cost(event, trigger, player) {
-			const { card, targets } = trigger;
-			const result = await player
-				.chooseControl({
-					prompt: get.prompt2(event.skill),
-					choiceList: [`摸一张牌`, `令${get.translation(card)}造成的伤害+1`, `背水！获得一个“燃”`],
-					controls: ["选项一", "选项二", "背水！", "cancel2"],
-					choice: (() => {
-						if (!get.is.damageCard(card)) {
-							return 0;
-						}
-						if (targets.reduce((sum, target) => sum + get.effect(target, card, player, player), 0) > 0) {
-							return 1;
-						}
-						return 0;
-					})(),
-				})
-				.forResult();
-			if (result.control !== "cancel2") {
-				event.result = {
-					bool: true,
-					cost_data: { index: result.index },
-				};
-			}
-		},
-		async content(event, trigger, player) {
-			const {
-				cost_data: { index },
-			} = event;
-			if (index % 2 == 0) {
-				await player.draw();
-			}
-			if (index > 0) {
-				game.log(trigger.card, "的基础伤害+1");
-				trigger.baseDamage++;
-			}
-			if (index == 2) {
-				player.addMark("mbranshang");
-			}
-		},
-	},
-	//程昱
-	mbshefu: {
-		audio: "shefu",
-		onremove(player, skill) {
-			delete player.storage[skill];
-			const cards = player.getExpansions(skill);
-			if (cards.length) {
-				player.loseToDiscardpile({ cards });
-			}
-		},
-		intro: {
-			content: "cards",
-			mark(dialog, storage, player) {
-				const cards = storage.map(arr => arr[1]);
-				const names = storage.map(arr => arr[0]);
-				dialog.addAuto(cards);
-				if (player.isUnderControl(true)) {
-					const { buttons } = dialog;
-					buttons.forEach((button, index) => ui.create.cardTempName(get.autoViewAs({ name: names[index] }), button));
-				}
-			},
-		},
-		trigger: {
-			player: "phaseJieshuBegin",
-		},
-		getList(player, exclude) {
-			return get.inpileVCardList(info => {
-				if (!["basic", "trick"].includes(info[0]) || (exclude && exclude == info[2])) {
-					return false;
-				}
-				if (info[2] == "sha" && info[3]) {
-					return false;
-				}
-				return !player.getStorage("mbshefu").some(arr => arr[0] == info[2]);
-			});
-		},
-		filter(event, player) {
-			return get.info("mbshefu").getList(player).length > 0 && player.hasCards("he");
-		},
-		async cost(event, trigger, player) {
-			const result = await player
-				.chooseButton({
-					createDialog: [get.prompt2(event.skill), [get.info(event.skill).getList(player), "vcard"]],
-					ai(button) {
-						const { rand } = get.event();
-						switch (button.link[2]) {
-							case "sha":
-								return 5 + rand[1];
-							case "tao":
-								return 4 + rand[2];
-							case "shan":
-								return 4.5 + rand[4];
-							case "wuzhong":
-								return 4 + rand[5];
-							case "shunshou":
-								return 3 + rand[6];
-							case "nanman":
-								return 2 + rand[7];
-							case "wanjian":
-								return 2 + rand[8];
-							default:
-								return rand[0];
-						}
-					},
-				})
-				.set("rand", [Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random()])
-				.forResult();
-			if (result?.bool && result.links?.length) {
-				const {
-					links: [link],
-				} = result;
-				event.result = {
-					bool: true,
-					cost_data: link[2],
-				};
-			}
-		},
-		async content(event, trigger, player) {
-			const { cost_data: name } = event;
-			const result = await player.chooseCard({ position: "he", prompt: "设伏：选择一张牌作为“伏兵”", forced: true }).forResult();
-			const { cards } = result;
-			if (cards?.length) {
-				await player.addToExpansion({ cards, source: player, animate: "give", gaintag: [event.name] });
-				if (player.getExpansions(event.name).includes(cards[0])) {
-					player.markAuto(event.name, [[name, cards[0]]]);
-				}
-			}
-		},
-		group: "mbshefu_exclude",
-		subSkill: {
-			exclude: {
-				audio: "shefu",
-				trigger: {
-					global: ["useCard"],
-				},
-				filter(event, player) {
-					if (_status.currentPhase == player || event.player == player || event.all_excluded) {
-						return false;
-					}
-					return player.getStorage("mbshefu").some(arr => arr[0] == get.name(event.card));
-				},
-				logTarget: "player",
-				prompt2(event, player) {
-					return `移去“伏兵”令其${event.targets?.length ? `对${get.translation(event.targets)}` : ""}使用的${get.translation(event.card)}无效`;
-				},
-				check(event, player) {
-					const { card, player: target, targets } = event;
-					const name = get.name(card);
-					let effect = 0;
-					if (name == "wuxie" || name == "shan") {
-						if (get.attitude(player, target) < -1) {
-							effect = -1;
-						}
-					} else if (targets?.length) {
-						for (let i = 0; i < targets.length; i++) {
-							effect += get.effect(targets[i], card, target, player);
-						}
-					}
-					if (effect < 0) {
-						if (name == "sha") {
-							if (targets[0] == player) {
-								return !player.countCards("h", "shan");
-							} else {
-								return targets[0].hp == 1 || (targets[0].countCards("h") <= 2 && targets[0].hp <= 2);
-							}
-						} else {
-							return true;
-						}
-					}
-					return false;
-				},
-				async content(event, trigger, player) {
-					const { card } = trigger;
-					const {
-						targets: [target],
-					} = event;
-					const name = get.name(card);
-					const skill = "mbshefu";
-					/**@type {[string, Card][]} */
-					const storage = player.getStorage(skill);
-					const index = storage.findIndex(arr => arr[0] == name);
-					if (index !== -1) {
-						console.log(index);
-						console.log(storage[index]);
-						const list = storage[index].slice();
-						storage.splice(index, 1);
-						player.setStorage(skill, storage, true);
-						await player.loseToDiscardpile({ cards: [list[1]] });
-						game.log(card, "被无效了");
-						trigger.targets.length = 0;
-						trigger.all_excluded = true;
-						const vcardList = get.info(skill).getList(player, name);
-						if (vcardList.length && player.hasCards("he")) {
-							const result = await player
-								.chooseButton({
-									createDialog: ["设伏：你可以再放置一个“伏兵”", [vcardList, "vcard"]],
-									ai(button) {
-										const { rand } = get.event();
-										switch (button.link[2]) {
-											case "sha":
-												return 5 + rand[1];
-											case "tao":
-												return 4 + rand[2];
-											case "shan":
-												return 4.5 + rand[4];
-											case "wuzhong":
-												return 4 + rand[5];
-											case "shunshou":
-												return 3 + rand[6];
-											case "nanman":
-												return 2 + rand[7];
-											case "wanjian":
-												return 2 + rand[8];
-											default:
-												return rand[0];
-										}
-									},
-								})
-								.set("rand", [Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random(), Math.random()])
-								.forResult();
-							if (result?.bool && result.links?.length) {
-								const {
-									links: [link],
-								} = result;
-								const name = link[2];
-								const result2 = await player.chooseCard({ position: "he", prompt: "设伏：选择一张牌作为“伏兵”", forced: true }).forResult();
-								const { cards } = result2;
-								if (cards?.length) {
-									await player.addToExpansion({ cards, source: player, animate: "give", gaintag: [skill] });
-									if (player.getExpansions(skill).includes(cards[0])) {
-										player.markAuto(skill, [[name, cards[0]]]);
-									}
-								}
-							}
-						}
-					}
-				},
-			},
-		},
-	},
-	mbbenyu: {
-		audio: "benyu",
-		trigger: {
-			player: "damageEnd",
-		},
-		filter(event, player) {
-			if (!event.source?.isIn()) {
-				return false;
-			}
-			const targetNum = event.source.countCards("h");
-			const playerNum = player.countCards("h");
-			const delta = playerNum - targetNum;
-			return delta < 0 ? playerNum < Math.min(5, targetNum) : true;
-		},
-		logTarget: "source",
-		async cost(event, trigger, player) {
-			const target = trigger.source;
-			const targetNum = target.countCards("h");
-			const sgn = Math.sign(player.countCards("h") - targetNum);
-			if (sgn <= 0) {
-				event.result = await player
-					.chooseBool({
-						prompt: get.prompt(event.skill, target),
-						prompt2: sgn == 0 ? "令其技能失效直到你下回合开始" : `你将手牌摸至${Math.min(5, targetNum)}`,
-						choice: sgn == 0 ? get.attitude(player, target) <= 0 : true,
-					})
-					.forResult();
-			} else {
-				event.result = await player
-					.chooseToDiscard({
-						prompt: get.prompt(event.skill, target),
-						prompt2: `弃置至少${get.cnNumber(targetNum + 1)}张牌对其造成一点伤害`,
-						selectCard: [targetNum + 1, Infinity],
-						ai(card) {
-							const { player, target, num } = get.event();
-							if (ui.selected.cards.length >= num) {
-								return -1;
-							}
-							if (get.damageEffect(target, player, player) > 0 && (get.value(card, player) < 0 || num <= 2)) {
-								return 8 - get.value(card);
-							}
-							return -1;
-						},
-						chooseonly: true,
-						allowChooseAll: true,
-					})
-					.set("target", target)
-					.set("num", targetNum + 1)
-					.forResult();
-			}
-			event.result.cost_data ??= {};
-			event.result.cost_data.sgn = sgn;
-		},
-		async content(event, trigger, player) {
-			const {
-				cost_data: { sgn },
-				cards,
-				targets: [target],
-			} = event;
-			if (sgn < 0) {
-				await player.drawTo(Math.min(5, target.countCards("h")));
-			} else if (sgn == 0) {
-				target.addAdditionalSkill(`${event.name}_${player.playerid}`, "baiban");
-				player.addTempSkill(`${event.name}_clear`, { player: "phaseBeginStart" });
-			} else {
-				await player.modedDiscard({ cards });
-				await target.damage();
-			}
-		},
-		subSkill: {
-			clear: {
-				charlotte: true,
-				onremove(player, skill) {
-					game.players.forEach(target => target.removeAdditionalSkill("mbbenyu_" + player.playerid));
-				},
-			},
-		},
-	},
-	//董白
-	mblianzhu: {
-		audio: "lianzhu",
-		enable: "phaseUse",
-		usable: 1,
-		filterCard: true,
-		filterTarget: lib.filter.notMe,
-		lose: false,
-		discard: false,
-		delay: false,
-		async content(event, trigger, player) {
-			const {
-				cards: [card],
-				target,
-			} = event;
-			await player.showCards(card);
-			player.addTempSkill(event.name + "_effect", "phaseChange");
-			target.addTempSkill(event.name + "_mark", "phaseChange");
-			const next = player.give(card, target);
-			next.gaintag.add(event.name);
-			await next;
-			/**@type { Player | null } */
-			let targetx = target;
-			while (targetx && targetx != player) {
-				const prevPlayer = targetx.getPrevious();
-				/** @type { Partial<Result> } */
-				let result;
-				if (!targetx.hasCards("he", cardx => cardx != card)) {
-					result = { bool: false };
-				} else {
-					result = await targetx
-						.chooseToGive({
-							prompt: `连诛：交给${get.translation(player)}一张不为${get.translation(card)}的牌${prevPlayer ? `然后将连诛牌交给${get.translation(prevPlayer)}` : ""}，否则其摸两张牌`,
-							target: player,
-							filterCard(card, player) {
-								// @ts-ignore
-								return card !== get.event().card;
-							},
-							position: "he",
-							ai(card) {
-								return 5.5 - get.value(card);
-							},
-						})
-						.set("card", card)
-						.forResult();
-				}
-				if (result?.bool) {
-					if (prevPlayer) {
-						prevPlayer.addTempSkill(event.name + "_mark", "phaseChange");
-						const next = targetx.give(card, prevPlayer);
-						next.gaintag.add(event.name);
-						await next;
-					}
-					targetx = prevPlayer;
-				} else {
-					await player.draw(2);
-					break;
-				}
-			}
-		},
-		ai: {
-			order: 8,
-			result: {
-				target(player, target) {
-					if (target == player.getPrevious()) {
-						return 1;
-					}
-				},
-			},
-		},
-		subSkill: {
-			mark: {
-				init(player, skill) {
-					player.addTip(skill, "连诛");
-				},
-				onremove(player, skill) {
-					player.removeGaintag("mblianzhu");
-					player.removeTip(skill);
-				},
-				charlotte: true,
-				firstDo: true,
-				silent: true,
-				trigger: {
-					player: "loseEnd",
-					global: ["loseAsyncEnd", "equipEnd", "gainEnd", "addToExpansionEnd", "addJudgeEnd"],
-				},
-				filter(event, player) {
-					const cards = event.getl?.(player)?.hs;
-					const map = event.getl?.(player)?.gaintag_map;
-					return cards.some(i => map[i.cardid]?.includes("mblianzhu")) && !player.hasCards("h", card => card.hasGaintag("mblianzhu"));
-				},
-				async content(event, trigger, player) {
-					player.removeSkill(event.name);
-				},
-			},
-			effect: {
-				charlotte: true,
-				audio: "mblianzhu",
-				mod: {
-					cardUsableTarget(card, player, target) {
-						if (target.hasCards("h", card => card.hasGaintag("mblianzhu"))) {
-							return true;
-						}
-					},
-					targetInRange(card, player, target) {
-						if (target.hasCards("h", card => card.hasGaintag("mblianzhu"))) {
-							return true;
-						}
-					},
-				},
-				trigger: {
-					source: "damageSource",
-				},
-				filter(event, player) {
-					return event.player.isIn() && event.player.hasCards("h", card => card.hasGaintag("mblianzhu"));
-				},
-				prompt2: "获得其连诛牌",
-				check: () => true,
-				logTarget: "player",
-				async content(event, trigger, player) {
-					const cards = event.targets[0].getCards("h", card => card.hasGaintag("mblianzhu"));
-					player.addTempSkill("mblianzhu_mark", "phaseChange");
-					await player.gain({ cards, animate: "giveAuto", source: event.targets[0], gaintag: ["mblianzhu"] });
-				},
-			},
-		},
-	},
-	mbxiahui: {
-		audio: "xiahui",
-		mod: {
-			ignoredHandcard(card, player) {
-				if (get.color(card) == "black") {
-					return true;
-				}
-			},
-			cardDiscardable(card, player, name) {
-				if (name == "phaseDiscard" && get.color(card) == "black") {
-					return false;
-				}
-			},
-		},
-		trigger: {
-			global: "gainAfter",
-			player: "loseAsyncAfter",
-		},
-		forced: true,
-		popup: false,
-		filter(event, player) {
-			if (event.name == "loseAsync") {
-				if (event.type != "gain") {
-					return false;
-				}
-				return game.hasPlayer(function (current) {
-					if (current == player) {
-						return false;
-					}
-					const hs = current.getCards("h"),
-						cards = event.getl(player).cards2;
-					const cardsx = event.getg(current);
-					for (const i of cardsx) {
-						if (i.hasGaintag("mblianzhu")) {
-							return true;
-						}
-						if (hs.includes(i) && cards.includes(i) && get.color(i, player) == "black") {
-							return true;
-						}
-					}
-					return false;
-				});
-			}
-			if (event.player != player) {
-				const hs = event.player.getCards("h");
-				const evt = event.getl(player);
-				return (
-					evt?.cards2?.filter(function (card) {
-						return card.hasGaintag("mblianzhu") || (hs.includes(card) && get.color(card, player) == "black");
-					}).length > 0
-				);
-			}
-			return false;
-		},
-		async content(event, trigger, player) {
-			const cards = trigger.getl(player).cards2;
-			game.filterPlayer().forEach(function (current) {
-				if (current == player) {
-					return;
-				}
-				const hs = current.getCards("h"),
-					cardsx = trigger.getg(current).filter(function (card) {
-						return hs.includes(card) && (card.hasGaintag("mblianzhu") || (cards.includes(card) && get.color(card, player) == "black"));
-					});
-				if (cardsx.length > 0) {
-					current.addSkill("mbxiahui_effect");
-					current.addGaintag(cardsx, "mbxiahui_effect");
-				}
-			});
-		},
-		subSkill: {
-			effect: {
-				mark: true,
-				intro: {
-					content: "不能使用、打出或弃置标记牌",
-				},
-				mod: {
-					cardDiscardable(card, player) {
-						if (card.hasGaintag("mbxiahui_effect")) {
-							return false;
-						}
-					},
-					cardEnabled2(card, player) {
-						if (get.itemtype(card) == "card" && card.hasGaintag("mbxiahui_effect")) {
-							return false;
-						}
-					},
-				},
-				trigger: {
-					player: "changeHp",
-				},
-				forced: true,
-				popup: false,
-				charlotte: true,
-				filter(event) {
-					return event.changedHp < 0;
-				},
-				async content(event, trigger, player) {
-					player.removeSkill(event.name);
-				},
-				onremove(player, skill) {
-					player.removeGaintag(skill);
-				},
-			},
-		},
-	},
 	// 诸葛果
 	mbqirang: {
 		audio: 2,
@@ -1366,9 +125,8 @@ const skills = {
 					}
 				}
 			}
-			player.storage.mbshanjia = num;
 			if (num > 0) {
-				player.markSkill("mbshanjia");
+				player.addMark("mbshanjia", num, false);
 			}
 		},
 		async content(event, trigger, player) {
@@ -3779,14 +2537,18 @@ const skills = {
 		audio: 4,
 		trigger: { player: "useCardAfter" },
 		filter(event, player) {
-			return get.is.damageCard(event.card) && event.targets?.some(target => target !== player);
+			if (!event.targets?.length) {
+				return false;
+			}
+			return get.is.damageCard(event.card);
 		},
 		async cost(event, trigger, player) {
 			event.result = await player
 				.chooseTarget({
 					prompt: get.prompt2(event.skill),
 					filterTarget(card, player, target) {
-						return get.event().targets.includes(target);
+						const trigger = get.event().getTrigger();
+						return trigger.targets?.includes(target);
 					},
 					ai(target) {
 						const player = get.player();
@@ -3799,10 +2561,6 @@ const skills = {
 						return 10 / target.countCards("he");
 					},
 				})
-				.set(
-					"targets",
-					trigger.targets.filter(target => target !== player)
-				)
 				.forResult();
 		},
 		async content(event, trigger, player) {
@@ -3821,7 +2579,7 @@ const skills = {
 				return num;
 			};
 			const list = [
-				["useCard", `对${get.translation(player)}使用一张非转化且非虚拟的【${get.translation(trigger.card.name)}】`],
+				//["useCard", `对${get.translation(player)}使用一张${get.translation(trigger.card.name)}`],
 				["discard", `弃置${get.cnNumber(getNum(player, target))}张牌`],
 				["damage", `${get.translation(player)}对你造成1点伤害`],
 			];
@@ -3829,7 +2587,7 @@ const skills = {
 				.map(info => info[0])
 				.filter(info => {
 					switch (info) {
-						case "useCard": {
+						/*case "useCard": {
 							return (
 								target.countCards("hs", card => {
 									if (get.name(card) != trigger.card.name) {
@@ -3838,7 +2596,7 @@ const skills = {
 									return target.canUse(card, player);
 								}) > 0
 							);
-						}
+						}*/
 						case "discard": {
 							const num = getNum(player, target);
 							return target.countDiscardableCards(target, "he") >= num;
@@ -3860,20 +2618,20 @@ const skills = {
 								ai(button) {
 									const { player, getNum } = get.event(),
 										trigger = get.event().getTrigger();
-									if (button.link == "useCard") {
-										const cards = player.getCards("hs", card => {
+									/*if (button.link == "useCard") {
+									const cards = player.getCards("hs", card => {
 											if (get.name(card) != trigger.card.name) {
 												return false;
 											}
 											return player.canUse(card, trigger.player);
-										});
-										const check = card => get.effect(trigger.player, card, player, player);
-										return cards.length ? check(cards.maxBy(check)) : 0;
-									}
+										}),
+										check = card => get.effect(trigger.player, card, player, player);
+									return check(cards.maxBy(check));
+								}*/
 									if (button.link == "discard") {
 										return get.effect(player, { name: "guohe_copy2" }, player, player) / getNum;
 									}
-									return get.damageEffect(player, trigger.player, player);
+									return get.damageEffect(player, player, player);
 								},
 							})
 							.set("getNum", getNum(player, target))
@@ -3887,10 +2645,21 @@ const skills = {
 				return;
 			}
 			const type = result.links[0];
-			const index = ["useCard", "discard", "damage"].indexOf(type);
-			game.log(player, "选择了", "#g【荡势】", "的", "#y选项" + get.cnNumber(index + 1, true));
+			//next = { skill: name, type: type, event: event };
+			game.log(target, "选择了", `#y${list.find(info => info[0] == type)?.[1]}`);
+			/*player.getHistory("custom").push(next);
+			if (
+				!player.hasHistory("custom", evt => {
+					if (evt.skill != name || evt.type != type) {
+						return false;
+					}
+					return evt.event != event;
+				})
+			) {
+				await player.draw();
+			}*/
 			switch (type) {
-				case "useCard": {
+				/*case "useCard": {
 					await target
 						.chooseToUse({
 							filterCard(card, player, event) {
@@ -3899,7 +2668,7 @@ const skills = {
 								}
 								return lib.filter.filterCard.apply(this, arguments);
 							},
-							prompt: `荡势：对${get.translation(player)}使用一张非转化且非虚拟的【${get.translation(trigger.card.name)}】`,
+							prompt: `荡势：对${get.translation(player)}使用一张${get.translation(trigger.card.name)}`,
 							addCount: false,
 							forced: true,
 							filterTarget(card, player, target) {
@@ -3913,34 +2682,20 @@ const skills = {
 						.set("complexTarget", true)
 						.set("cardx", trigger.card.name)
 						.set("sourcex", player);
-					break;
-				}
+					return;
+				}*/
 				case "discard": {
 					const num = Math.min(target.countDiscardableCards(target, "he"), getNum(player, target));
 					target.addMark(`${name}_count`, 1, false);
 					target.addTempSkill(`${name}_count`, "roundStart");
 					if (num > 0) {
-						await target.chooseToDiscard({ position: "he", forced: true, selectCard: num, allowChooseAll: true });
+						await target.chooseToDiscard({ position: "he", forced: true, selectCard: num });
 					}
-					break;
+					return;
 				}
 				default: {
 					await target.damage();
-				}
-			}
-			const bool = !player.getStorage("hefeidangshi_choices").includes(type);
-			if (bool) {
-				for (const name of lib.phaseName) {
-					const evt = event.getParent(name);
-					if (!evt || evt.name != name) {
-						continue;
-					}
-					player.addTempSkill("hefeidangshi_choices", name + "After");
-					player.markAuto("hefeidangshi_choices", [type]);
-					await player.draw();
-					player.addTempSkill("hefeidangshi_effect", name + "After");
-					player.addMark("hefeidangshi_effect", 1, false);
-					break;
+					return;
 				}
 			}
 		},
@@ -3952,27 +2707,15 @@ const skills = {
 			effect: {
 				charlotte: true,
 				onremove: true,
-				intro: { content: "本阶段出杀次数+#" },
+				intro: {
+					content: "出杀次数+#",
+				},
 				mod: {
 					cardUsable(card, player, num) {
 						if (card.name == "sha") {
 							return num + player.countMark("hefeidangshi_effect");
 						}
 					},
-				},
-			},
-			choices: {
-				charlotte: true,
-				onremove: true,
-				marktext: "势",
-				intro: {
-					content: (storage, player) =>
-						`本阶段【荡势】已执行选项：${storage
-							.map(item => {
-								const index = ["useCard", "discard", "damage"].indexOf(item);
-								return `选项${get.cnNumber(index + 1, true)}`;
-							})
-							.join("、")}`,
 				},
 			},
 		},
@@ -5763,14 +4506,36 @@ const skills = {
 	//手杀崔令仪
 	mbcaiqiu: {
 		audio: 4,
-		logAudio: () => 2,
-		trigger: { global: "roundStart" },
+		logAudio(event, player) {
+			if (event.name == "useCard") {
+				return ["mbcaiqiu3.mp3", "mbcaiqiu4.mp3"];
+			}
+			return 2;
+		},
+		trigger: {
+			global: ["roundStart", "useCardAfter"],
+		},
 		filter(event, player) {
+			if (event.name == "useCard") {
+				return (
+					event.player != player &&
+					player.getRoundHistory("gain", evt => {
+						if (evt.getParent().name != "mbcaiqiu") {
+							return false;
+						}
+						return evt.cards?.length && evt.cards.some(card => card.name == event.card.name);
+					}).length > 0
+				);
+			}
 			return game.countPlayer2(() => true, true) > 0;
 		},
 		forced: true,
 		locked: false,
 		async content(event, trigger, player) {
+			if (trigger?.name == "useCard") {
+				await player.loseHp();
+				return;
+			}
 			const cards = get.cards(
 				game.countPlayer2(() => true, true),
 				true
@@ -5780,7 +4545,7 @@ const skills = {
 				.set("ai", button => {
 					const player = get.player();
 					//只要贪不死就往死里贪
-					if (player.hp <= 1 && ["sha", "shan"].includes(button.link.name)) {
+					if (game.countPlayer(() => true) > player.hp && ["sha", "shan"].includes(button.link.name)) {
 						return 0;
 					}
 					return 1;
@@ -5789,31 +4554,6 @@ const skills = {
 			if (result?.bool && result.links?.length) {
 				await player.gain(result.links, "draw");
 			}
-		},
-		group: "mbcaiqiu_effect",
-		subSkill: {
-			effect: {
-				audio: "mbcaiqiu",
-				logAudio: () => ["mbcaiqiu3.mp3", "mbcaiqiu4.mp3"],
-				trigger: { global: "useCardAfter" },
-				filter(event, player) {
-					return (
-						event.player != player &&
-						player.hasRoundHistory("gain", evt => {
-							if (evt.getParent().name != "mbcaiqiu") {
-								return false;
-							}
-							return evt.cards?.length && evt.cards.some(card => card.name == event.card.name);
-						})
-					);
-				},
-				round: 1,
-				forced: true,
-				locked: false,
-				async content(event, trigger, player) {
-					await player.loseHp();
-				},
-			},
 		},
 	},
 	mbxishang: {
@@ -6331,19 +5071,28 @@ const skills = {
 						if (player.getStorage("mbweizhuang_blocker").includes(name)) {
 							return false;
 						}
-						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
-						if (!event.filterCard(vcard, player, event)) {
-							return false;
-						}
 						const subtype = `equip${list.indexOf(name) + 1}`;
-						return (
-							player.countCards("he", card => {
+						if (
+							!player.countCards("he", card => {
 								if (get.subtype(card) != subtype) {
 									return false;
 								}
 								return count >= 4 || lib.filter.cardDiscardable(card, player, "mbweizhuang");
-							}) > 0
-						);
+							})
+						) {
+							return false;
+						}
+						if (name == "sha") {
+							return [null].concat(lib.inpile_nature).some(nature => {
+								const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
+								if (nature) {
+									vcard.nature = nature;
+								}
+								return event.filterCard(new lib.element.VCard(vcard), player, event);
+							});
+						}
+						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+						return event.filterCard(vcard, player, event);
 					});
 				},
 				viewAs(cards, player) {
@@ -6383,14 +5132,21 @@ const skills = {
 						if (player.getStorage("mbweizhuang_blocker").includes(name)) {
 							continue;
 						}
-						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
-						if (!filter(vcard, player, event)) {
+						const subtype = `equip${list.indexOf(name) + 1}`;
+						if (subtype != get.subtype(card, player)) {
 							continue;
 						}
-						const subtype = `equip${list.indexOf(name) + 1}`;
-						if (subtype == get.subtype(card, player)) {
-							return true;
+						if (name == "sha") {
+							return [null].concat(lib.inpile_nature).some(nature => {
+								const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
+								if (nature) {
+									vcard.nature = nature;
+								}
+								return filter(new lib.element.VCard(vcard), player, event);
+							});
 						}
+						const vcard = new lib.element.VCard({ name: name, isCard: true, storage: { wzxiuge: true } });
+						return filter(vcard, player, event);
 					}
 					return false;
 				},
@@ -6400,11 +5156,23 @@ const skills = {
 				log: false,
 				check(card) {
 					const player = get.player();
-					if (_status.event.type === "phase") {
-						const name = ["sha", "shan", "tao", "jiu"][get.subtype(card, player)?.slice(5) - 1];
+					if (_status.event.type == "phase") {
+						const subtype = get.subtype(card, player);
+						const name = ["sha", "shan", "tao", "jiu"][subtype?.slice(5) - 1];
 						if (name) {
-							const vcard = get.autoViewAs({ name: name, isCard: true, storage: { wzxiuge: true } });
-							if (player.getUseValue(vcard) > 0) {
+							let value = 0;
+							if (name == "sha") {
+								for (const nature of [null].concat(lib.inpile_nature)) {
+									const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
+									if (nature) {
+										vcard.nature = nature;
+									}
+									value = Math.max(value, player.getUseValue(vcard));
+								}
+							} else {
+								value = player.getUseValue({ name: name, isCard: true, storage: { wzxiuge: true } });
+							}
+							if (value > 0) {
 								return 14 - get.value(card);
 							}
 						}
@@ -6416,36 +5184,42 @@ const skills = {
 					return get.skillInfoTranslation("mbweizhuang_xiugex", player);
 				},
 				async precontent(event, trigger, player) {
-					const name = event.result.card?.name;
-					let nature = event.result.card?.nature;
-					const cards = event.result.cards;
-					const parent = event.getParent();
-					if (parent == null) {
-						return;
-					}
-					if (name === "sha" && get.subtype(cards[0], player) === "equip1") {
+					let name = event.result.card?.name,
+						nature = event.result.card?.nature,
+						cards = event.result.cards;
+					if (name == "sha" && get.subtype(cards[0], player) == "equip1") {
+						const parent = event.getParent();
 						const list = [null].concat(lib.inpile_nature).filter(nature => {
 							const vcard = { name: "sha", isCard: true, storage: { wzxiuge: true } };
 							if (nature) {
 								vcard.nature = nature;
 							}
-							return parent.filterCard(get.autoViewAs(vcard), player, parent);
+							return parent.filterCard(new lib.element.VCard(vcard), player, parent);
 						});
 						if (list.length > 1) {
 							const result = await player
-								.chooseControl({
-									prompt: "绣阁：请选择视为使用的【杀】",
-									controls: list.map(nature => nature || "普通杀"),
+								.chooseControl(list.map(nature => nature || "普通杀"))
+								.set("prompt", "绣阁：请选择视为使用的【杀】")
+								.set("ai", () => {
+									const player = get.player();
+									return get
+										.event()
+										.controls.slice()
+										.sort((a, b) => {
+											const cardA = { name: "sha", nature: a == "普通杀" ? null : a };
+											const cardB = { name: "sha", nature: b == "普通杀" ? null : b };
+											return player.getUseValue(cardB) - player.getUseValue(cardA);
+										})[0];
 								})
 								.forResult();
-							nature = result.control === "普通杀" ? null : result.control;
+							nature = result.control == "普通杀" ? null : result.control;
 						} else {
 							nature = list[0];
 						}
 					}
 					player.addTempSkill("mbweizhuang_blocker");
 					player.markAuto("mbweizhuang_blocker", name);
-					parent.addCount = false;
+					event.getParent().addCount = false;
 					const count = get
 						.info("mbweizhuang")
 						.getFaceupCards(player)
@@ -6457,24 +5231,21 @@ const skills = {
 					} else {
 						const index = ["sha", "jiu", "tao", "shan"].indexOf(name) + 3;
 						player.logSkill("mbweizhuang_xiuge", null, null, null, [index]);
-						await player.modedDiscard({ cards });
+						await player.modedDiscard(cards);
 					}
 					const vcard = { name: name, isCard: true, storage: { wzxiuge: true } };
 					if (nature) {
 						vcard.nature = nature;
 					}
-					event.result.card = get.autoViewAs(vcard);
+					event.result.card = new lib.element.VCard(vcard);
 					event.result.cards = [];
 					player
 						.when("useCardAfter")
-						.filter(evt => evt.getParent() === event.getParent())
+						.filter(evt => evt.getParent() == event.getParent())
 						.step(async (event, trigger, player) => {
 							const card = get.cardPile(card => get.suit(card) == get.suit(cards[0]));
 							if (card) {
-								await player.gain({
-									cards: [card],
-									animate: "gain2",
-								});
+								await player.gain(card, "gain2");
 							}
 						});
 				},
@@ -6942,18 +5713,15 @@ const skills = {
 		filter(event, player) {
 			return game.roundNumber < 3 || player.hasSkill("mblingfa", null, false, false);
 		},
-		async cost(event, trigger, player) {
+		prompt2(event, player) {
 			switch (game.roundNumber) {
-				case 1: {
-					event.result = await player.chooseBool(get.prompt(event.skill), "本轮其他角色使用【杀】时，其需弃置一张牌，否则你对其造成1点伤害").forResult();
-					break;
-				}
-				case 2: {
-					event.result = await player.chooseBool(get.prompt(event.skill), "本轮其他角色使用【桃】结算结束后，其需交给你一张牌，否则你对其造成1点伤害").forResult();
-					break;
-				}
+				case 1:
+					return "本轮其他角色使用【杀】时，其需弃置一张牌，否则你对其造成1点伤害";
+				case 2:
+					return "本轮其他角色使用【桃】结算结束后，其需交给你一张牌，否则你对其造成1点伤害";
 				default: {
-					event.result = { bool: true };
+					const skills = lib.skill["mblingfa"].derivation.filter(i => !player.hasSkill(i, null, false, false));
+					return `失去【${get.translation("mblingfa")}】${skills.length > 0 ? `并获得${skills.map(i => `【${get.translation(i)}】`).join("、")}` : ""}`;
 				}
 			}
 		},
@@ -6983,21 +5751,21 @@ const skills = {
 				},
 				forced: true,
 				logTarget: "player",
-				async content(event, trigger, player) {
-					await game.delayx();
-					const target = event.targets[0];
-					const result = await target
+				content() {
+					"step 0";
+					game.delayx();
+					trigger.player
 						.chooseToDiscard("he", "令法：弃置一张牌，或受到来自" + get.translation(player) + "的1点伤害")
-						.set("goon", get.damageEffect(target, player, target) < 0)
+						.set("goon", get.damageEffect(trigger.player, player, trigger.player) < 0)
 						.set("ai", function (card) {
 							if (!_status.event.goon) {
 								return 0;
 							}
 							return 8 - get.value(card);
-						})
-						.forResult();
-					if (!result?.bool) {
-						await target.damage();
+						});
+					"step 1";
+					if (!result.bool) {
+						trigger.player.damage();
 					}
 				},
 				mark: true,
@@ -7013,21 +5781,23 @@ const skills = {
 				},
 				forced: true,
 				logTarget: "player",
-				async content(event, trigger, player) {
-					await game.delayx();
-					const target = event.targets[0];
-					const result = await target
-						.chooseToGive("he", player, "令法：交给" + get.translation(player) + "一张牌，否则受到来自其的1点伤害")
-						.set("goon", get.damageEffect(target, player, target) < 0)
+				content() {
+					"step 0";
+					game.delayx();
+					trigger.player
+						.chooseCard("he", "令法：交给" + get.translation(player) + "一张牌，否则受到来自其的1点伤害")
+						.set("goon", get.damageEffect(trigger.player, player, trigger.player) < 0)
 						.set("ai", function (card) {
 							if (!_status.event.goon) {
 								return 0;
 							}
 							return 8 - get.value(card);
-						})
-						.forResult();
-					if (!result?.bool) {
-						await target.damage();
+						});
+					"step 1";
+					if (!result.bool) {
+						trigger.player.damage();
+					} else {
+						trigger.player.give(result.cards, player);
 					}
 				},
 				mark: true,
@@ -7386,7 +6156,7 @@ const skills = {
 							.set("createDialog", [`###许身###令一名令你回复过体力的角色获得【${get.translation(skill)}】`, [[skill], "skill"]])
 							.set("filterTarget", (card, player, target) => {
 								const { targetx } = get.event();
-								return targetx?.includes(target);
+								return targetx.includes(target);
 							})
 							.set("ai", target => {
 								const { gainSkill: skill, player } = get.event();
@@ -7412,9 +6182,6 @@ const skills = {
 			},
 		},
 	},
-	wusheng_re_baosanniang: { audio: 1 },
-	zhiman_re_baosanniang: { audio: 1 },
-	dangxian_re_baosanniang: { audio: 1 },
 	mbzhennan: {
 		audio: "xinfu_zhennan",
 		trigger: { global: "useCardToPlayered" },
@@ -8463,11 +7230,10 @@ const skills = {
 		},
 		ai: {
 			order(item, player) {
-				let sha = player.countCards("hs", card => card.name == "sha" && player.hasUseTarget("sha", true, true));
-				if (!sha.length) {
-					return 0.5;
-				} else if (player.countCards("hs", card => get.tag(card, "draw"))) {
-					return 0;
+				let num = player.countCards("h"),
+					sha = player.countCards("h", "sha");
+				if (player.countCards("hs", card => get.tag(card, "draw"))) {
+					return 1;
 				} else if (!game.hasPlayer(target => target != player && get.attitude(player, target) < 0 && lib.skill.mbjinzu.ai.result.target(player, target) < 0)) {
 					return 0;
 				}
@@ -8475,23 +7241,18 @@ const skills = {
 			},
 			result: {
 				target(player, target) {
-					if (!target.hasCards("h")) {
-						let sha = player.countCards("hs", card => card.name == "sha" && player.hasUseTarget("sha", true, true));
-						if (!sha.length) {
+					if (!target.countCards("h")) {
+						if (target.hasSkillTag("filterDamage", null, { player })) {
 							return 0;
-						} else if (target.hasSkillTag("filterDamage", null, { player })) {
-							return 0;
-						} else if (!player.hasCards("h", "sha")) {
+						} else if (!player.countCards("h", "sha")) {
 							return 0;
 						} else if (!player.canUse("sha", target, undefined, true)) {
 							return 0;
 						} else if (get.effect(target, { name: "sha" }, player, player) < 0) {
 							return 0;
-						} else if (player.hasHistory("useSkill", evt => evt.skill == "mbanxian") && !player.canUse("sha", target, true, true)) {
-							return 0;
 						}
 					}
-					return -1;
+					return target.countCards("h") ? -1 : -0.5;
 				},
 			},
 		},
@@ -9711,7 +8472,7 @@ const skills = {
 			await game.delayx();
 			await player.viewHandcards(target);
 			// 基本牌名
-			let names = lib.inpile.filter(name => get.type(name) === "basic");
+			const names = lib.inpile.filter(name => get.type(name) === "basic");
 			// 共同拥有的牌名
 			const allNames = player
 				.getCards("h", card => target.hasCards("h", { name: get.name(card) }))
@@ -9728,44 +8489,49 @@ const skills = {
 				return !target.hasCards("h", { name: info[2] });
 			});
 			const goon = list.length > 0;
-			const listx = names.filter(name => !target.hasCards("h", { name }));
-			const choiceList = [];
-			choiceList.push(goon ? `视为使用两张${listx.map(name => `【${get.translation(name)}】`).join("、")}${listx.length > 1 ? "中的牌" : ""}（不计入次数且无次数限制）` : "视为使用空气");
-			choiceList.push(allNames.length ? `将你与其手牌中的${allNames.map(name => `【${get.translation(name)}】`).join("、")}替换为牌堆中等量的【杀】且你的这些牌不计入手牌上限直到你的结束阶段` : "替换空气");
-			let result = await player
-				.chooseControl()
-				.set("choiceList", choiceList)
-				.set("ai", () => {
-					const {
-						player,
-						goon,
-						list: [target, names, allNames],
-					} = get.event();
-					const list = get
-						.inpileVCardList(info => {
-							if (info[0] !== "basic") {
-								return false;
-							}
-							if (info[3]) {
-								return false;
-							}
-							return !target.hasCards("h", { name: info[2] });
-						})
-						.filter(info => player.hasUseTarget(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), true, false));
-					return Math.max(...list.map(info => player.getUseValue(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), false))) >
-						(() => {
-							let sum = 0;
-							sum += target.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, target), 0);
-							sum -= player.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, player), 0);
-							return sum;
-						})() *
-							Math.sign(get.attitude(player, target))
-						? 0
-						: 1;
-				})
-				.set("list", [target, names, allNames])
-				.set("goon", goon)
-				.forResult();
+			if (!goon && !allNames.length) {
+				return;
+			}
+			let result;
+			if (!goon) {
+				result = { index: 1 };
+			} else if (!allNames.length) {
+				result = { index: 0 };
+			} else {
+				const listx = names.filter(name => !target.hasCards("h", { name }));
+				result = await player
+					.chooseControl()
+					.set("choiceList", [`视为使用两张${listx.map(name => `【${get.translation(name)}】`).join("、")}${listx.length > 1 ? "中的牌" : ""}（不计入次数且无次数限制）`, `将你与其手牌中的${allNames.map(name => `【${get.translation(name)}】`).join("、")}替换为牌堆中等量的【杀】且你的这些牌不计入手牌上限直到你的结束阶段`])
+					.set("ai", () => {
+						const {
+							player,
+							list: [target, names, allNames],
+						} = get.event();
+						const list = get
+							.inpileVCardList(info => {
+								if (info[0] !== "basic") {
+									return false;
+								}
+								if (info[3]) {
+									return false;
+								}
+								return !target.hasCards("h", { name: info[2] });
+							})
+							.filter(info => player.hasUseTarget(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), true, false));
+						return Math.max(...list.map(info => player.getUseValue(new lib.element.VCard({ name: info[2], nature: info[3], isCard: true }), false))) >
+							(() => {
+								let sum = 0;
+								sum += target.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, target), 0);
+								sum -= player.getCards("h", { name: allNames }).reduce((num, card) => num + get.value(card, player), 0);
+								return sum;
+							})() *
+								Math.sign(get.attitude(player, target))
+							? 0
+							: 1;
+					})
+					.set("list", [target, names, allNames])
+					.forResult();
+			}
 			if (result?.index === 0) {
 				const used = [];
 				for (let i = 0; i < 2; i++) {
@@ -9801,7 +8567,6 @@ const skills = {
 							[player, cards[0]],
 							[target, cards[1]],
 						],
-						position: ui.cardPile,
 					})
 					.setContent("loseToDiscardpileMultiple");
 				let gains = [[], []];
@@ -9838,7 +8603,6 @@ const skills = {
 					}
 				}
 			}
-			names = names.filter(name => !target.storage?.["mbzengou_debuff"]?.[name]);
 			if (names.length && target.isIn()) {
 				const choose =
 					names.length > 1
@@ -10593,7 +9357,7 @@ const skills = {
 			return true;
 		},
 		check(event, player, name) {
-			return name !== "roundStart";
+			return name != "roundStart";
 		},
 		round: 1,
 		popup: false,
@@ -10618,13 +9382,11 @@ const skills = {
 					return typeof player.storage.friendyance !== "number" || player.hasMark("friendyance");
 				})
 				.set("ai", button => {
-					const { triggername } = get.event();
-					if (triggername === "roundStart") {
+					if (event.triggername == "roundStart") {
 						return 0;
 					}
-					return button.link === "minigame" ? 2 : 1;
+					return button.link == "minigame" ? 2 : 1;
 				})
-				.set("triggername", event.triggername)
 				.forResult();
 			event.result = {
 				bool: result.bool,
@@ -10669,7 +9431,7 @@ const skills = {
 				.set("ai", () => get.rand(0, 1))
 				.forResult();
 			const type = lib.inpile.map(c => get.type2(c)).unique();
-			const color = Object.keys(lib.color).filter(color => color !== "none");
+			const color = Object.keys(lib.color).filter(color => color != "none");
 			const list = [];
 			if (control === "颜色预测") {
 				list.addArray(color);
@@ -10791,7 +9553,7 @@ const skills = {
 							}
 						} else {
 							player.logSkill("friendyance", null, null, null, [trueArr.length === storage[3] ? 7 : 6]);
-							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color !== "none") : lib.inpile.map(name => get.type2(name)).unique();
+							const choice = storage[2] == "color" ? Object.keys(lib.color).filter(color => color != "none") : lib.inpile.map(name => get.type2(name)).unique();
 							const control =
 								choice.length > 1
 									? (
@@ -11228,27 +9990,51 @@ const skills = {
 				if (!cards.length) {
 					return;
 				}
-				const result = await player
-					.chooseButtonTarget({
-						createDialog: [`博鉴：请将其中一张牌交给一名角色`, cards],
-						forced: true,
-						filterTarget: true,
-						ai1(button) {
-							return get.value(button.link);
-						},
-						canHidden: true,
-						ai2(target) {
-							const player = get.player();
-							const card = ui.selected.buttons[0].link;
-							if (card) {
-								return get.value(card, target) * get.attitude(player, target);
-							}
-							return 1;
-						},
-					})
-					.forResult();
+				const result =
+					cards.length > 1
+						? await player
+								.chooseButtonTarget({
+									createDialog: [`博鉴：请选择要分配的牌`, cards],
+									selectButton: [1, Infinity],
+									forced: true,
+									filterTarget: true,
+									ai1(button) {
+										return get.value(button.link);
+									},
+									canHidden: true,
+									ai2(target) {
+										const player = get.player();
+										const card = ui.selected.buttons[0].link;
+										if (card) {
+											return get.value(card, target) * get.attitude(player, target);
+										}
+										return 1;
+									},
+								})
+								.forResult()
+						: await player
+								.chooseTarget(`博鉴：令一名角色获得${get.translation(cards)}`, true)
+								.set("ai", target => {
+									const { player, enemy } = get.event();
+									const att = get.attitude(player, target);
+									if (enemy) {
+										return -att;
+									} else if (att > 0) {
+										return att / (1 + target.countCards("h"));
+									} else {
+										return att / 100;
+									}
+								})
+								.set("enemy", get.value(cards[0], player, "raw") < 0)
+								.forResult();
 				if (result?.bool) {
-					await result.targets[0].gain(result.links, "gain2");
+					let links;
+					if (!result.links?.length) {
+						links = cards.slice();
+					} else {
+						links = result.links;
+					}
+					await result.targets[0].gain(links, "gain2");
 				}
 			}
 		},
@@ -14712,24 +13498,17 @@ const skills = {
 			//let num = get.mode() == "identity" ? 3 : 4;
 			let num = 3;
 			const history = game.getAllGlobalHistory("everything");
-			let index;
 			for (let i = history.length - 1; i >= 0; i--) {
 				const evt = history[i];
 				if (evt.name == "jieyu" && evt.player == player) {
 					if (!event || evt != event) {
-						index = i;
 						break;
 					}
 				}
-			}
-			if (index) {
-				for (let i = index + 1; i < history.length; i++) {
-					const evt = history[i];
-					if (evt.name == "useCard" && evt.player != player && evt.targets?.includes(player) && get.is.damageCard(evt.card)) {
-						num--;
-						if (num == 1) {
-							break;
-						}
+				if (evt.name == "useCard" && evt.player != player && evt.targets && evt.targets.includes(player) && get.tag(evt.card, "damage")) {
+					num--;
+					if (num == 1) {
+						break;
 					}
 				}
 			}
@@ -15607,7 +14386,6 @@ const skills = {
 		},
 		subSkill: {
 			target: {
-				audio: "twruilian",
 				onremove: true,
 				intro: { content: "已选择$" },
 				trigger: { global: "phaseEnd" },
@@ -22871,7 +21649,7 @@ const skills = {
 						num = get.event().getParent().num;
 					let att = get.attitude(player, target);
 					if (num <= 1) {
-						return -att * (target.countCards("h") + 0.1);
+						return -att * target.countCards("h");
 					}
 					if (num == 2) {
 						if (target.hasJudge("lebu")) {
@@ -29967,7 +28745,7 @@ const skills = {
 						return false;
 					}
 					const source = evt.targets[0];
-					return event.changedHp < 0 && event.getParent().source == source && event.getParent(3).player == source;
+					return event.changedHp < 0 && event.getParent().source == source && evt.getParent(3).player == source;
 				},
 				forced: true,
 				popup: false,


### PR DESCRIPTION
修复崔芙【绣阁】用武器牌视为使用【杀】时不能选择不同属性杀的问题。

调整友诸葛亮【演策】：
1. AI 不再于第一轮开始时直接选择卧龙演策；
2. 颜色预测中排除无色；
3. 结算获得牌的颜色选择中排除无色。