### PR TITLE
fix: 修复兼习未识别空 info 与八咫镜未处理 event.card 为 undefined 的问题

### DIFF
--- a/apps/core/character/collab/skill.js
+++ b/apps/core/character/collab/skill.js
@@ -1980,6 +1980,9 @@ const skills = {
 			) {
 				return false;
 			}
+			if (!event.card) {
+				return false;
+			}
 			const bool = player.getStorage("bazhijing").includes(event.card.name);
 			if (triggername == "damageAfter") {
 				return !bool;

--- a/apps/core/character/offline/skill.js
+++ b/apps/core/character/offline/skill.js
@@ -17451,7 +17451,7 @@ const skills = {
 					const skillsx = get.character(character, 3);
 					skillsx.forEach(skill => {
 						const info = get.info(skill);
-						if (!info || info.charlotte) {
+						if (!info || !Object.keys(info).length || info.charlotte) {
 							return false;
 						}
 						if (info.derivation) {
@@ -17461,7 +17461,7 @@ const skills = {
 							}
 							list.forEach(deriSkill => {
 								const infox = get.info(deriSkill);
-								if (!infox || infox.charlotte) {
+								if (!infox || !Object.keys(infox).length || infox.charlotte) {
 									return false;
 								}
 								if (!get.skillInfoTranslation(deriSkill).includes(`【${get.translation(name)}】`)) {


### PR DESCRIPTION
- 兼习（offline/skill.js）：initSkill 中 get.info(skill) 与 get.info(deriSkill) 均可能 返回空对象 {}，原 !info/!infox 判断无法拦截（空对象为 truthy），导致对无效技能仍继续 调用 skillInfoTranslation。两处均新增 !Object.keys(info).length 判断，与代码库既有写法一致。
- 八咫镜（collab/skill.js）：filter 中 event.card.name 在 event.card 为 undefined 时会抛 TypeError（如非卡牌造成的伤害）。新增 event.card 守卫，无牌时直接返回 false， 同时避免 content 中 markAuto 写入 undefined。