### PR TITLE
fix: 修复部分布局下当前角色手牌数存在偏移

### DIFF
--- a/apps/core/layout/mobile/layout.css
+++ b/apps/core/layout/mobile/layout.css
@@ -253,13 +253,13 @@
 	border-radius: 0 2px 2px 0;
 	left: -1px;
 	z-index: 3;
-	text-align: right;
+	text-align: center;
 }
 #arena:not(.chess).slim_player .player[data-position="0"]:not(.minskin) > .count {
 	border-radius: 0 2px 2px 0;
 	left: -1px;
 	z-index: 3;
-	text-align: right;
+	text-align: center;
 }
 #arena:not(.chess) .player[data-position="0"] > .hp.actcount {
 	top: 10px;


### PR DESCRIPTION
在更改手牌数样式后，在【默认】和【宽屏】布局下，当前角色的手牌数会存在向右的偏移

将相关样式从`text-align: right;`改成`text-align: center;`后得到解决