### PR TITLE
fix: 修复联机结算手牌信息异常

### DIFF
--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -10,6 +10,25 @@
  * @typedef { { mode: string, name: string[], name1: string, name2?: string, time: number, video: Video, win: boolean } } Videos
  */
 
+/**
+ * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipPayload
+ * @property {string} poptipId 结算手牌入口的稳定 ID
+ * @property {string} position 角色的联机座位标识
+ * @property {string} name 结算时的角色显示名
+ * @property {GameOverHandcardCardInfo[]} cards get.cardsInfo 生成的卡牌信息
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipOptions
+ * @property {string} poptipId
+ * @property {string} name
+ * @property {Card[]} cards
+ */
+
 import { _status, lib, get, ai, ui } from "noname";
 import { isClass, userAgentLowerCase, GeneratorFunction, AsyncFunction, delay } from "@/util/index.js";
 
@@ -20,6 +39,26 @@ import { Check } from "./check.js";
 import { security } from "@/util/sandbox.js";
 import { save } from "@/util/config.js";
 import { debounce } from "@/util/utils.js";
+
+const GAME_OVER_HANDCARD_POPTIP_PREFIX = "game_over_handcards_";
+
+/**
+ * 注册结算手牌 poptip，并返回现有手牌图标 HTML。
+ *
+ * @param {GameOverHandcardPoptipOptions} options
+ * @returns {string}
+ */
+function createGameOverHandcardPoptip({ poptipId, name, cards }) {
+	return get.poptip({
+		id: poptipId,
+		name: `<img style="width:15px; vertical-align: middle;" src="${lib.assetURL}image/card/handcard.png">`,
+		dialog(dialog) {
+			dialog.add(`${name}的手牌`);
+			dialog[cards.length > 0 ? "addSmall" : "addText"](cards.length > 0 ? cards : "（没有手牌）");
+			return dialog;
+		},
+	});
+}
 
 export class Game {
 	documentZoom;
@@ -6634,6 +6673,17 @@ ${e instanceof Error ? e.stack : String(e)}`);
 			}
 			return;
 		}
+		let handcardPoptipIndex = 0;
+		/**
+		 * @param {Player} target
+		 * @returns {string}
+		 */
+		const getHandcardPoptip = target =>
+			createGameOverHandcardPoptip({
+				poptipId: `${GAME_OVER_HANDCARD_POPTIP_PREFIX}${handcardPoptipIndex++}`,
+				name: get.translation(target),
+				cards: hsMap.get(target) ?? [],
+			});
 		if (lib.config.background_audio) {
 			if (result === true) {
 				game.playAudio("effect", "win");
@@ -6852,16 +6902,7 @@ ${e instanceof Error ? e.stack : String(e)}`);
 				td.innerHTML = num;
 				tr.appendChild(td);
 				td = document.createElement("td");
-				let target = game.players[i];
-				td.innerHTML = get.poptip({
-					name: `<img style="width:15px; vertical-align: middle;" src="${lib.assetURL}image/card/handcard.png">`,
-					dialog(dialog) {
-						let hs = hsMap.get(target) ?? [];
-						dialog.add(`${get.translation(target)}的手牌`);
-						dialog[hs.length > 0 ? "addSmall" : "addText"](hs.length > 0 ? hs : "（没有手牌）");
-						return dialog;
-					},
-				});
+				td.innerHTML = getHandcardPoptip(game.players[i]);
 				tr.appendChild(td);
 				table.appendChild(tr);
 			}
@@ -6945,16 +6986,7 @@ ${e instanceof Error ? e.stack : String(e)}`);
 				td.innerHTML = num;
 				tr.appendChild(td);
 				td = document.createElement("td");
-				let target = game.dead[i];
-				td.innerHTML = get.poptip({
-					name: `<img style="width:15px; vertical-align: middle;" src="${lib.assetURL}image/card/handcard.png">`,
-					dialog(dialog) {
-						let hs = hsMap.get(target) ?? [];
-						dialog.add(`${get.translation(target)}的手牌`);
-						dialog[hs.length > 0 ? "addSmall" : "addText"](hs.length > 0 ? hs : "（没有手牌）");
-						return dialog;
-					},
-				});
+				td.innerHTML = getHandcardPoptip(game.dead[i]);
 				tr.appendChild(td);
 				table.appendChild(tr);
 			}

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -41,6 +41,7 @@ import { save } from "@/util/config.js";
 import { debounce } from "@/util/utils.js";
 
 const GAME_OVER_HANDCARD_POPTIP_PREFIX = "game_over_handcards_";
+const GAME_OVER_HANDCARD_POPTIP_ID_PATTERN = /^game_over_handcards_\d+$/;
 
 /**
  * 注册结算手牌 poptip，并返回现有手牌图标 HTML。
@@ -57,6 +58,86 @@ function createGameOverHandcardPoptip({ poptipId, name, cards }) {
 			dialog[cards.length > 0 ? "addSmall" : "addText"](cards.length > 0 ? cards : "（没有手牌）");
 			return dialog;
 		},
+	});
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardCardInfo}
+ */
+function isGameOverHandcardCardInfo(value) {
+	return Array.isArray(value) && value.length >= 3 && value.length <= 5 && typeof value[2] === "string";
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardPoptipPayload}
+ */
+function isGameOverHandcardPoptipPayload(value) {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		typeof value.poptipId === "string" &&
+		GAME_OVER_HANDCARD_POPTIP_ID_PATTERN.test(value.poptipId) &&
+		typeof value.position === "string" &&
+		value.position.length > 0 &&
+		typeof value.name === "string" &&
+		Array.isArray(value.cards) &&
+		value.cards.every(isGameOverHandcardCardInfo)
+	);
+}
+
+/**
+ * 恢复客机结算手牌 poptip；参数缺省时保持旧调用行为。
+ *
+ * @param {unknown} handcardPoptips
+ * @returns {void}
+ */
+function restoreGameOverHandcardPoptips(handcardPoptips) {
+	if (handcardPoptips === undefined) {
+		return;
+	}
+	if (!Array.isArray(handcardPoptips)) {
+		console.warn("联机结算手牌载荷无效：载荷必须是数组", handcardPoptips);
+		return;
+	}
+
+	const poptipIds = new Set();
+	const players = [...game.players, ...game.dead, ...(game.additionaldead ?? [])];
+	handcardPoptips.forEach((payload, index) => {
+		if (!isGameOverHandcardPoptipPayload(payload)) {
+			console.warn(`联机结算手牌载荷无效（索引 ${index}）`, payload);
+			return;
+		}
+		if (poptipIds.has(payload.poptipId)) {
+			console.warn(`联机结算手牌载荷无效：重复 poptipId ${payload.poptipId}`, payload);
+			return;
+		}
+		poptipIds.add(payload.poptipId);
+
+		const target = players.find(player => String(player.dataset.position) === payload.position);
+		if (!target) {
+			console.warn(`联机结算手牌找不到角色（poptipId: ${payload.poptipId}, position: ${payload.position}），使用载荷快照`, payload);
+		}
+
+		let cards;
+		try {
+			cards = get.infoCards(payload.cards);
+		} catch (error) {
+			console.warn(`联机结算手牌恢复失败（poptipId: ${payload.poptipId}, position: ${payload.position}）`, error);
+			return;
+		}
+		if (cards.length !== payload.cards.length || cards.some(Array.isArray)) {
+			console.warn(`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`, payload);
+			return;
+		}
+
+		createGameOverHandcardPoptip({
+			poptipId: payload.poptipId,
+			name: payload.name,
+			cards,
+		});
 	});
 }
 
@@ -6621,6 +6702,7 @@ ${e instanceof Error ? e.stack : String(e)}`);
 		if (game.online) {
 			let dialog = ui.create.dialog();
 			dialog.noforcebutton = true;
+			restoreGameOverHandcardPoptips(handcardPoptips);
 			dialog.content.innerHTML = result;
 			dialog.forcebutton = true;
 			let result2 = arguments[1];

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -125,6 +125,47 @@ function isGameOverHandcardNature(value) {
 }
 
 /**
+ * 按 Card.init 的杀别名规则返回规范化 wire tuple clone；失败时返回 null，且不修改原输入。
+ *
+ * @param {unknown} value
+ * @returns {GameOverHandcardCardInfo | null}
+ */
+function normalizeGameOverHandcardCardInfo(value) {
+	if (!Array.isArray(value) || value.length < 3 || value.length > 5 || typeof value[2] !== "string") {
+		return null;
+	}
+	const normalized = value.slice();
+	if (normalized[2] === "huosha") {
+		normalized[2] = "sha";
+		normalized[3] = "fire";
+	} else if (normalized[2] === "leisha") {
+		normalized[2] = "sha";
+		normalized[3] = "thunder";
+	} else if (normalized[2] === "cisha") {
+		normalized[2] = "sha";
+		normalized[3] = "stab";
+	} else if (normalized[2].length > 3) {
+		const prefix = normalized[2].slice(0, normalized[2].lastIndexOf("sha"));
+		if (prefix && lib.nature.has(prefix) && prefix.length + 3 === normalized[2].length) {
+			normalized[2] = "sha";
+			normalized[3] = prefix;
+		}
+		if (normalized[2].startsWith("sha_")) {
+			const natureList = normalized[2].slice(4).split("_");
+			if (natureList.some(nature => !nature || nature !== nature.trim() || !lib.nature.has(nature))) {
+				return null;
+			}
+			normalized[2] = "sha";
+			normalized[3] = get.nature(natureList);
+		}
+	}
+	if (!isGameOverHandcardSuit(normalized[0]) || !isGameOverHandcardNumber(normalized[1]) || !isGameOverHandcardSafeKey(normalized[2]) || !isGameOverHandcardNature(normalized[3]) || !isGameOverHandcardCardId(normalized[4])) {
+		return null;
+	}
+	return normalized;
+}
+
+/**
  * 校验 wire cardid；只接受 get.id 现有数字字符串形态，避免对象或原型键进入 cardOL。
  *
  * @param {unknown} value
@@ -142,7 +183,7 @@ function isGameOverHandcardCardId(value) {
  * @returns {value is GameOverHandcardCardInfo}
  */
 function isGameOverHandcardCardInfo(value) {
-	return Array.isArray(value) && value.length >= 3 && value.length <= 5 && isGameOverHandcardSuit(value[0]) && isGameOverHandcardNumber(value[1]) && isGameOverHandcardSafeKey(value[2]) && isGameOverHandcardNature(value[3]) && isGameOverHandcardCardId(value[4]);
+	return normalizeGameOverHandcardCardInfo(value) !== null;
 }
 
 /**
@@ -153,18 +194,22 @@ function isGameOverHandcardCardInfo(value) {
  * @returns {card is Card}
  */
 function isRecoveredGameOverHandcardCard(card, info) {
+	const normalizedInfo = normalizeGameOverHandcardCardInfo(info);
+	if (normalizedInfo === null) {
+		return false;
+	}
 	if (card === info || Array.isArray(card) || typeof card !== "object" || card === null) {
 		return false;
 	}
-	if (card.suit !== info[0] || card.number !== (parseInt(info[1]) || 0) || card.name !== info[2]) {
+	if (card.suit !== normalizedInfo[0] || card.number !== (parseInt(normalizedInfo[1]) || 0) || card.name !== normalizedInfo[2]) {
 		return false;
 	}
-	const expectedNature = normalizeGameOverHandcardNature(info[3]);
+	const expectedNature = normalizeGameOverHandcardNature(normalizedInfo[3]);
 	const actualNature = normalizeGameOverHandcardNature(card.nature);
 	if (expectedNature === null || actualNature === null || expectedNature !== actualNature) {
 		return false;
 	}
-	return info[4] == null || card.cardid === info[4];
+	return normalizedInfo[4] == null || card.cardid === normalizedInfo[4];
 }
 
 /**
@@ -202,6 +247,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 	}
 
 	const poptipIds = new Set();
+	const cardIds = new Set();
 	const players = [...game.players, ...game.dead];
 	handcardPoptips.forEach((payload, index) => {
 		if (!isGameOverHandcardPoptipPayload(payload)) {
@@ -213,6 +259,23 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 			return;
 		}
 		poptipIds.add(payload.poptipId);
+		const payloadCardIds = [];
+		const duplicateCardIndex = payload.cards.findIndex(cardInfo => {
+			const cardId = cardInfo[4];
+			if (cardId == null) {
+				return false;
+			}
+			if (payloadCardIds.includes(cardId) || cardIds.has(cardId)) {
+				return true;
+			}
+			payloadCardIds.push(cardId);
+			return false;
+		});
+		if (duplicateCardIndex !== -1) {
+			console.warn(`联机结算手牌载荷无效：重复 cardid ${payload.cards[duplicateCardIndex][4]}（poptipId: ${payload.poptipId}, 索引 ${index}, 卡牌索引 ${duplicateCardIndex}）`, payload);
+			return;
+		}
+		payloadCardIds.forEach(cardId => cardIds.add(cardId));
 
 		const target = players.find(player => String(player.dataset.position) === payload.position);
 		if (!target) {
@@ -6761,7 +6824,7 @@ ${e instanceof Error ? e.stack : String(e)}`);
 		}
 	}
 	/**
-	 * @param { boolean | string } [result]
+	 * @param { boolean | string | null } [result]
 	 * @param { boolean } [bool]
 	 * @param { GameOverHandcardPoptipPayload[] } [handcardPoptips]
 	 * @returns

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -11,7 +11,7 @@
  */
 
 /**
- * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ * @typedef {[(string|null|undefined), (number|string|null|undefined), string, (string|null|undefined)?, (string|null|undefined)?]} GameOverHandcardCardInfo
  */
 
 /**
@@ -66,7 +66,16 @@ function createGameOverHandcardPoptip({ poptipId, name, cards }) {
  * @returns {value is GameOverHandcardCardInfo}
  */
 function isGameOverHandcardCardInfo(value) {
-	return Array.isArray(value) && value.length >= 3 && value.length <= 5 && typeof value[2] === "string";
+	return (
+		Array.isArray(value) &&
+		value.length >= 3 &&
+		value.length <= 5 &&
+		typeof value[2] === "string" &&
+		(value[0] == null || typeof value[0] === "string") &&
+		(value[1] == null || typeof value[1] === "number" || typeof value[1] === "string") &&
+		(value[3] == null || typeof value[3] === "string") &&
+		(value[4] == null || typeof value[4] === "string")
+	);
 }
 
 /**
@@ -128,7 +137,21 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 			console.warn(`联机结算手牌恢复失败（poptipId: ${payload.poptipId}, position: ${payload.position}）`, error);
 			return;
 		}
-		if (cards.length !== payload.cards.length || cards.some(Array.isArray)) {
+		if (
+			!Array.isArray(cards) ||
+			cards.length !== payload.cards.length ||
+			cards.some((card, cardIndex) => {
+				const wireName = payload.cards[cardIndex]?.[2];
+				return (
+					card === payload.cards[cardIndex] ||
+					Array.isArray(card) ||
+					typeof card !== "object" ||
+					card === null ||
+					typeof card.name !== "string" ||
+					card.name !== wireName
+				);
+			})
+		) {
 			console.warn(`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`, payload);
 			return;
 		}

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -104,7 +104,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 	}
 
 	const poptipIds = new Set();
-	const players = [...game.players, ...game.dead, ...(game.additionaldead ?? [])];
+	const players = [...game.players, ...game.dead];
 	handcardPoptips.forEach((payload, index) => {
 		if (!isGameOverHandcardPoptipPayload(payload)) {
 			console.warn(`联机结算手牌载荷无效（索引 ${index}）`, payload);

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -6580,9 +6580,10 @@ ${e instanceof Error ? e.stack : String(e)}`);
 	/**
 	 * @param { boolean | string } [result]
 	 * @param { boolean } [bool]
+	 * @param { GameOverHandcardPoptipPayload[] } [handcardPoptips]
 	 * @returns
 	 */
-	over(result, bool) {
+	over(result, bool, handcardPoptips) {
 		if (_status.over) {
 			return;
 		}
@@ -6673,17 +6674,28 @@ ${e instanceof Error ? e.stack : String(e)}`);
 			}
 			return;
 		}
+		/** @type {GameOverHandcardPoptipPayload[]} */
+		handcardPoptips = [];
 		let handcardPoptipIndex = 0;
 		/**
 		 * @param {Player} target
 		 * @returns {string}
 		 */
-		const getHandcardPoptip = target =>
-			createGameOverHandcardPoptip({
+		const getHandcardPoptip = target => {
+			const cards = hsMap.get(target) ?? [];
+			const payload = {
 				poptipId: `${GAME_OVER_HANDCARD_POPTIP_PREFIX}${handcardPoptipIndex++}`,
+				position: String(target.dataset.position),
 				name: get.translation(target),
-				cards: hsMap.get(target) ?? [],
+				cards: get.cardsInfo(cards),
+			};
+			handcardPoptips.push(payload);
+			return createGameOverHandcardPoptip({
+				poptipId: payload.poptipId,
+				name: payload.name,
+				cards,
 			});
+		};
 		if (lib.config.background_audio) {
 			if (result === true) {
 				game.playAudio("effect", "win");
@@ -7068,7 +7080,7 @@ ${e instanceof Error ? e.stack : String(e)}`);
 		let clients = game.players.concat(game.dead);
 		for (let i = 0; i < clients.length; i++) {
 			if (clients[i].isOnline2()) {
-				clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]));
+				clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]), handcardPoptips);
 			}
 		}
 

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -42,6 +42,8 @@ import { debounce } from "@/util/utils.js";
 
 const GAME_OVER_HANDCARD_POPTIP_PREFIX = "game_over_handcards_";
 const GAME_OVER_HANDCARD_POPTIP_ID_PATTERN = /^game_over_handcards_\d+$/;
+const GAME_OVER_HANDCARD_CARD_ID_PATTERN = /^\d+$/;
+const GAME_OVER_HANDCARD_DANGEROUS_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
 /**
  * 注册结算手牌 poptip，并返回现有手牌图标 HTML。
@@ -62,20 +64,107 @@ function createGameOverHandcardPoptip({ poptipId, name, cards }) {
 }
 
 /**
+ * 判断来自网络且会作为普通对象属性读取的字符串是否安全。
+ *
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isGameOverHandcardSafeKey(value) {
+	return typeof value === "string" && value.length > 0 && !GAME_OVER_HANDCARD_DANGEROUS_KEYS.has(value) && !(value in Object.prototype);
+}
+
+/**
+ * 校验 wire 花色；只接受 get.cardsInfo 产生的空值或当前牌堆注册花色。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardSuit(value) {
+	return value == null || (typeof value === "string" && lib.suits.includes(value));
+}
+
+/**
+ * 校验 wire 点数；禁止对象、函数和会让 Card.init 得到非有限数值的 number。
+ *
+ * @param {unknown} value
+ * @returns {value is number | string | null | undefined}
+ */
+function isGameOverHandcardNumber(value) {
+	return value == null || typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
+}
+
+/**
+ * 将 wire 或 Card 上的属性字符串规范化为 Card.$init 使用的排序复合属性。
+ * nullish 与空字符串都视为无属性；其他值必须拆成已注册且无空白的非空 token。
+ *
+ * @param {unknown} value
+ * @returns {string | null} 合法时返回规范化属性字符串，无属性返回空字符串，非法返回 null
+ */
+function normalizeGameOverHandcardNature(value) {
+	if (value == null || value === "") {
+		return "";
+	}
+	if (typeof value !== "string") {
+		return null;
+	}
+	const natures = get.natureList(value);
+	if (!natures.length || natures.some(nature => !nature || nature !== nature.trim() || !lib.nature.has(nature))) {
+		return null;
+	}
+	return natures.slice().sort(lib.sort.nature).join(lib.natureSeparator);
+}
+
+/**
+ * 校验 wire 属性；在进入 Card.init 前拒绝 classList.add 会抛错的空白或未知 token。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardNature(value) {
+	return normalizeGameOverHandcardNature(value) !== null;
+}
+
+/**
+ * 校验 wire cardid；只接受 get.id 现有数字字符串形态，避免对象或原型键进入 cardOL。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardCardId(value) {
+	return value == null || (typeof value === "string" && GAME_OVER_HANDCARD_CARD_ID_PATTERN.test(value));
+}
+
+/**
+ * 校验单张结算手牌的 wire tuple。该边界只阻止 payload primitive 触发已知
+ * Card.init 半初始化路径，不要求卡牌名必须已存在于 lib.card，以保留扩展兼容性。
+ *
  * @param {unknown} value
  * @returns {value is GameOverHandcardCardInfo}
  */
 function isGameOverHandcardCardInfo(value) {
-	return (
-		Array.isArray(value) &&
-		value.length >= 3 &&
-		value.length <= 5 &&
-		typeof value[2] === "string" &&
-		(value[0] == null || typeof value[0] === "string") &&
-		(value[1] == null || typeof value[1] === "number" || typeof value[1] === "string") &&
-		(value[3] == null || typeof value[3] === "string") &&
-		(value[4] == null || typeof value[4] === "string")
-	);
+	return Array.isArray(value) && value.length >= 3 && value.length <= 5 && isGameOverHandcardSuit(value[0]) && isGameOverHandcardNumber(value[1]) && isGameOverHandcardSafeKey(value[2]) && isGameOverHandcardNature(value[3]) && isGameOverHandcardCardId(value[4]);
+}
+
+/**
+ * 校验 get.infoCards 返回的 Card 是否完整对应其可能被 Card.init 原地规范化后的 wire tuple。
+ *
+ * @param {unknown} card
+ * @param {GameOverHandcardCardInfo} info
+ * @returns {card is Card}
+ */
+function isRecoveredGameOverHandcardCard(card, info) {
+	if (card === info || Array.isArray(card) || typeof card !== "object" || card === null) {
+		return false;
+	}
+	if (card.suit !== info[0] || card.number !== (parseInt(info[1]) || 0) || card.name !== info[2]) {
+		return false;
+	}
+	const expectedNature = normalizeGameOverHandcardNature(info[3]);
+	const actualNature = normalizeGameOverHandcardNature(card.nature);
+	if (expectedNature === null || actualNature === null || expectedNature !== actualNature) {
+		return false;
+	}
+	return info[4] == null || card.cardid === info[4];
 }
 
 /**
@@ -140,17 +229,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 		if (
 			!Array.isArray(cards) ||
 			cards.length !== payload.cards.length ||
-			cards.some((card, cardIndex) => {
-				const wireName = payload.cards[cardIndex]?.[2];
-				return (
-					card === payload.cards[cardIndex] ||
-					Array.isArray(card) ||
-					typeof card !== "object" ||
-					card === null ||
-					typeof card.name !== "string" ||
-					card.name !== wireName
-				);
-			})
+			cards.some((card, cardIndex) => !isRecoveredGameOverHandcardCard(card, payload.cards[cardIndex]))
 		) {
 			console.warn(`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`, payload);
 			return;

--- a/apps/core/noname/game/index.js
+++ b/apps/core/noname/game/index.js
@@ -7162,7 +7162,14 @@ ${e instanceof Error ? e.stack : String(e)}`);
 		let clients = game.players.concat(game.dead);
 		for (let i = 0; i < clients.length; i++) {
 			if (clients[i].isOnline2()) {
-				clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]), handcardPoptips);
+				clients[i].send(
+					function (result, bool, handcardPoptips) {
+						game.over(result, bool, handcardPoptips);
+					},
+					dialog.content.innerHTML,
+					game.checkOnlineResult(clients[i]),
+					handcardPoptips
+				);
 			}
 		}
 

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -37,9 +37,10 @@
 | `apps\core\noname\game\index.js` | `7036-7040` | 修改 | 把纯数据载荷作为第四个 `send` 实参发送。 |
 | `apps\core\noname\library\poptip.js` | `208-244` | 只读参考 | 已支持显式 `id`、名称和 `createDialog` 注册；本计划不改动。 |
 | `apps\core\noname\get\index.js` | `2302-2342` | 只读参考 | 提供 `get.cardsInfo`、`get.infoCard`、`get.infoCards`；本计划不复制序列化逻辑。 |
-| `docs\superpowers\specs\2026-07-21-online-game-over-handcards-design.md` | `1-247` | 只读参考 | 设计约束和验收来源。 |
+| `docs\superpowers\specs\2026-07-21-online-game-over-handcards-design.md` | `1-247` | 修改 | 同步严格 guard、恢复 postcondition 和测试矩阵。 |
+| `docs\superpowers\plans\2026-07-22-online-game-over-handcards.md` | 本文 | 修改 | 同步 JSDoc/helper 接口、malformed nature 注入步骤和验证矩阵。 |
 
-不创建自动化测试文件。失败复现、边界断言和回归检查都通过项目现有浏览器运行时执行；静态验证使用现有 lint/build 命令。
+不创建提交到仓库的自动化测试文件。严格卡牌恢复边界使用 `.superpowers\sdd\strict-card-recovery-assertions.mjs` 这类 ignored Node/VM/source boundary script 先 RED 后 GREEN 记录；浏览器回归仍通过项目现有运行时执行，静态验证使用现有 lint/build 命令。
 
 当前 `additionaldead` 段虽然创建了一个手牌 `td`，但没有执行 `tr.appendChild(td)`，因此页面没有第三个可见手牌入口。为遵守“不改变结算 HTML”的设计边界，本计划只统一实际显示的存活和阵亡两处入口，不补列、不为不可见入口发送多余载荷。
 
@@ -74,10 +75,55 @@
 function createGameOverHandcardPoptip({ poptipId, name, cards }) {}
 
 /**
+ * 判断来自网络且会作为普通对象属性读取的字符串是否安全。
+ *
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isGameOverHandcardSafeKey(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardSuit(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is number | string | null | undefined}
+ */
+function isGameOverHandcardNumber(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+function normalizeGameOverHandcardNature(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardNature(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardCardId(value) {}
+
+/**
  * @param {unknown} value
  * @returns {value is GameOverHandcardCardInfo}
  */
 function isGameOverHandcardCardInfo(value) {}
+
+/**
+ * @param {unknown} card
+ * @param {GameOverHandcardCardInfo} info
+ * @returns {card is Card}
+ */
+function isRecoveredGameOverHandcardCard(card, info) {}
 
 /**
  * @param {unknown} value
@@ -518,28 +564,87 @@ console.assert(
 
 - [ ] **Step 2: 增加卡牌条目和载荷类型守卫**
 
-在 `createGameOverHandcardPoptip` 后加入：
+在 `createGameOverHandcardPoptip` 后加入小型 guard/normalization helper，避免把主 guard 写成难读的大表达式：
 
 ```js
 const GAME_OVER_HANDCARD_POPTIP_ID_PATTERN = /^game_over_handcards_\d+$/;
+const GAME_OVER_HANDCARD_CARD_ID_PATTERN = /^\d+$/;
+const GAME_OVER_HANDCARD_DANGEROUS_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
 /**
+ * 判断来自网络且会作为普通对象属性读取的字符串是否安全。
+ *
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isGameOverHandcardSafeKey(value) {
+	return typeof value === "string" && value.length > 0 && !GAME_OVER_HANDCARD_DANGEROUS_KEYS.has(value) && !(value in Object.prototype);
+}
+
+/**
+ * 校验 wire 花色；只接受 get.cardsInfo 产生的空值或当前牌堆注册花色。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardSuit(value) {
+	return value == null || (typeof value === "string" && lib.suits.includes(value));
+}
+
+/**
+ * 校验 wire 点数；禁止对象、函数和会让 Card.init 得到非有限数值的 number。
+ *
+ * @param {unknown} value
+ * @returns {value is number | string | null | undefined}
+ */
+function isGameOverHandcardNumber(value) {
+	return value == null || typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
+}
+
+/**
+ * 将 wire 或 Card 上的属性字符串规范化为 Card.$init 使用的排序复合属性。
+ * nullish 与空字符串都视为无属性；其他值必须拆成已注册且无空白的非空 token。
+ *
+ * @param {unknown} value
+ * @returns {string | null} 合法时返回规范化属性字符串，无属性返回空字符串，非法返回 null
+ */
+function normalizeGameOverHandcardNature(value) {
+	if (value == null || value === "") return "";
+	if (typeof value !== "string") return null;
+	const natures = get.natureList(value);
+	if (!natures.length || natures.some(nature => !nature || nature !== nature.trim() || !lib.nature.has(nature))) return null;
+	return natures.slice().sort(lib.sort.nature).join(lib.natureSeparator);
+}
+
+/**
+ * 校验 wire 属性；在进入 Card.init 前拒绝 classList.add 会抛错的空白或未知 token。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardNature(value) {
+	return normalizeGameOverHandcardNature(value) !== null;
+}
+
+/**
+ * 校验 wire cardid；只接受 get.id 现有数字字符串形态，避免对象或原型键进入 cardOL。
+ *
+ * @param {unknown} value
+ * @returns {value is string | null | undefined}
+ */
+function isGameOverHandcardCardId(value) {
+	return value == null || (typeof value === "string" && GAME_OVER_HANDCARD_CARD_ID_PATTERN.test(value));
+}
+
+/**
+ * 校验单张结算手牌的 wire tuple。该边界只阻止 payload primitive 触发已知
+ * Card.init 半初始化路径，不要求卡牌名必须已存在于 lib.card，以保留扩展兼容性。
+ *
  * @param {unknown} value
  * @returns {value is GameOverHandcardCardInfo}
  */
 function isGameOverHandcardCardInfo(value) {
-	return (
-		Array.isArray(value) &&
-		value.length >= 3 &&
-		value.length <= 5 &&
-		typeof value[2] === "string" &&
-		(value[0] == null || typeof value[0] === "string") &&
-		(value[1] == null ||
-			typeof value[1] === "number" ||
-			typeof value[1] === "string") &&
-		(value[3] == null || typeof value[3] === "string") &&
-		(value[4] == null || typeof value[4] === "string")
-	);
+	return Array.isArray(value) && value.length >= 3 && value.length <= 5 && isGameOverHandcardSuit(value[0]) && isGameOverHandcardNumber(value[1]) && isGameOverHandcardSafeKey(value[2]) && isGameOverHandcardNature(value[3]) && isGameOverHandcardCardId(value[4]);
 }
 
 /**
@@ -562,13 +667,29 @@ function isGameOverHandcardPoptipPayload(value) {
 }
 ```
 
-预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少字符串卡牌名的条目失败；suit/nature/cardid 只接受 string/nullish，number 只接受 number/string/nullish，拒绝对象和函数。
+预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少非空安全卡牌名的条目失败。suit 只接受 nullish 或 `lib.suits` 中的字符串；number 只接受 nullish、字符串或有限 number；name 拒绝 `__proto__`、`prototype`、`constructor` 和原型链键但不要求 `hasOwn(lib.card)`，保留 `huosha`/`leisha`/`cisha` 与扩展卡名；nature 只接受 nullish、空字符串或 `get.natureList(value)` 拆出的已注册非空 token；cardid 只接受 nullish 或 `get.id` 数字字符串。
 
 - [ ] **Step 3: 增加逐项恢复函数和精确告警**
 
 继续加入：
 
 ```js
+/**
+ * 校验 get.infoCards 返回的 Card 是否完整对应其可能被 Card.init 原地规范化后的 wire tuple。
+ *
+ * @param {unknown} card
+ * @param {GameOverHandcardCardInfo} info
+ * @returns {card is Card}
+ */
+function isRecoveredGameOverHandcardCard(card, info) {
+	if (card === info || Array.isArray(card) || typeof card !== "object" || card === null) return false;
+	if (card.suit !== info[0] || card.number !== (parseInt(info[1]) || 0) || card.name !== info[2]) return false;
+	const expectedNature = normalizeGameOverHandcardNature(info[3]);
+	const actualNature = normalizeGameOverHandcardNature(card.nature);
+	if (expectedNature === null || actualNature === null || expectedNature !== actualNature) return false;
+	return info[4] == null || card.cardid === info[4];
+}
+
 /**
  * 恢复客机结算手牌 poptip；参数缺省时保持旧调用行为。
  *
@@ -623,17 +744,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 		if (
 			!Array.isArray(cards) ||
 			cards.length !== payload.cards.length ||
-			cards.some((card, cardIndex) => {
-				const wireName = payload.cards[cardIndex]?.[2];
-				return (
-					card === payload.cards[cardIndex] ||
-					Array.isArray(card) ||
-					typeof card !== "object" ||
-					card === null ||
-					typeof card.name !== "string" ||
-					card.name !== wireName
-				);
-			})
+			cards.some((card, cardIndex) => !isRecoveredGameOverHandcardCard(card, payload.cards[cardIndex]))
 		) {
 			console.warn(
 				`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`,
@@ -651,7 +762,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 }
 ```
 
-预期：只捕获 `get.infoCards` 的转换错误；无宽泛包裹整个循环。缺失 Player 只告警，不阻止快照注册。
+预期：只捕获 `get.infoCards` 的转换错误；无宽泛包裹整个循环。`get.infoCards` 调用后按被 `Card.init` 原地规范化后的 tuple 比较对象/non-array、suit、`parseInt(wireNumber) || 0` 后的 number、name、经 `get.natureList`/`lib.nature`/`lib.sort.nature`/`lib.natureSeparator` 规范化的 nature，以及存在 wire cardid 时的 cardid；任一不匹配都告警并跳过该 payload。缺失 Player 只告警，不阻止快照注册。
 
 - [ ] **Step 4: 在插入 HTML 前恢复收到的第三参数**
 
@@ -728,6 +839,12 @@ console.assert(
 				name: "快照角色",
 				cards: [],
 			},
+			{
+				poptipId: "game_over_handcards_10000",
+				position: "0",
+				name: "坏属性",
+				cards: [[null, null, "shan", "bad nature", null]],
+			},
 			null,
 			{
 				poptipId: "invalid-id",
@@ -750,7 +867,7 @@ console.assert(
 
 结束游戏后，客机预期：
 
-1. 控制台分别出现缺失角色、空对象、非法 ID、坏 `cards`、重复 ID 的明确 `console.warn`。
+1. 控制台分别出现缺失角色、malformed nature 载荷无效、空对象、非法 ID、坏 `cards`、重复 ID 的明确 `console.warn`；malformed nature 使用合法独立 `poptipId`，不得先被重复 ID 拦截。
 2. 正常存活和阵亡角色入口仍可点击。
 3. 新增的“快照角色”入口已注册，点击后显示“（没有手牌）”。
 4. 没有未捕获异常，胜负结果和退出按钮正常。
@@ -866,6 +983,7 @@ Test-Path $baseline
 
 ## 测试
 
+- `node .superpowers\sdd\strict-card-recovery-assertions.mjs`（RED 覆盖旧 guard 接受 `bad nature`、name-only postcondition 接受半初始化 Card；GREEN 覆盖合法 suits/nullish/finite number/string/单或复合 nature/`huosha`/`leisha`/`cisha`/三四五元组，以及 bad nature、空白 token、危险 name/id、object field、`NaN`、`Infinity`、标准字段 mismatch 和规范化完整 Card）
 - `pnpm --filter noname lint`
 - `pnpm build`
 - 主机与客机：存活、阵亡、多张、零张、坏条目、缺失 Player

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -108,6 +108,12 @@ function isGameOverHandcardNature(value) {}
 
 /**
  * @param {unknown} value
+ * @returns {GameOverHandcardCardInfo | null}
+ */
+function normalizeGameOverHandcardCardInfo(value) {}
+
+/**
+ * @param {unknown} value
  * @returns {value is string | null | undefined}
  */
 function isGameOverHandcardCardId(value) {}
@@ -140,7 +146,7 @@ function isGameOverHandcardPoptipPayload(value) {}
 function restoreGameOverHandcardPoptips(handcardPoptips) {}
 
 /**
- * @param {boolean | string} [result]
+ * @param {boolean | string | null} [result]
  * @param {boolean} [bool]
  * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
  * @returns
@@ -349,7 +355,7 @@ git commit -m "refactor: 统一结算手牌入口" -m "Co-authored-by: Copilot A
 在主机开始一局联机游戏后、游戏结束前，于主机 DevTools Console 执行：
 
 ```js
-const isGameOverResult = value => typeof value === "boolean" || typeof value === "string";
+const isGameOverResult = value => value == null || typeof value === "boolean" || typeof value === "string";
 const isGameOverHtml = value =>
 	typeof value === "string" &&
 	value.includes("<table") &&
@@ -398,7 +404,7 @@ if (calls.length > 0) {
 window.__gameOverSendRestores.forEach(restore => restore());
 ```
 
-预期：Task 1 后的旧 direct `game.over` 三实参调用能被捕获，`calls.length > 0` 通过；第二个断言因缺少第四个数组实参失败。`boolean` 和 `string` 胜负结果都属于合法结果形态。
+预期：Task 1 后的旧 direct `game.over` 三实参调用能被捕获，`calls.length > 0` 通过；第二个断言因缺少第四个数组实参失败。`boolean`、`string` 与 `null` 胜负结果都属于合法结果形态，`undefined` 仍因参数可选继续安全退化。
 
 - [ ] **Step 2: 扩展 `Game.over` JSDoc 并初始化载荷**
 
@@ -406,7 +412,7 @@ window.__gameOverSendRestores.forEach(restore => restore());
 
 ```js
 	/**
-	 * @param {boolean | string} [result]
+	 * @param {boolean | string | null} [result]
 	 * @param {boolean} [bool]
 	 * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
 	 * @returns
@@ -667,7 +673,7 @@ function isGameOverHandcardPoptipPayload(value) {
 }
 ```
 
-预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少非空安全卡牌名的条目失败。suit 只接受 nullish 或 `lib.suits` 中的字符串；number 只接受 nullish、字符串或有限 number；name 拒绝 `__proto__`、`prototype`、`constructor` 和原型链键但不要求 `hasOwn(lib.card)`，保留 `huosha`/`leisha`/`cisha` 与扩展卡名；nature 只接受 nullish、空字符串或 `get.natureList(value)` 拆出的已注册非空 token；cardid 只接受 nullish 或 `get.id` 数字字符串。
+预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少非空安全卡牌名的条目失败。suit 只接受 nullish 或 `lib.suits` 中的字符串；number 只接受 nullish、字符串或有限 number；name 先通过规范化 clone 镜像 `Card.init` 的 `huosha`/`leisha`/`cisha`、完整已注册 `<nature>sha`、以及 `sha_<nature...>` alias 路径；`sha_`、`sha_unknown`、`sha_bad nature` 在进入 `get.infoCards` 前失败。随后对规范化 clone 复用 suit/number/safe name/nature/cardid guard；普通扩展卡名仍不要求 `hasOwn(lib.card)`。nature 只接受 nullish、空字符串或 `get.natureList(value)` 拆出的已注册非空 token；cardid 只接受 nullish 或 `get.id` 数字字符串。
 
 - [ ] **Step 3: 增加逐项恢复函数和精确告警**
 
@@ -706,6 +712,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 	}
 
 	const poptipIds = new Set();
+	const cardIds = new Set();
 	const players = [...game.players, ...game.dead];
 	handcardPoptips.forEach((payload, index) => {
 		if (!isGameOverHandcardPoptipPayload(payload)) {
@@ -720,6 +727,22 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 			return;
 		}
 		poptipIds.add(payload.poptipId);
+		const payloadCardIds = [];
+		const duplicateCardIndex = payload.cards.findIndex(cardInfo => {
+			const cardId = cardInfo[4];
+			if (cardId == null) return false;
+			if (payloadCardIds.includes(cardId) || cardIds.has(cardId)) return true;
+			payloadCardIds.push(cardId);
+			return false;
+		});
+		if (duplicateCardIndex !== -1) {
+			console.warn(
+				`联机结算手牌载荷无效：重复 cardid ${payload.cards[duplicateCardIndex][4]}（poptipId: ${payload.poptipId}, 索引 ${index}, 卡牌索引 ${duplicateCardIndex}）`,
+				payload
+			);
+			return;
+		}
+		payloadCardIds.forEach(cardId => cardIds.add(cardId));
 
 		const target = players.find(
 			player => String(player.dataset.position) === payload.position
@@ -762,7 +785,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 }
 ```
 
-预期：只捕获 `get.infoCards` 的转换错误；无宽泛包裹整个循环。`get.infoCards` 调用后按被 `Card.init` 原地规范化后的 tuple 比较对象/non-array、suit、`parseInt(wireNumber) || 0` 后的 number、name、经 `get.natureList`/`lib.nature`/`lib.sort.nature`/`lib.natureSeparator` 规范化的 nature，以及存在 wire cardid 时的 cardid；任一不匹配都告警并跳过该 payload。缺失 Player 只告警，不阻止快照注册。
+预期：只捕获 `get.infoCards` 的转换错误；无宽泛包裹整个循环。每个通过结构 guard 的 payload 在 `get.infoCards` 前先检查本 entry 内和此前 entry 的非空 cardid 唯一；重复时告警包含 poptipId、cardid、entry/card 索引并跳过整条 payload，且不会调用 `get.infoCards`。通过检查的非空 cardid 会在调用前预留，即使恢复抛错或 postcondition 失败，后续 entry 也不得复用。`get.infoCards` 调用后按规范化 clone 比较对象/non-array、suit、`parseInt(wireNumber) || 0` 后的 number、name、经 `get.natureList`/`lib.nature`/`lib.sort.nature`/`lib.natureSeparator` 规范化的 nature，以及存在 wire cardid 时的 cardid；任一不匹配都告警并跳过该 payload。缺失 Player 只告警，不阻止快照注册。
 
 - [ ] **Step 4: 在插入 HTML 前恢复收到的第三参数**
 
@@ -843,7 +866,28 @@ console.assert(
 				poptipId: "game_over_handcards_10000",
 				position: "0",
 				name: "坏属性",
-				cards: [[null, null, "shan", "bad nature", null]],
+				cards: [[null, null, "sha_bad nature", null, null]],
+			},
+			{
+				poptipId: "game_over_handcards_10001",
+				position: "0",
+				name: "同项重复 cardid",
+				cards: [
+					["spade", 7, "sha", null, "9876543210"],
+					["heart", 8, "shan", null, "9876543210"],
+				],
+			},
+			{
+				poptipId: "game_over_handcards_10002",
+				position: "0",
+				name: "先占用 cardid",
+				cards: [["spade", 7, "sha", null, "9876543211"]],
+			},
+			{
+				poptipId: "game_over_handcards_10003",
+				position: "0",
+				name: "跨项重复 cardid",
+				cards: [["heart", 8, "shan", null, "9876543211"]],
 			},
 			null,
 			{
@@ -867,7 +911,7 @@ console.assert(
 
 结束游戏后，客机预期：
 
-1. 控制台分别出现缺失角色、malformed nature 载荷无效、空对象、非法 ID、坏 `cards`、重复 ID 的明确 `console.warn`；malformed nature 使用合法独立 `poptipId`，不得先被重复 ID 拦截。
+1. 控制台分别出现缺失角色、malformed/alias nature 载荷无效、空对象、非法 ID、坏 `cards`、重复 poptipId、same-entry 重复 cardid、cross-entry 重复 cardid 的明确 `console.warn`；malformed nature 使用合法独立 `poptipId`，不得先被重复 ID 拦截。
 2. 正常存活和阵亡角色入口仍可点击。
 3. 新增的“快照角色”入口已注册，点击后显示“（没有手牌）”。
 4. 没有未捕获异常，胜负结果和退出按钮正常。
@@ -983,7 +1027,8 @@ Test-Path $baseline
 
 ## 测试
 
-- `node .superpowers\sdd\strict-card-recovery-assertions.mjs`（RED 覆盖旧 guard 接受 `bad nature`、name-only postcondition 接受半初始化 Card；GREEN 覆盖合法 suits/nullish/finite number/string/单或复合 nature/`huosha`/`leisha`/`cisha`/三四五元组，以及 bad nature、空白 token、危险 name/id、object field、`NaN`、`Infinity`、标准字段 mismatch 和规范化完整 Card）
+- `node .superpowers\sdd\strict-card-recovery-assertions.mjs`（严格恢复边界）
+- `node .superpowers\sdd\alias-cardid-boundary.mjs`（RED/GREEN 覆盖 `sha_bad nature`、`sha_`、`sha_unknown` preguard，`huosha`/`leisha`/`cisha`/`firesha`/`sha_fire`/`sha_fire_thunder` 规范化，same-entry/cross-entry/失败后重复 cardid 隔离，以及 nullable result JSDoc/probe）
 - `pnpm --filter noname lint`
 - `pnpm build`
 - 主机与客机：存活、阵亡、多张、零张、坏条目、缺失 Player

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -294,13 +294,16 @@ git commit -m "refactor: 统一结算手牌入口" -m "Co-authored-by: Copilot A
 
 **Interfaces:**
 - Consumes: Task 1 的 `GAME_OVER_HANDCARD_POPTIP_PREFIX`、`createGameOverHandcardPoptip(options)` 和 `getHandcardPoptip(target)`。
-- Produces: `GameOverHandcardPoptipPayload[]` 主机快照；`clients[i].send(game.over, html, result, handcardPoptips)` 四实参调用。
+- Produces: `GameOverHandcardPoptipPayload[]` 主机快照；`clients[i].send(function (result, bool, handcardPoptips) { game.over(result, bool, handcardPoptips); }, html, result, handcardPoptips)` 四实参调用。
 
 - [ ] **Step 1: 安装运行时发送探针并确认当前调用缺少载荷**
 
 在主机开始一局联机游戏后、游戏结束前，于主机 DevTools Console 执行：
 
 ```js
+const isGameOverWrapper = fn =>
+	typeof fn === "function" &&
+	/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
 window.__gameOverSendCalls = [];
 window.__gameOverSendRestores = game.players
 	.concat(game.dead)
@@ -308,7 +311,7 @@ window.__gameOverSendRestores = game.players
 	.map(client => {
 		const originalSend = client.send;
 		client.send = function (...args) {
-			if (args[0] === game.over) {
+			if (isGameOverWrapper(args[0])) {
 				window.__gameOverSendCalls.push({
 					args,
 					overAtSend: _status.over,
@@ -327,7 +330,10 @@ window.__gameOverSendRestores = game.players
 ```js
 console.assert(window.__gameOverSendCalls.length > 0, "必须捕获至少一次 game.over 发送");
 console.assert(
-	window.__gameOverSendCalls.every(call => call.args.length === 4 && Array.isArray(call.args[3])),
+	window.__gameOverSendCalls.every(call => {
+		const args = call.args;
+		return args.length === 4 && Array.isArray(args[3]);
+	}),
 	"当前发送只有 HTML 和胜负结果，缺少第四个手牌载荷实参"
 );
 window.__gameOverSendRestores.forEach(restore => restore());
@@ -392,7 +398,9 @@ window.__gameOverSendRestores.forEach(restore => restore());
 		for (let i = 0; i < clients.length; i++) {
 			if (clients[i].isOnline2()) {
 				clients[i].send(
-					game.over,
+					function (result, bool, handcardPoptips) {
+						game.over(result, bool, handcardPoptips);
+					},
 					dialog.content.innerHTML,
 					game.checkOnlineResult(clients[i]),
 					handcardPoptips
@@ -551,7 +559,7 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 	}
 
 	const poptipIds = new Set();
-	const players = [...game.players, ...game.dead, ...(game.additionaldead ?? [])];
+	const players = [...game.players, ...game.dead];
 	handcardPoptips.forEach((payload, index) => {
 		if (!isGameOverHandcardPoptipPayload(payload)) {
 			console.warn(`联机结算手牌载荷无效（索引 ${index}）`, payload);
@@ -657,10 +665,13 @@ console.assert(
 
 ```js
 (() => {
+	const isGameOverWrapper = fn =>
+		typeof fn === "function" &&
+		/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
 	const client = game.players.concat(game.dead).find(current => current.isOnline2());
 	const originalSend = client.send;
 	client.send = function (fn, html, result, payloads) {
-		if (fn !== game.over) {
+		if (!isGameOverWrapper(fn) || arguments.length !== 4 || !Array.isArray(payloads)) {
 			return originalSend.apply(this, arguments);
 		}
 		client.send = originalSend;
@@ -708,10 +719,13 @@ console.assert(
 
 ```js
 (() => {
+	const isGameOverWrapper = fn =>
+		typeof fn === "function" &&
+		/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
 	const client = game.players.concat(game.dead).find(current => current.isOnline2());
 	const originalSend = client.send;
 	client.send = function (fn, html, result, payloads) {
-		if (fn !== game.over) {
+		if (!isGameOverWrapper(fn) || arguments.length !== 4 || !Array.isArray(payloads)) {
 			return originalSend.apply(this, arguments);
 		}
 		client.send = originalSend;

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -1,0 +1,824 @@
+# 联机结算剩余手牌同步实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让联机游戏的客机在结算页使用主机发送的纯数据快照恢复每名角色的剩余手牌 poptip，同时保持单机、旧调用和混合版本安全退化。
+
+**Architecture:** 在 `apps\core\noname\game\index.js` 内增加一个本地 poptip 创建辅助函数，主机按现有结算行顺序生成稳定 ID、收集 `{ poptipId, position, name, cards }` 并随结算 HTML 发送。客机在插入 HTML 前校验载荷、用 `get.infoCards` 恢复卡牌并注册相同 ID；单项错误只告警并跳过，缺失本地 Player 时仍使用名称和卡牌快照。
+
+**Tech Stack:** JavaScript ES modules、JSDoc、DOM Custom Elements、`lib.poptip`、`get.cardsInfo`、`get.infoCards`、pnpm、ESLint、项目现有 Vite/Fastify 运行环境。
+
+## Global Constraints
+
+- 实现仅修改 `apps\core\noname\game\index.js`；不修改 `poptip.js`、`get\index.js`、录像格式或结算表格结构。
+- 不新增依赖、测试框架、测试目录、测试脚本或通用网络协议。
+- JavaScript 使用 Tab 缩进，并通过仓库现有 ESLint；新增类型、函数和 `Game.over` 参数必须有完整 JSDoc。
+- 稳定 ID 固定使用 `game_over_handcards_<行序号>`，序号依次覆盖实际渲染手牌入口的 `game.players` 和 `game.dead`，不得只使用可能复用的 `position`。
+- 网络载荷固定为 `{ poptipId, position, name, cards }`；`cards` 由主机 `get.cardsInfo` 生成，由客机 `get.infoCards` 恢复。
+- 只在 `Game.over` 已进入结算流程后随结算 HTML 发送手牌快照，不改变游戏进行中的隐藏信息。
+- `Game.over` 第三个参数保持可选；缺省时不告警、不失败，前两个参数和现有 HTML 行为不变。
+- 非数组载荷、坏条目、重复或非法 ID、卡牌恢复失败必须 `console.warn` 后继续；不得静默失败或伪装成零手牌。
+- 找不到本地 Player 时必须 `console.warn`，但仍使用有效的 `name` 和 `cards` 快照注册 poptip。
+- 零张手牌是有效结果，显示“（没有手牌）”；不改变 `game.additionaldead` 当前未把手牌单元格加入行节点的既有 HTML 行为。
+- 混合版本只保证不崩溃：旧客户端忽略新增参数，完整 poptip 交互要求主客机都包含修复。
+- 实现提交使用中文动词短语 Conventional Commit；PR 目标为 `libnoname/noname:main`，描述包含原因、测试结果和 `Fixes #4042`。
+
+---
+
+## 文件结构与职责
+
+| 路径 | 当前行范围 | 处理方式 | 职责 |
+| --- | --- | --- | --- |
+| `apps\core\noname\game\index.js` | `1-24` | 修改 | 定义序列化条目、载荷、辅助函数选项的 JSDoc 类型，定义稳定 ID 常量和本地 poptip 创建/校验/恢复函数。 |
+| `apps\core\noname\game\index.js` | `6541-6564`、`6635-6645` | 修改 | 扩展 `Game.over(result, bool, handcardPoptips)`，并在客机分支返回后初始化主机快照、行序号和统一入口闭包。 |
+| `apps\core\noname\game\index.js` | `6581-6635` | 修改 | 客机先恢复 poptip，再设置 `dialog.content.innerHTML`；保持缺省第三参数兼容。 |
+| `apps\core\noname\game\index.js` | `6854-6865` | 修改 | 存活角色手牌列改用统一入口。 |
+| `apps\core\noname\game\index.js` | `6947-6958` | 修改 | 阵亡角色手牌列改用统一入口。 |
+| `apps\core\noname\game\index.js` | `7036-7040` | 修改 | 把纯数据载荷作为第四个 `send` 实参发送。 |
+| `apps\core\noname\library\poptip.js` | `208-244` | 只读参考 | 已支持显式 `id`、名称和 `createDialog` 注册；本计划不改动。 |
+| `apps\core\noname\get\index.js` | `2302-2342` | 只读参考 | 提供 `get.cardsInfo`、`get.infoCard`、`get.infoCards`；本计划不复制序列化逻辑。 |
+| `docs\superpowers\specs\2026-07-21-online-game-over-handcards-design.md` | `1-247` | 只读参考 | 设计约束和验收来源。 |
+
+不创建自动化测试文件。失败复现、边界断言和回归检查都通过项目现有浏览器运行时执行；静态验证使用现有 lint/build 命令。
+
+当前 `additionaldead` 段虽然创建了一个手牌 `td`，但没有执行 `tr.appendChild(td)`，因此页面没有第三个可见手牌入口。为遵守“不改变结算 HTML”的设计边界，本计划只统一实际显示的存活和阵亡两处入口，不补列、不为不可见入口发送多余载荷。
+
+## 锁定接口
+
+```js
+/**
+ * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipPayload
+ * @property {string} poptipId 结算手牌入口的稳定 ID
+ * @property {string} position 角色的联机座位标识
+ * @property {string} name 结算时的角色显示名
+ * @property {GameOverHandcardCardInfo[]} cards get.cardsInfo 生成的卡牌信息
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipOptions
+ * @property {string} poptipId
+ * @property {string} name
+ * @property {Card[]} cards
+ */
+
+/**
+ * 注册结算手牌 poptip，并返回现有手牌图标 HTML。
+ *
+ * @param {GameOverHandcardPoptipOptions} options
+ * @returns {string}
+ */
+function createGameOverHandcardPoptip({ poptipId, name, cards }) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardCardInfo}
+ */
+function isGameOverHandcardCardInfo(value) {}
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardPoptipPayload}
+ */
+function isGameOverHandcardPoptipPayload(value) {}
+
+/**
+ * 恢复客机结算手牌 poptip；参数缺省时保持旧调用行为。
+ *
+ * @param {unknown} handcardPoptips
+ * @returns {void}
+ */
+function restoreGameOverHandcardPoptips(handcardPoptips) {}
+
+/**
+ * @param {boolean | string} [result]
+ * @param {boolean} [bool]
+ * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
+ * @returns
+ */
+over(result, bool, handcardPoptips) {}
+```
+
+### Task 1: 统一本地结算手牌入口并生成稳定 ID
+
+**Files:**
+- Modify: `apps\core\noname\game\index.js:1-24`
+- Modify: `apps\core\noname\game\index.js:6541-6564`
+- Modify: `apps\core\noname\game\index.js:6635-6645`
+- Modify: `apps\core\noname\game\index.js:6854-6865`
+- Modify: `apps\core\noname\game\index.js:6947-6958`
+- Test: 浏览器运行时结算页断言；不创建测试文件
+
+**Interfaces:**
+- Consumes: `get.poptip({ id, name, dialog })`、`hsMap.get(Player)`、`get.translation(Player)`。
+- Produces: `GAME_OVER_HANDCARD_POPTIP_PREFIX`、`GameOverHandcardCardInfo`、`GameOverHandcardPoptipPayload`、`GameOverHandcardPoptipOptions`、`createGameOverHandcardPoptip(options): string`，以及 `Game.over` 内部的 `getHandcardPoptip(target): string`。
+
+- [ ] **Step 1: 在未修改代码上复现随机 ID**
+
+从仓库根目录启动现有开发服务器：
+
+```powershell
+pnpm --filter noname dev --host 127.0.0.1 --port 5173 --strictPort
+```
+
+预期：终端打印 `http://127.0.0.1:5173/`，浏览器可打开游戏。完成一局至少包含一名存活角色和一名阵亡角色的单机对局，在结算页 DevTools Console 执行：
+
+```js
+const handcardPoptips = [...document.querySelectorAll("noname-poptip")].filter(node =>
+	node.querySelector('img[src*="image/card/handcard.png"]')
+);
+const handcardPoptipIds = handcardPoptips.map(node => node.getAttribute("poptip"));
+console.assert(handcardPoptips.length >= 2, "失败复现需要至少两个结算手牌入口");
+console.assert(
+	handcardPoptipIds.every(id => /^game_over_handcards_\d+$/.test(id)),
+	`当前实现使用随机 ID：${handcardPoptipIds.join(", ")}`
+);
+```
+
+预期：第二个断言失败并打印随机 ID，证明稳定 ID 尚未实现。
+
+- [ ] **Step 2: 保存旧客户端构建供混合版本验收**
+
+另开 PowerShell，在未修改产品代码时构建并保存基线产物：
+
+```powershell
+pnpm build
+$baseline = Join-Path $env:TEMP "noname-4042-old-dist"
+if (Test-Path $baseline) {
+	Remove-Item -Recurse -Force $baseline
+}
+Copy-Item -Recurse ".\dist" $baseline
+Get-ChildItem $baseline | Select-Object -First 5
+```
+
+预期：`pnpm build` 退出码为 `0`，`$env:TEMP\noname-4042-old-dist` 存在且包含构建文件。该目录只用于最终旧客户端验收，不提交到仓库。
+
+- [ ] **Step 3: 增加类型、稳定 ID 常量和本地 poptip 辅助函数**
+
+在 `apps\core\noname\game\index.js` 顶部现有 typedef 后、imports 前加入类型；在 imports 后、`export class Game` 前加入常量和函数：
+
+```js
+/**
+ * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipPayload
+ * @property {string} poptipId 结算手牌入口的稳定 ID
+ * @property {string} position 角色的联机座位标识
+ * @property {string} name 结算时的角色显示名
+ * @property {GameOverHandcardCardInfo[]} cards get.cardsInfo 生成的卡牌信息
+ */
+
+/**
+ * @typedef {Object} GameOverHandcardPoptipOptions
+ * @property {string} poptipId
+ * @property {string} name
+ * @property {Card[]} cards
+ */
+
+const GAME_OVER_HANDCARD_POPTIP_PREFIX = "game_over_handcards_";
+
+/**
+ * 注册结算手牌 poptip，并返回现有手牌图标 HTML。
+ *
+ * @param {GameOverHandcardPoptipOptions} options
+ * @returns {string}
+ */
+function createGameOverHandcardPoptip({ poptipId, name, cards }) {
+	return get.poptip({
+		id: poptipId,
+		name: `<img style="width:15px; vertical-align: middle;" src="${lib.assetURL}image/card/handcard.png">`,
+		dialog(dialog) {
+			dialog.add(`${name}的手牌`);
+			dialog[cards.length > 0 ? "addSmall" : "addText"](cards.length > 0 ? cards : "（没有手牌）");
+			return dialog;
+		},
+	});
+}
+```
+
+预期：函数不引用 `target` 或 `hsMap`，只闭包捕获传入的 `name` 和 `cards`。
+
+- [ ] **Step 4: 在客机分支返回后建立统一入口闭包**
+
+在现有 `if (game.online) { ... return; }` 之后、主机继续生成结算内容之前增加递增序号和闭包：
+
+```js
+		let handcardPoptipIndex = 0;
+		const getHandcardPoptip = target => {
+			const cards = hsMap.get(target) ?? [];
+			return createGameOverHandcardPoptip({
+				poptipId: `${GAME_OVER_HANDCARD_POPTIP_PREFIX}${handcardPoptipIndex++}`,
+				name: get.translation(target),
+				cards,
+			});
+		};
+```
+
+此位置只会被单机或主机执行。序号只在生成可见结算手牌单元格时递增，调用顺序保持 `game.players`、`game.dead`。
+
+- [ ] **Step 5: 将存活与阵亡两个重复入口替换为统一闭包**
+
+存活角色段使用：
+
+```js
+				td = document.createElement("td");
+				td.innerHTML = getHandcardPoptip(game.players[i]);
+				tr.appendChild(td);
+```
+
+阵亡角色段使用：
+
+```js
+				td = document.createElement("td");
+				td.innerHTML = getHandcardPoptip(game.dead[i]);
+				tr.appendChild(td);
+```
+
+预期：存活和阵亡两处匿名 `dialog(dialog)` 回调删除。`additionaldead` 段保持原样，避免本修复新增结算列。
+
+- [ ] **Step 6: 运行目标文件 ESLint**
+
+```powershell
+pnpm --filter noname exec eslint noname/game/index.js
+```
+
+预期：退出码为 `0`，没有 ESLint error。
+
+- [ ] **Step 7: 重跑稳定 ID 与本地弹窗断言**
+
+刷新开发服务器页面并完成相同单机场景，在结算页执行：
+
+```js
+const handcardPoptips = [...document.querySelectorAll("noname-poptip")].filter(node =>
+	node.querySelector('img[src*="image/card/handcard.png"]')
+);
+const handcardPoptipIds = handcardPoptips.map(node => node.getAttribute("poptip"));
+console.assert(handcardPoptips.length >= 2, "必须包含存活和阵亡角色入口");
+console.assert(
+	handcardPoptipIds.every((id, index) => id === `game_over_handcards_${index}`),
+	`ID 必须按行连续：${handcardPoptipIds.join(", ")}`
+);
+console.assert(
+	new Set(handcardPoptipIds).size === handcardPoptipIds.length,
+	"结算手牌 ID 不得碰撞"
+);
+console.assert(
+	handcardPoptipIds.every(id => lib.poptip.createDialog.has(id)),
+	"每个稳定 ID 必须在本地注册 dialog"
+);
+```
+
+预期：所有断言通过。逐个点击存活、阵亡、多张和零张手牌入口，分别看到实际卡牌或“（没有手牌）”。
+
+- [ ] **Step 8: 提交统一入口**
+
+```powershell
+git add apps\core\noname\game\index.js
+git commit -m "refactor: 统一结算手牌入口" -m "Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>"
+```
+
+预期：提交成功，提交内容只包含 `apps\core\noname\game\index.js` 的类型、辅助函数、稳定 ID 和存活/阵亡两个入口替换。
+
+### Task 2: 收集并发送主机结算手牌快照
+
+**Files:**
+- Modify: `apps\core\noname\game\index.js:6541-6546`
+- Modify: `apps\core\noname\game\index.js:6635-6645`
+- Modify: `apps\core\noname\game\index.js:7036-7040`
+- Test: 主机浏览器运行时 `Player.send` 探针；不创建测试文件
+
+**Interfaces:**
+- Consumes: Task 1 的 `GAME_OVER_HANDCARD_POPTIP_PREFIX`、`createGameOverHandcardPoptip(options)` 和 `getHandcardPoptip(target)`。
+- Produces: `GameOverHandcardPoptipPayload[]` 主机快照；`clients[i].send(game.over, html, result, handcardPoptips)` 四实参调用。
+
+- [ ] **Step 1: 安装运行时发送探针并确认当前调用缺少载荷**
+
+在主机开始一局联机游戏后、游戏结束前，于主机 DevTools Console 执行：
+
+```js
+window.__gameOverSendCalls = [];
+window.__gameOverSendRestores = game.players
+	.concat(game.dead)
+	.filter(client => client.isOnline2())
+	.map(client => {
+		const originalSend = client.send;
+		client.send = function (...args) {
+			if (args[0] === game.over) {
+				window.__gameOverSendCalls.push({
+					args,
+					overAtSend: _status.over,
+				});
+			}
+			return originalSend.apply(this, args);
+		};
+		return () => {
+			client.send = originalSend;
+		};
+	});
+```
+
+结束游戏后在主机 Console 执行：
+
+```js
+console.assert(window.__gameOverSendCalls.length > 0, "必须捕获至少一次 game.over 发送");
+console.assert(
+	window.__gameOverSendCalls.every(call => call.args.length === 4 && Array.isArray(call.args[3])),
+	"当前发送只有 HTML 和胜负结果，缺少第四个手牌载荷实参"
+);
+window.__gameOverSendRestores.forEach(restore => restore());
+```
+
+预期：第二个断言失败；随后恢复所有临时 `send` 包装。
+
+- [ ] **Step 2: 扩展 `Game.over` JSDoc 并初始化载荷**
+
+把方法签名更新为：
+
+```js
+	/**
+	 * @param {boolean | string} [result]
+	 * @param {boolean} [bool]
+	 * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
+	 * @returns
+	 */
+	over(result, bool, handcardPoptips) {
+```
+
+在客机分支 `return` 后、Task 1 的统一入口闭包前初始化主机载荷：
+
+```js
+		/** @type {GameOverHandcardPoptipPayload[]} */
+		handcardPoptips = [];
+```
+
+该赋值只位于主机生成结算表格的路径，不会覆盖客机收到的第三参数。
+
+- [ ] **Step 3: 让统一入口同时记录纯数据快照**
+
+将 `getHandcardPoptip` 更新为：
+
+```js
+		let handcardPoptipIndex = 0;
+		const getHandcardPoptip = target => {
+			const cards = hsMap.get(target) ?? [];
+			const payload = {
+				poptipId: `${GAME_OVER_HANDCARD_POPTIP_PREFIX}${handcardPoptipIndex++}`,
+				position: String(target.dataset.position),
+				name: get.translation(target),
+				cards: get.cardsInfo(cards),
+			};
+			handcardPoptips.push(payload);
+			return createGameOverHandcardPoptip({
+				poptipId: payload.poptipId,
+				name: payload.name,
+				cards,
+			});
+		};
+```
+
+预期：载荷只含字符串和数组；回调、DOM、Player、`hsMap` 均不进入网络参数。
+
+- [ ] **Step 4: 把载荷作为第四个 `send` 实参发送**
+
+修改现有发送点：
+
+```js
+		let clients = game.players.concat(game.dead);
+		for (let i = 0; i < clients.length; i++) {
+			if (clients[i].isOnline2()) {
+				clients[i].send(
+					game.over,
+					dialog.content.innerHTML,
+					game.checkOnlineResult(clients[i]),
+					handcardPoptips
+				);
+			}
+		}
+```
+
+该代码仍位于 `_status.over = true` 之后和结算 HTML 完成之后；不得在其他游戏阶段广播载荷。
+
+- [ ] **Step 5: 运行目标文件 ESLint**
+
+```powershell
+pnpm --filter noname exec eslint noname/game/index.js
+```
+
+预期：退出码为 `0`，没有 ESLint error。
+
+- [ ] **Step 6: 重跑发送探针并校验序列化内容**
+
+重新开始联机游戏并安装 Step 1 的探针。确保至少一名角色有多张手牌、至少一名角色为零张手牌，然后结束游戏并执行：
+
+```js
+const calls = window.__gameOverSendCalls;
+console.assert(calls.length > 0, "必须捕获 game.over 发送");
+for (const { args, overAtSend } of calls) {
+	const payloads = args[3];
+	console.assert(args.length === 4, "game.over 发送必须有四个实参");
+	console.assert(overAtSend === true, "手牌载荷只能在 _status.over 后发送");
+	console.assert(Array.isArray(payloads), "第四个实参必须是数组");
+	console.assert(
+		payloads.every((entry, index) =>
+			entry.poptipId === `game_over_handcards_${index}` &&
+			typeof entry.position === "string" &&
+			typeof entry.name === "string" &&
+			Array.isArray(entry.cards) &&
+			entry.cards.every(card => Array.isArray(card))
+		),
+		"每个载荷条目必须符合序列化接口"
+	);
+	console.assert(
+		payloads.some(entry => entry.cards.length === 0),
+		"载荷必须保留零张手牌"
+	);
+	console.assert(
+		payloads.some(entry => entry.cards.length > 1),
+		"载荷必须保留多张手牌"
+	);
+}
+window.__gameOverSendRestores.forEach(restore => restore());
+```
+
+预期：所有断言通过；客机在 Task 3 前仍无法打开 poptip，这是下一任务的失败起点。
+
+- [ ] **Step 7: 提交主机快照发送**
+
+```powershell
+git add apps\core\noname\game\index.js
+git commit -m "fix: 发送联机结算手牌快照" -m "Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>"
+```
+
+预期：提交成功，只包含载荷收集、序列化和第四个发送实参。
+
+### Task 3: 校验载荷并恢复客机 poptip
+
+**Files:**
+- Modify: `apps\core\noname\game\index.js:1-24`
+- Modify: `apps\core\noname\game\index.js:6541-6546`
+- Modify: `apps\core\noname\game\index.js:6581-6586`
+- Test: 客机浏览器运行时失败断言、载荷注入、双端联机和单机回归；不创建测试文件
+
+**Interfaces:**
+- Consumes: Task 2 的 `GameOverHandcardPoptipPayload[]` 和 `createGameOverHandcardPoptip(options)`；现有 `get.infoCards(infos): Card[]`。
+- Produces: `isGameOverHandcardCardInfo(value)`、`isGameOverHandcardPoptipPayload(value)`、`restoreGameOverHandcardPoptips(handcardPoptips): void`；完整的 `Game.over(result, bool, handcardPoptips?)` 客机恢复流程。
+
+- [ ] **Step 1: 在 Task 2 代码上复现客机缺少本地注册**
+
+完成一局新主机加新客机联机游戏，在客机结算页执行：
+
+```js
+const handcardPoptips = [...document.querySelectorAll("noname-poptip")].filter(node =>
+	node.getAttribute("poptip")?.startsWith("game_over_handcards_")
+);
+const missingDialogs = handcardPoptips.filter(
+	node => !lib.poptip.createDialog.has(node.getAttribute("poptip"))
+);
+console.assert(handcardPoptips.length > 0, "客机必须收到稳定 ID 的结算 HTML");
+console.assert(
+	missingDialogs.length === 0,
+	`客机缺少 ${missingDialogs.length} 个本地 poptip 回调`
+);
+```
+
+预期：第二个断言失败，点击图标无有效手牌内容。
+
+- [ ] **Step 2: 增加卡牌条目和载荷类型守卫**
+
+在 `createGameOverHandcardPoptip` 后加入：
+
+```js
+const GAME_OVER_HANDCARD_POPTIP_ID_PATTERN = /^game_over_handcards_\d+$/;
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardCardInfo}
+ */
+function isGameOverHandcardCardInfo(value) {
+	return (
+		Array.isArray(value) &&
+		value.length >= 3 &&
+		value.length <= 5 &&
+		typeof value[2] === "string"
+	);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is GameOverHandcardPoptipPayload}
+ */
+function isGameOverHandcardPoptipPayload(value) {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		typeof value.poptipId === "string" &&
+		GAME_OVER_HANDCARD_POPTIP_ID_PATTERN.test(value.poptipId) &&
+		typeof value.position === "string" &&
+		value.position.length > 0 &&
+		typeof value.name === "string" &&
+		Array.isArray(value.cards) &&
+		value.cards.every(isGameOverHandcardCardInfo)
+	);
+}
+```
+
+预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少字符串卡牌名的条目失败。
+
+- [ ] **Step 3: 增加逐项恢复函数和精确告警**
+
+继续加入：
+
+```js
+/**
+ * 恢复客机结算手牌 poptip；参数缺省时保持旧调用行为。
+ *
+ * @param {unknown} handcardPoptips
+ * @returns {void}
+ */
+function restoreGameOverHandcardPoptips(handcardPoptips) {
+	if (handcardPoptips === undefined) {
+		return;
+	}
+	if (!Array.isArray(handcardPoptips)) {
+		console.warn("联机结算手牌载荷无效：载荷必须是数组", handcardPoptips);
+		return;
+	}
+
+	const poptipIds = new Set();
+	const players = [...game.players, ...game.dead, ...(game.additionaldead ?? [])];
+	handcardPoptips.forEach((payload, index) => {
+		if (!isGameOverHandcardPoptipPayload(payload)) {
+			console.warn(`联机结算手牌载荷无效（索引 ${index}）`, payload);
+			return;
+		}
+		if (poptipIds.has(payload.poptipId)) {
+			console.warn(
+				`联机结算手牌载荷无效：重复 poptipId ${payload.poptipId}`,
+				payload
+			);
+			return;
+		}
+		poptipIds.add(payload.poptipId);
+
+		const target = players.find(
+			player => String(player.dataset.position) === payload.position
+		);
+		if (!target) {
+			console.warn(
+				`联机结算手牌找不到角色（poptipId: ${payload.poptipId}, position: ${payload.position}），使用载荷快照`,
+				payload
+			);
+		}
+
+		let cards;
+		try {
+			cards = get.infoCards(payload.cards);
+		} catch (error) {
+			console.warn(
+				`联机结算手牌恢复失败（poptipId: ${payload.poptipId}, position: ${payload.position}）`,
+				error
+			);
+			return;
+		}
+		if (cards.length !== payload.cards.length || cards.some(Array.isArray)) {
+			console.warn(
+				`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`,
+				payload
+			);
+			return;
+		}
+
+		createGameOverHandcardPoptip({
+			poptipId: payload.poptipId,
+			name: payload.name,
+			cards,
+		});
+	});
+}
+```
+
+预期：只捕获 `get.infoCards` 的转换错误；无宽泛包裹整个循环。缺失 Player 只告警，不阻止快照注册。
+
+- [ ] **Step 4: 在插入 HTML 前恢复收到的第三参数**
+
+```js
+		if (game.online) {
+			let dialog = ui.create.dialog();
+			dialog.noforcebutton = true;
+			restoreGameOverHandcardPoptips(handcardPoptips);
+			dialog.content.innerHTML = result;
+```
+
+Task 2 已把主机的 `handcardPoptips = []` 放在此分支 `return` 之后，不需要移动。预期：`handcardPoptips === undefined` 时恢复函数立即返回且不告警；有效载荷总是在自定义元素连接 DOM 前完成注册。
+
+- [ ] **Step 5: 运行完整核心 lint 与项目构建**
+
+```powershell
+pnpm --filter noname lint
+pnpm build
+```
+
+预期：两个命令退出码均为 `0`；ESLint 无 error，构建完成且无 JavaScript/JSDoc 相关失败。
+
+- [ ] **Step 6: 验证有效载荷、零张和多张手牌**
+
+启动新构建：
+
+```powershell
+pnpm -F @noname/fs dev --dirname=".\dist" --port=8091 --server
+```
+
+预期：打印 `Server listening on port 8091`。使用 `http://localhost:8091/` 打开两个新客户端，完成一局包含存活、阵亡、多张和零张手牌的联机游戏。在两个客户端结算页执行：
+
+```js
+const nodes = [...document.querySelectorAll("noname-poptip")].filter(node =>
+	node.getAttribute("poptip")?.startsWith("game_over_handcards_")
+);
+const ids = nodes.map(node => node.getAttribute("poptip"));
+console.assert(nodes.length >= 2, "必须包含存活和阵亡角色入口");
+console.assert(ids.length === new Set(ids).size, "稳定 ID 不得碰撞");
+console.assert(
+	ids.every(id => lib.poptip.createDialog.has(id)),
+	"主机和客机都必须注册全部有效 poptip"
+);
+```
+
+预期：所有断言通过。逐项点击并核对主客机角色名、卡牌名称、花色、点数、属性、顺序以及零张提示一致。
+
+- [ ] **Step 7: 注入坏条目和缺失 Player 快照**
+
+重新开始联机游戏。在主机游戏结束前，找到在线客机并安装一次性注入包装：
+
+```js
+(() => {
+	const client = game.players.concat(game.dead).find(current => current.isOnline2());
+	const originalSend = client.send;
+	client.send = function (fn, html, result, payloads) {
+		if (fn !== game.over) {
+			return originalSend.apply(this, arguments);
+		}
+		client.send = originalSend;
+		const missingId = "game_over_handcards_9999";
+		const injectedHtml =
+			html +
+			`<noname-poptip poptip = ${missingId}></noname-poptip>`;
+		const first = payloads[0];
+		const injectedPayloads = [
+			...payloads,
+			{
+				poptipId: missingId,
+				position: "missing-player",
+				name: "快照角色",
+				cards: [],
+			},
+			null,
+			{
+				poptipId: "invalid-id",
+				position: "0",
+				name: "非法 ID",
+				cards: [],
+			},
+			{
+				...first,
+				cards: "not-an-array",
+			},
+			{
+				...first,
+			},
+		];
+		return originalSend.call(this, fn, injectedHtml, result, injectedPayloads);
+	};
+})();
+```
+
+结束游戏后，客机预期：
+
+1. 控制台分别出现缺失角色、空对象、非法 ID、坏 `cards`、重复 ID 的明确 `console.warn`。
+2. 正常存活和阵亡角色入口仍可点击。
+3. 新增的“快照角色”入口已注册，点击后显示“（没有手牌）”。
+4. 没有未捕获异常，胜负结果和退出按钮正常。
+
+再开始一局，安装只替换整体载荷类型的一次性包装：
+
+```js
+(() => {
+	const client = game.players.concat(game.dead).find(current => current.isOnline2());
+	const originalSend = client.send;
+	client.send = function (fn, html, result, payloads) {
+		if (fn !== game.over) {
+			return originalSend.apply(this, arguments);
+		}
+		client.send = originalSend;
+		return originalSend.call(this, fn, html, result, "not-an-array");
+	};
+})();
+```
+
+预期：客机只输出一次“载荷必须是数组”的 `console.warn`；结算 HTML、胜负结果和退出按钮仍正常，没有未捕获异常。
+
+- [ ] **Step 8: 验证第三参数缺省与旧客户端安全退化**
+
+启动 Task 1 保存的旧客户端构建：
+
+```powershell
+$baseline = Join-Path $env:TEMP "noname-4042-old-dist"
+pnpm -F @noname/fs dev --dirname="$baseline" --port=8090 --server
+```
+
+预期：打印 `Server listening on port 8090`。执行两个方向：
+
+1. 使用 `http://localhost:8090/` 的旧主机创建房间，`http://localhost:8091/` 的新客机加入并完成一局。新客机收到缺省第三参数，不出现“联机结算手牌载荷无效”告警，HTML、胜负音效和退出按钮正常；手牌 poptip 维持旧行为。
+2. 使用 `http://localhost:8091/` 的新主机创建房间，`http://localhost:8090/` 的旧客机加入并完成一局。旧客机忽略第四个 `send` 实参，不崩溃，结算 HTML、胜负结果和退出按钮正常；手牌 poptip 维持旧行为。
+
+两个方向都只验证安全退化，不把旧行为误判为完整修复。
+
+- [ ] **Step 9: 执行单机回归**
+
+在新客户端完成一局单机游戏，逐项确认：
+
+```text
+PASS 结算表格结构、统计数字、透明度和手牌图标不变
+PASS 存活角色多张手牌可打开且顺序正确
+PASS 阵亡角色手牌可打开
+PASS 零张手牌显示“（没有手牌）”
+PASS 退出、再来一局和录像保存流程可用
+PASS 游戏结束前没有新增其他角色手牌数据发送
+```
+
+预期：六项均为 `PASS`。
+
+- [ ] **Step 10: 提交客机恢复逻辑**
+
+```powershell
+git add apps\core\noname\game\index.js
+git commit -m "fix: 恢复客机结算手牌弹窗" -m "Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>"
+```
+
+预期：提交成功，只包含类型守卫、恢复函数、可选参数和“先注册后插入 HTML”的客机流程。
+
+## 最终验证与 PR 准备
+
+- [ ] **重新运行静态检查和构建**
+
+```powershell
+pnpm --filter noname lint
+pnpm build
+```
+
+预期：两个命令退出码均为 `0`，没有 lint 或 build error。
+
+- [ ] **检查提交范围和工作树**
+
+```powershell
+git status --short
+git --no-pager diff --check upstream/main...HEAD
+git --no-pager diff --name-only upstream/main...HEAD
+git --no-pager log --oneline upstream/main..HEAD
+```
+
+预期：`git status --short` 无输出，`diff --check` 无输出；产品代码变更只有 `apps\core\noname\game\index.js`，另含已批准的设计和计划文档提交；日志显示三个中文动词短语实现提交及文档提交。
+
+- [ ] **清理临时基线构建**
+
+```powershell
+$baseline = Join-Path $env:TEMP "noname-4042-old-dist"
+if (Test-Path $baseline) {
+	Remove-Item -Recurse -Force $baseline
+}
+Test-Path $baseline
+```
+
+预期：输出 `False`；仓库内没有测试注入、探针或临时文件。
+
+- [ ] **准备 PR 描述**
+
+```markdown
+## 原因
+
+联机结算 HTML 引用了主机随机生成的自定义 poptip ID，但名称、手牌和 dialog 回调只存在于主机内存，客机无法恢复。
+
+## 修改
+
+- 使用按结算行递增的稳定 poptip ID，并统一存活和阵亡角色的手牌入口
+- 主机在 Game.over 后发送 `{ poptipId, position, name, cards }` 纯数据快照
+- 客机校验载荷、用 get.infoCards 恢复卡牌，并在插入 HTML 前注册本地回调
+- 坏条目告警后隔离；缺失 Player 时继续使用有效快照；第三参数缺省和旧客户端安全退化
+
+## 测试
+
+- `pnpm --filter noname lint`
+- `pnpm build`
+- 主机与客机：存活、阵亡、多张、零张、坏条目、缺失 Player
+- 新主机与旧客机安全退化
+- 单机结算与退出/再来一局/录像保存回归
+
+Fixes #4042
+```
+
+预期：PR 目标为 `libnoname/noname:main`，描述包含原因、验证命令、联机/单机结果和 `Fixes #4042`。

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -298,12 +298,22 @@ git commit -m "refactor: 统一结算手牌入口" -m "Co-authored-by: Copilot A
 
 - [ ] **Step 1: 安装运行时发送探针并确认当前调用缺少载荷**
 
+在 Task 1 代码完成、Task 2 尚未实施时，主机仍会发送旧三实参 direct `game.over` 调用。探针必须按结算发送边界识别，而不是按函数身份或最终 wrapper 形状识别。
+
 在主机开始一局联机游戏后、游戏结束前，于主机 DevTools Console 执行：
 
 ```js
-const isGameOverWrapper = fn =>
-	typeof fn === "function" &&
-	/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
+const isGameOverResult = value => typeof value === "boolean" || typeof value === "string";
+const isGameOverHtml = value =>
+	typeof value === "string" &&
+	value.includes("<table") &&
+	value.includes("game_over_handcards_");
+const isGameOverSettlementSend = args =>
+	_status.over === true &&
+	typeof args[0] === "function" &&
+	isGameOverHtml(args[1]) &&
+	isGameOverResult(args[2]) &&
+	(args.length === 3 || (args.length === 4 && Array.isArray(args[3])));
 window.__gameOverSendCalls = [];
 window.__gameOverSendRestores = game.players
 	.concat(game.dead)
@@ -311,7 +321,7 @@ window.__gameOverSendRestores = game.players
 	.map(client => {
 		const originalSend = client.send;
 		client.send = function (...args) {
-			if (isGameOverWrapper(args[0])) {
+			if (isGameOverSettlementSend(args)) {
 				window.__gameOverSendCalls.push({
 					args,
 					overAtSend: _status.over,
@@ -328,18 +338,21 @@ window.__gameOverSendRestores = game.players
 结束游戏后在主机 Console 执行：
 
 ```js
-console.assert(window.__gameOverSendCalls.length > 0, "必须捕获至少一次 game.over 发送");
-console.assert(
-	window.__gameOverSendCalls.every(call => {
-		const args = call.args;
-		return args.length === 4 && Array.isArray(args[3]);
-	}),
-	"当前发送只有 HTML 和胜负结果，缺少第四个手牌载荷实参"
-);
+const calls = window.__gameOverSendCalls;
+console.assert(calls.length > 0, "必须捕获至少一次 game.over 结算发送；若为 0，探针仍误判了发送边界");
+if (calls.length > 0) {
+	console.assert(
+		calls.every(call => {
+			const args = call.args;
+			return args.length === 4 && Array.isArray(args[3]);
+		}),
+		"当前发送缺少第四个手牌载荷数组实参"
+	);
+}
 window.__gameOverSendRestores.forEach(restore => restore());
 ```
 
-预期：第二个断言失败；随后恢复所有临时 `send` 包装。
+预期：Task 1 后的旧 direct `game.over` 三实参调用能被捕获，`calls.length > 0` 通过；第二个断言因缺少第四个数组实参失败。`boolean` 和 `string` 胜负结果都属于合法结果形态。
 
 - [ ] **Step 2: 扩展 `Game.over` JSDoc 并初始化载荷**
 
@@ -387,7 +400,7 @@ window.__gameOverSendRestores.forEach(restore => restore());
 		};
 ```
 
-预期：载荷只含字符串和数组；回调、DOM、Player、`hsMap` 均不进入网络参数。
+预期：第四个 `handcardPoptips` 业务载荷只含字符串和数组；回调、DOM、Player、`hsMap` 均不进入该业务载荷。RPC 信封仍由现有 `Client.send` 处理固定 wrapper。
 
 - [ ] **Step 4: 把载荷作为第四个 `send` 实参发送**
 
@@ -419,41 +432,48 @@ pnpm --filter noname exec eslint noname/game/index.js
 
 预期：退出码为 `0`，没有 ESLint error。
 
-- [ ] **Step 6: 重跑发送探针并校验序列化内容**
+- [ ] **Step 6: 重跑发送探针并校验 wrapper 与序列化内容**
 
-重新开始联机游戏并安装 Step 1 的探针。确保至少一名角色有多张手牌、至少一名角色为零张手牌，然后结束游戏并执行：
+重新开始联机游戏并安装 Step 1 的探针（只复用安装代码，不执行 Step 1 的 RED 断言）。确保至少一名角色有多张手牌、至少一名角色为零张手牌，然后结束游戏并执行：
 
 ```js
+const isGameOverWrapper = fn =>
+	typeof fn === "function" &&
+	/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
 const calls = window.__gameOverSendCalls;
-console.assert(calls.length > 0, "必须捕获 game.over 发送");
+console.assert(calls.length > 0, "必须捕获 game.over 结算发送");
 for (const { args, overAtSend } of calls) {
 	const payloads = args[3];
+	console.assert(isGameOverWrapper(args[0]), "第一个实参必须是固定 game.over wrapper");
 	console.assert(args.length === 4, "game.over 发送必须有四个实参");
 	console.assert(overAtSend === true, "手牌载荷只能在 _status.over 后发送");
 	console.assert(Array.isArray(payloads), "第四个实参必须是数组");
-	console.assert(
-		payloads.every((entry, index) =>
-			entry.poptipId === `game_over_handcards_${index}` &&
-			typeof entry.position === "string" &&
-			typeof entry.name === "string" &&
-			Array.isArray(entry.cards) &&
-			entry.cards.every(card => Array.isArray(card))
-		),
-		"每个载荷条目必须符合序列化接口"
-	);
-	console.assert(
-		payloads.some(entry => entry.cards.length === 0),
-		"载荷必须保留零张手牌"
-	);
-	console.assert(
-		payloads.some(entry => entry.cards.length > 1),
-		"载荷必须保留多张手牌"
-	);
+	if (Array.isArray(payloads)) {
+		console.assert(payloads.length >= 2, "载荷必须包含实际可见的存活和阵亡手牌入口");
+		console.assert(
+			payloads.every((entry, index) =>
+				entry.poptipId === `game_over_handcards_${index}` &&
+				typeof entry.position === "string" &&
+				typeof entry.name === "string" &&
+				Array.isArray(entry.cards) &&
+				entry.cards.every(card => Array.isArray(card))
+			),
+			"每个载荷条目必须符合序列化接口"
+		);
+		console.assert(
+			payloads.some(entry => entry.cards.length === 0),
+			"载荷必须保留零张手牌"
+		);
+		console.assert(
+			payloads.some(entry => entry.cards.length > 1),
+			"载荷必须保留多张手牌"
+		);
+	}
 }
 window.__gameOverSendRestores.forEach(restore => restore());
 ```
 
-预期：所有断言通过；客机在 Task 3 前仍无法打开 poptip，这是下一任务的失败起点。
+预期：所有断言通过；GREEN 同时证明发送函数已换成固定 wrapper，第四实参是非空数组载荷，且零张和多张手牌都保留。客机在 Task 3 前仍无法打开 poptip，这是下一任务的失败起点。
 
 - [ ] **Step 7: 提交主机快照发送**
 

--- a/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
+++ b/docs/superpowers/plans/2026-07-22-online-game-over-handcards.md
@@ -47,7 +47,7 @@
 
 ```js
 /**
- * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ * @typedef {[(string|null|undefined), (number|string|null|undefined), string, (string|null|undefined)?, (string|null|undefined)?]} GameOverHandcardCardInfo
  */
 
 /**
@@ -162,7 +162,7 @@ Get-ChildItem $baseline | Select-Object -First 5
 
 ```js
 /**
- * @typedef {Array<unknown>} GameOverHandcardCardInfo
+ * @typedef {[(string|null|undefined), (number|string|null|undefined), string, (string|null|undefined)?, (string|null|undefined)?]} GameOverHandcardCardInfo
  */
 
 /**
@@ -439,7 +439,7 @@ pnpm --filter noname exec eslint noname/game/index.js
 ```js
 const isGameOverWrapper = fn =>
 	typeof fn === "function" &&
-	/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
+	/^\s*function\s*\(\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*\)\s*\{\s*game\.over\s*\(\s*\1\s*,\s*\2\s*,\s*\3\s*\)\s*;?\s*\}\s*$/.test(fn.toString());
 const calls = window.__gameOverSendCalls;
 console.assert(calls.length > 0, "必须捕获 game.over 结算发送");
 for (const { args, overAtSend } of calls) {
@@ -532,7 +532,13 @@ function isGameOverHandcardCardInfo(value) {
 		Array.isArray(value) &&
 		value.length >= 3 &&
 		value.length <= 5 &&
-		typeof value[2] === "string"
+		typeof value[2] === "string" &&
+		(value[0] == null || typeof value[0] === "string") &&
+		(value[1] == null ||
+			typeof value[1] === "number" ||
+			typeof value[1] === "string") &&
+		(value[3] == null || typeof value[3] === "string") &&
+		(value[4] == null || typeof value[4] === "string")
 	);
 }
 
@@ -556,7 +562,7 @@ function isGameOverHandcardPoptipPayload(value) {
 }
 ```
 
-预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少字符串卡牌名的条目失败。
+预期：零长度 `cards` 通过；非数组、长度小于三或大于五、缺少字符串卡牌名的条目失败；suit/nature/cardid 只接受 string/nullish，number 只接受 number/string/nullish，拒绝对象和函数。
 
 - [ ] **Step 3: 增加逐项恢复函数和精确告警**
 
@@ -614,7 +620,21 @@ function restoreGameOverHandcardPoptips(handcardPoptips) {
 			);
 			return;
 		}
-		if (cards.length !== payload.cards.length || cards.some(Array.isArray)) {
+		if (
+			!Array.isArray(cards) ||
+			cards.length !== payload.cards.length ||
+			cards.some((card, cardIndex) => {
+				const wireName = payload.cards[cardIndex]?.[2];
+				return (
+					card === payload.cards[cardIndex] ||
+					Array.isArray(card) ||
+					typeof card !== "object" ||
+					card === null ||
+					typeof card.name !== "string" ||
+					card.name !== wireName
+				);
+			})
+		) {
 			console.warn(
 				`联机结算手牌恢复结果无效（poptipId: ${payload.poptipId}, position: ${payload.position}）`,
 				payload
@@ -659,7 +679,7 @@ pnpm build
 启动新构建：
 
 ```powershell
-pnpm -F @noname/fs dev --dirname=".\dist" --port=8091 --server
+pnpm -F @noname/fs dev --dirname="..\..\dist" --port=8091 --server
 ```
 
 预期：打印 `Server listening on port 8091`。使用 `http://localhost:8091/` 打开两个新客户端，完成一局包含存活、阵亡、多张和零张手牌的联机游戏。在两个客户端结算页执行：
@@ -687,7 +707,7 @@ console.assert(
 (() => {
 	const isGameOverWrapper = fn =>
 		typeof fn === "function" &&
-		/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
+		/^\s*function\s*\(\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*\)\s*\{\s*game\.over\s*\(\s*\1\s*,\s*\2\s*,\s*\3\s*\)\s*;?\s*\}\s*$/.test(fn.toString());
 	const client = game.players.concat(game.dead).find(current => current.isOnline2());
 	const originalSend = client.send;
 	client.send = function (fn, html, result, payloads) {
@@ -741,7 +761,7 @@ console.assert(
 (() => {
 	const isGameOverWrapper = fn =>
 		typeof fn === "function" &&
-		/function\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*\{\s*game\.over\s*\(\s*result\s*,\s*bool\s*,\s*handcardPoptips\s*\)\s*;\s*\}/.test(fn.toString());
+		/^\s*function\s*\(\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*,\s*([^,\s()]+)\s*\)\s*\{\s*game\.over\s*\(\s*\1\s*,\s*\2\s*,\s*\3\s*\)\s*;?\s*\}\s*$/.test(fn.toString());
 	const client = game.players.concat(game.dead).find(current => current.isOnline2());
 	const originalSend = client.send;
 	client.send = function (fn, html, result, payloads) {

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -6,7 +6,7 @@
 
 ## 根因
 
-当前 `Game.over` 在主机端生成结算表格时，为每个手牌图标调用 `get.poptip({ name, dialog })`。未指定 `id` 时，`PoptipManager.add` 会生成随机 ID，并只在当前页面内存中的 `#customPoptip` 与 `createDialog` 注册表保存名称和回调。主机随后通过：
+改动前 `Game.over` 在主机端生成结算表格时，为每个手牌图标调用 `get.poptip({ name, dialog })`。未指定 `id` 时，`PoptipManager.add` 会生成随机 ID，并只在当前页面内存中的 `#customPoptip` 与 `createDialog` 注册表保存名称和回调。主机随后通过：
 
 ```js
 clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]));
@@ -18,7 +18,7 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
 
 - 保留现有结算页 HTML 结构和视觉样式。
 - 主机与客机使用一致、可预测且互不冲突的结算手牌 poptip ID。
-- 主机只在游戏结束后发送每个结算行的角色标识、显示名称和剩余手牌快照。
+- 主机只在游戏结束后发送实际可见的 `game.players`、`game.dead` 结算行角色标识、显示名称和剩余手牌快照。
 - 客机先恢复本地 poptip 注册，再插入收到的 HTML，使存活角色和阵亡角色的手牌入口都可用。
 - 单个坏条目不得阻断其余结算内容；诊断信息必须通过 `console.warn` 明确暴露。
 - `Game.over` 的新增参数保持可选，已有两参数调用不报错。
@@ -39,7 +39,7 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
 设计包含三个协作部分：
 
 1. **本地 poptip 创建辅助函数**：接收稳定 ID、角色显示名和本地 `Card[]`，注册 poptip 回调并返回现有手牌图标 HTML。
-2. **主机载荷收集**：生成每个结算行的稳定 ID，使用结算开始时的 `hsMap` 快照构造纯数据载荷，并复用辅助函数渲染主机页面。
+2. **主机载荷收集**：仅为实际可见的 `game.players` 和 `game.dead` 手牌列生成稳定 ID，使用结算开始时的 `hsMap` 快照构造纯数据载荷，并复用辅助函数渲染主机页面。
 3. **客机载荷恢复**：在 `Game.over` 的联机接收分支校验可选载荷，使用 `get.infoCards` 恢复卡牌对象，逐项调用同一辅助函数注册回调，然后再设置 `dialog.content.innerHTML`。
 
 该边界保证网络只传输可序列化数据，不传输函数、DOM 节点或主机闭包。
@@ -109,7 +109,7 @@ game_over_handcards_1
 game_over_handcards_2
 ```
 
-序号按现有三段表格的生成顺序分配：`game.players`、`game.dead`、`game.additionaldead`。不直接使用 `position` 作为唯一后缀，因为特殊模式中的 `additionaldead` 可能与当前角色复用座位；行序号能在一次结算中保证唯一，并且主机发送的 HTML 与载荷天然引用同一 ID。
+序号按实际带有可见手牌入口的结算行生成顺序分配：`game.players`、`game.dead`。不直接使用 `position` 作为唯一后缀，因为特殊模式中的不可见或复用座位入口不应参与载荷；可见行序号能在一次结算中保证唯一，并且主机发送的 HTML 与载荷天然引用同一 ID。
 
 客机只接受匹配 `^game_over_handcards_\d+$` 的 ID，并拒绝同一载荷中的重复 ID，避免覆盖其他 poptip 注册。
 
@@ -119,7 +119,7 @@ game_over_handcards_2
 
 1. `Game.over` 进入时按现有逻辑把 `game.players` 和 `game.dead` 的手牌保存到 `hsMap`，保证后续动画或清理不会改变结算快照。
 2. 初始化空的 `handcardPoptips` 数组和递增行序号。
-3. 每次生成手牌列时：
+3. 每次为 `game.players` 或 `game.dead` 生成实际可见手牌列时：
    - 生成 `poptipId`。
    - 从 `hsMap` 读取该角色的 `Card[]`，缺省为空数组。
    - 读取 `String(target.dataset.position)` 和 `get.translation(target)`。
@@ -129,7 +129,9 @@ game_over_handcards_2
 
 ```js
 clients[i].send(
-	game.over,
+	function (result, bool, handcardPoptips) {
+		game.over(result, bool, handcardPoptips);
+	},
 	dialog.content.innerHTML,
 	game.checkOnlineResult(clients[i]),
 	handcardPoptips
@@ -138,7 +140,7 @@ clients[i].send(
 
 5. 单机和主机本地页面继续使用同一辅助函数，不经过序列化往返。
 
-`game.additionaldead` 保持现有语义：由于当前 `hsMap` 不为其保存手牌，载荷中的 `cards` 为空数组。本修复只消除联机主客机差异，不顺带改变特殊阵亡角色的既有展示。
+`game.additionaldead` 保持既有 HTML：当前实现创建手牌 `td` 后未追加到行中，因此不补列、不分配稳定 ID、不加入 `handcardPoptips`，也不发送不可见入口载荷。本修复只消除联机主客机差异，不顺带改变特殊阵亡角色的既有展示。
 
 ### 客机
 
@@ -151,7 +153,7 @@ clients[i].send(
    - `position` 必须是非空字符串。
    - `name` 必须是字符串。
    - `cards` 必须是数组；每项也必须是数组，长度为三至五项，且索引 `2` 的卡牌名必须是字符串。花色、点数、属性和 `cardid` 继续交由现有 `get.infoCard` 兼容处理，避免拒绝已有合法牌型。
-5. 通过 `position` 在 `game.players`、`game.dead` 和 `game.additionaldead` 中查找本地角色。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
+5. `position` 用于诊断和匹配实际可见的 `game.players`、`game.dead` 角色；主机不会为 `game.additionaldead` 补建或发送不可见入口载荷。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
 6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。若结果数量与输入不一致，或仍包含 `get.infoCard` 失败时返回的原始数组，则视为恢复失败；否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
 7. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
 8. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -64,7 +64,7 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
  */
 ```
 
-`cards` 的运行时校验按显式 wire tuple 处理：suit 为 string/nullish，number|string|nullish，name 必须 string，nature/cardid 为 string/nullish；拒绝对象、函数等会触发转换或属性键副作用的值，不在本修复中修改通用卡牌协议。
+`cards` 的运行时校验按显式 wire tuple 处理：suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空 string，并拒绝 `__proto__`、`prototype`、`constructor` 等会命中原型属性的危险键，但不要求 `hasOwn(lib.card)`，以保留 `huosha`、`leisha`、`cisha` 和普通扩展卡牌名兼容；nature 为 nullish、空 string，或 `get.natureList(value)` 拆出的每个非空 token 均存在于 `lib.nature` 且不含空白；cardid 为 nullish 或 `get.id` 现有数字字符串格式。对象、函数、`NaN`、`Infinity`、未知/空白 nature token 和原型键在进入 `Card.init` 前被拒绝；不在本修复中修改通用卡牌协议。
 
 ### 本地 poptip 创建辅助函数
 
@@ -156,9 +156,9 @@ clients[i].send(
    - `poptipId` 必须符合固定前缀格式且在本批次唯一。
    - `position` 必须是非空字符串。
    - `name` 必须是字符串。
-   - `cards` 必须是数组；每项也必须是数组，长度为三至五项。suit 为 string/nullish，number|string|nullish，name 必须 string，nature/cardid 为 string/nullish；拒绝对象、函数等会触发转换或属性键副作用的值。
+   - `cards` 必须是数组；每项也必须是数组，长度为三至五项。suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空安全 string，拒绝 `__proto__`、`prototype`、`constructor` 等原型键但不要求 `hasOwn(lib.card)`；nature 为 nullish、空 string，或经 `get.natureList` 拆出的已注册非空 token；cardid 为 nullish 或数字字符串。拒绝对象、函数、`NaN`、`Infinity`、空白/未知 nature token 和原型键。
 5. `position` 用于诊断和匹配实际可见的 `game.players`、`game.dead` 角色；主机不会为 `game.additionaldead` 补建或发送不可见入口载荷。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
-6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。若结果数量与输入不一致，任一恢复项仍是原数组、不是带 string `name` 的 Card，或 name 与对应 wire entry（考虑 `get.infoCard` 对历史 huosha/leisha/cisha 可能原地规范化）不一致，则视为恢复失败；半初始化 Card 也必须拒绝。否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
+6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。该调用可能原地规范化 `huosha`、`leisha`、`cisha` 的 wire tuple，因此 postcondition 在调用后逐张比较：恢复项必须是非数组对象且不能仍是原数组；`suit` 与 tuple 一致；`number` 等于 `parseInt(wireNumber) || 0`；`name` 与 tuple 一致；`nature` 按 `get.natureList`、`lib.nature`、`lib.sort.nature`、`lib.natureSeparator` 规范化后一致，且无 nature 时 nullish/空字符串等价；存在 wire cardid 时必须一致。任一不匹配视为恢复失败并跳过整个 payload；半初始化 Card 也必须拒绝。否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
 7. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
 8. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。
 
@@ -196,7 +196,7 @@ clients[i].send(
 
 ## 测试
 
-仓库当前没有针对 `Game.over` 的 JavaScript 单元测试运行器，因此本修复不新增第三方框架或自动化测试脚本。实现阶段必须在浏览器开发环境中执行下列边界测试矩阵，并在 PR 中逐项记录结果；缺失角色、坏条目和重复 ID 通过在主机发送前替换一份载荷副本注入，不修改正常结算数据源。
+仓库当前没有针对 `Game.over` 的 JavaScript 单元测试运行器，因此本修复不新增第三方框架或提交新的测试脚本。严格卡牌恢复边界使用 ignored Node/VM/source boundary script 先 RED 后 GREEN 记录；浏览器开发环境仍需执行下列边界测试矩阵，并在 PR 中逐项记录结果。缺失角色、malformed nature、坏条目和重复 ID 通过在主机发送前替换一份载荷副本注入，不修改正常结算数据源。
 
 | 场景 | 预期结果 |
 | --- | --- |
@@ -208,6 +208,10 @@ clients[i].send(
 | 重复或非法 `poptipId` | 输出明确 `console.warn`，不覆盖已有 poptip |
 | 第三个参数缺省 | 不报错，结算 HTML、胜负结果和退出流程与旧调用一致 |
 | `cards` 不是数组或卡牌项格式错误 | 输出明确 `console.warn`，不把错误伪装成零手牌 |
+| 合法 card tuple：合法/缺省 suit、有限 number 或 string、单属性/复合属性、`huosha`/`leisha`/`cisha`、三/四/五元组 | guard 通过，`get.infoCards` 规范化后 postcondition 通过 |
+| 非法 card tuple：`bad nature`、空白或未知 nature token、危险 name/cardid、对象/函数字段、`NaN`、`Infinity` | 输出明确“联机结算手牌载荷无效”告警，跳过坏条目，正常条目仍注册 |
+| `get.infoCards` 返回半初始化 Card 或 suit/number/name/nature/cardid 与规范化 tuple 不一致 | 输出明确“恢复结果无效”告警，跳过整条 payload |
+| 完整恢复 Card 的标准字段与规范化 tuple 一致 | 正常注册 poptip；若内部可信卡牌定义在标准字段已完整后抛错，不扩大通用 `get.infoCard` API |
 
 ### 联机验收
 

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -1,0 +1,247 @@
+# 联机结算剩余手牌同步设计
+
+## 问题
+
+联机游戏结束后，主机结算页可以点击角色行末的手牌图标，查看该角色结算时的剩余手牌；客机虽然收到相同的结算表格外观，但图标文字异常，点击后也没有内容。该问题对应 `libnoname/noname#4042`。
+
+## 根因
+
+当前 `Game.over` 在主机端生成结算表格时，为每个手牌图标调用 `get.poptip({ name, dialog })`。未指定 `id` 时，`PoptipManager.add` 会生成随机 ID，并只在当前页面内存中的 `#customPoptip` 与 `createDialog` 注册表保存名称和回调。主机随后通过：
+
+```js
+clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]));
+```
+
+仅把 HTML 和胜负结果发送给客机。HTML 中包含随机 ID，但客机没有对应的名称、卡牌快照或 `createDialog` 回调，因此无法还原该 poptip。
+
+## 目标
+
+- 保留现有结算页 HTML 结构和视觉样式。
+- 主机与客机使用一致、可预测且互不冲突的结算手牌 poptip ID。
+- 主机只在游戏结束后发送每个结算行的角色标识、显示名称和剩余手牌快照。
+- 客机先恢复本地 poptip 注册，再插入收到的 HTML，使存活角色和阵亡角色的手牌入口都可用。
+- 单个坏条目不得阻断其余结算内容；诊断信息必须通过 `console.warn` 明确暴露。
+- `Game.over` 的新增参数保持可选，已有两参数调用不报错。
+
+## 非目标
+
+- 不重写结算表格，不调整统计列、排序、透明度或现有图标样式。
+- 不改变手牌的序列化格式；继续复用 `get.cardsInfo` 和 `get.infoCards`。
+- 不修改游戏进行中的手牌可见性或同步协议。
+- 不处理录像回放中的结算手牌交互；现有 `game.addVideo("over", ...)` 仍只记录 HTML。
+- 不为本修复引入新的通用网络协议、第三方测试框架或 poptip 生命周期系统。
+- 不顺带重构 `PoptipManager` 的其他注册路径。
+
+## 架构
+
+改动集中在 `apps/core/noname/game/index.js`，继续使用 `apps/core/noname/library/poptip.js` 已支持的显式 `id` 注册能力。`PoptipManager.add` 在提供 `id` 时会把名称写入 `lib.translate`、把回调写入 `createDialog`，并把 ID 加入对应类型列表，因此不需要修改 poptip 核心实现。
+
+设计包含三个协作部分：
+
+1. **本地 poptip 创建辅助函数**：接收稳定 ID、角色显示名和本地 `Card[]`，注册 poptip 回调并返回现有手牌图标 HTML。
+2. **主机载荷收集**：生成每个结算行的稳定 ID，使用结算开始时的 `hsMap` 快照构造纯数据载荷，并复用辅助函数渲染主机页面。
+3. **客机载荷恢复**：在 `Game.over` 的联机接收分支校验可选载荷，使用 `get.infoCards` 恢复卡牌对象，逐项调用同一辅助函数注册回调，然后再设置 `dialog.content.innerHTML`。
+
+该边界保证网络只传输可序列化数据，不传输函数、DOM 节点或主机闭包。
+
+## 组件接口
+
+### 结算手牌载荷
+
+在文件顶部增加完整 JSDoc 类型，表达网络边界：
+
+```js
+/**
+ * @typedef {Object} GameOverHandcardPoptipPayload
+ * @property {string} poptipId 结算页手牌入口的稳定 ID
+ * @property {string} position 角色在联机状态中的座位标识
+ * @property {string} name 结算时的角色显示名
+ * @property {Array<unknown[]>} cards get.cardsInfo 生成的卡牌信息
+ */
+```
+
+`cards` 的运行时校验仍按 `get.cardInfo` 最多五项的数组格式处理，不在本修复中另建一套卡牌协议类型。
+
+### 本地 poptip 创建辅助函数
+
+在 `Game` 类外、同一模块内定义：
+
+```js
+/**
+ * 注册结算页手牌 poptip，并返回手牌图标 HTML。
+ *
+ * @param {Object} options
+ * @param {string} options.poptipId
+ * @param {string} options.name
+ * @param {Card[]} options.cards
+ * @returns {string}
+ */
+function createGameOverHandcardPoptip({ poptipId, name, cards }) {}
+```
+
+辅助函数调用 `get.poptip` 时显式传入 `id: poptipId`，保留现有图标 HTML。回调继续显示“`角色名`的手牌”，有牌时调用 `dialog.addSmall(cards)`，零张牌时显示“（没有手牌）”。
+
+名称和卡牌数组作为独立局部值传入回调，不再依赖主机专有的 `target` 和 `hsMap` 闭包。该函数只负责本地注册与 HTML 生成，不负责网络发送。
+
+### `Game.over`
+
+接口扩展为：
+
+```js
+/**
+ * @param {boolean | string} [result]
+ * @param {boolean} [bool]
+ * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
+ * @returns
+ */
+over(result, bool, handcardPoptips) {}
+```
+
+第三个参数仅供主机向客机发送结算手牌载荷。省略时沿用现有流程，不尝试恢复注册，也不抛出异常。
+
+## 稳定 ID
+
+ID 使用固定前缀和结算手牌行的递增序号，例如：
+
+```text
+game_over_handcards_0
+game_over_handcards_1
+game_over_handcards_2
+```
+
+序号按现有三段表格的生成顺序分配：`game.players`、`game.dead`、`game.additionaldead`。不直接使用 `position` 作为唯一后缀，因为特殊模式中的 `additionaldead` 可能与当前角色复用座位；行序号能在一次结算中保证唯一，并且主机发送的 HTML 与载荷天然引用同一 ID。
+
+客机只接受匹配 `^game_over_handcards_\d+$` 的 ID，并拒绝同一载荷中的重复 ID，避免覆盖其他 poptip 注册。
+
+## 数据流
+
+### 主机
+
+1. `Game.over` 进入时按现有逻辑把 `game.players` 和 `game.dead` 的手牌保存到 `hsMap`，保证后续动画或清理不会改变结算快照。
+2. 初始化空的 `handcardPoptips` 数组和递增行序号。
+3. 每次生成手牌列时：
+   - 生成 `poptipId`。
+   - 从 `hsMap` 读取该角色的 `Card[]`，缺省为空数组。
+   - 读取 `String(target.dataset.position)` 和 `get.translation(target)`。
+   - 将 `{ poptipId, position, name, cards: get.cardsInfo(cards) }` 追加到载荷。
+   - 调用 `createGameOverHandcardPoptip` 取得 HTML。
+4. 主机完成整个结算页后，调用：
+
+```js
+clients[i].send(
+	game.over,
+	dialog.content.innerHTML,
+	game.checkOnlineResult(clients[i]),
+	handcardPoptips
+);
+```
+
+5. 单机和主机本地页面继续使用同一辅助函数，不经过序列化往返。
+
+`game.additionaldead` 保持现有语义：由于当前 `hsMap` 不为其保存手牌，载荷中的 `cards` 为空数组。本修复只消除联机主客机差异，不顺带改变特殊阵亡角色的既有展示。
+
+### 客机
+
+1. 进入 `game.online` 分支后创建 dialog，但暂不写入收到的 HTML。
+2. 若第三个参数为 `undefined`，直接走旧流程。
+3. 若第三个参数不是数组，输出 `console.warn`，忽略整份手牌载荷并继续显示结算 HTML。
+4. 对数组逐项执行结构校验：
+   - 条目必须是非空对象。
+   - `poptipId` 必须符合固定前缀格式且在本批次唯一。
+   - `position` 必须是非空字符串。
+   - `name` 必须是字符串。
+   - `cards` 必须是数组；每项也必须是数组，长度为三至五项，且索引 `2` 的卡牌名必须是字符串。花色、点数、属性和 `cardid` 继续交由现有 `get.infoCard` 兼容处理，避免拒绝已有合法牌型。
+5. 通过 `position` 在 `game.players`、`game.dead` 和 `game.additionaldead` 中查找本地角色。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
+6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。若结果数量与输入不一致，或仍包含 `get.infoCard` 失败时返回的原始数组，则视为恢复失败；否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
+7. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
+8. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。
+
+## 错误处理
+
+- **缺少第三个参数**：视为旧调用，不告警、不失败。
+- **载荷整体类型错误**：告警一次，忽略载荷，结算 HTML、胜负音效和退出按钮继续正常显示。
+- **条目字段错误**：告警并跳过该条目，不终止循环。
+- **重复或越界 ID**：告警并跳过，防止覆盖本地注册。
+- **本地找不到角色**：告警后使用载荷快照继续注册；`position` 用于诊断，不作为渲染的硬依赖。
+- **卡牌恢复失败**：告警并跳过该条目，不使用空数组伪装成功。
+- **零张手牌**：这是有效数据，正常注册并显示“（没有手牌）”，不告警。
+
+告警需包含固定前缀（例如“联机结算手牌载荷无效”）以及可用的 `poptipId`、`position` 或数组索引，便于定位异常。不得使用空 `catch`、静默返回或成功形态的兜底数据。
+
+## 兼容性
+
+- 新增的第三个参数是可选参数，仓库内已有 `game.over(result, bool)` 调用保持可用。
+- 新客机连接旧主机时收不到载荷，不会崩溃；其手牌 poptip 维持旧版本行为。
+- 旧客机连接新主机时会忽略 JavaScript 的额外参数，不会崩溃；由于旧客机不会本地注册稳定 ID，手牌 poptip 仍不可用。
+- 主机和客机都包含本修复时，完整功能生效。
+- HTML、录像记录格式和前两个参数的含义不变。
+
+因此，此兼容策略保证混合版本安全退化，不承诺在只升级一端时修复交互。
+
+## 安全性与隐私
+
+- 手牌载荷只在 `_status.over` 已进入结算流程、主机准备发送结算 HTML 时发送，不提前广播，不改变对局中的隐藏信息规则。
+- 只传输字符串和 `get.cardsInfo` 产生的数组，不序列化函数、闭包、DOM 或可执行代码。
+- 客机不执行来自网络的回调；回调由本地固定辅助函数创建。
+- `poptipId` 使用白名单格式并检查重复，不能借载荷覆盖任意 poptip。
+- 图标 HTML 由本地常量生成；载荷字段不会拼接进主结算 HTML。
+- `name` 来自主机对已存在角色执行的 `get.translation`。它仅用于现有 dialog 标题路径，不扩大当前主机权威模型。
+
+## 测试
+
+仓库当前没有针对 `Game.over` 的 JavaScript 单元测试运行器，因此本修复不新增第三方框架或自动化测试脚本。实现阶段必须在浏览器开发环境中执行下列边界测试矩阵，并在 PR 中逐项记录结果；缺失角色、坏条目和重复 ID 通过在主机发送前替换一份载荷副本注入，不修改正常结算数据源。
+
+| 场景 | 预期结果 |
+| --- | --- |
+| 存活角色，多张手牌 | 主机和客机显示相同角色名、相同卡牌顺序与数量 |
+| 阵亡角色，多张手牌 | 阵亡表格透明度不变，双方均可打开相同手牌 |
+| 存活或阵亡角色，零张手牌 | 双方均显示“（没有手牌）”，无告警 |
+| 本地缺失 `position` 对应角色 | 输出明确 `console.warn`，仍使用有效载荷显示该项，其余项不受影响 |
+| 单个条目字段错误 | 输出明确 `console.warn`，仅跳过坏条目 |
+| 重复或非法 `poptipId` | 输出明确 `console.warn`，不覆盖已有 poptip |
+| 第三个参数缺省 | 不报错，结算 HTML、胜负结果和退出流程与旧调用一致 |
+| `cards` 不是数组或卡牌项格式错误 | 输出明确 `console.warn`，不把错误伪装成零手牌 |
+
+### 联机验收
+
+使用两个独立客户端完成一局主机加客机联机对局，并至少保留一名存活角色和一名阵亡角色：
+
+1. 结束前确认客机看不到其他角色的隐藏手牌。
+2. 结束后分别在主机和客机点击所有手牌图标。
+3. 对照角色名、卡牌名称、花色、点数、属性、顺序和零手牌提示。
+4. 确认控制台没有正常载荷相关告警。
+5. 注入一个缺失角色或坏条目，确认只出现预期告警，其他结算行仍可点击。
+
+### 单机回归
+
+完成一局单机对局，确认：
+
+- 结算表格结构、统计数字、图标和胜负结果不变。
+- 存活和阵亡角色手牌入口仍可点击。
+- 多张和零张手牌显示与修改前一致。
+- 退出、再来一局和录像保存流程未受影响。
+
+### 静态检查与构建
+
+实现阶段执行：
+
+```text
+pnpm --filter noname lint
+pnpm build
+```
+
+JavaScript 使用 Tab 缩进，新增类型和函数提供完整 JSDoc；稳定 ID、先注册后插入 HTML、缺失角色仍可使用快照等非直观逻辑添加简短原因说明。
+
+## PR 验收
+
+- 分支基于最新 `upstream/main`，PR 目标分支为 `libnoname/noname:main`。
+- 实现提交使用清晰的 Conventional Commit 动词短语；不混入无关重构。
+- PR 描述包含：
+  - **原因**：随机自定义 poptip ID、名称和闭包只存在于主机内存，客机只收到 HTML。
+  - **方案**：稳定 ID、纯数据手牌载荷、客机本地恢复注册、坏条目隔离。
+  - **测试**：列出 lint、build、主机加客机验收和单机回归结果。
+  - **Issue**：使用 `Fixes #4042`。
+- 主机和客机的存活、阵亡、多张、零张场景全部通过。
+- 缺失角色、坏条目和参数缺省均按本设计安全退化。
+- 游戏结束前没有新增手牌信息广播。
+- 变更范围适合单个实现 PR，不包含录像 poptip、通用 poptip 重构或其他结算页改造。

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -52,15 +52,19 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
 
 ```js
 /**
+ * @typedef {[(string|null|undefined), (number|string|null|undefined), string, (string|null|undefined)?, (string|null|undefined)?]} GameOverHandcardCardInfo
+ */
+
+/**
  * @typedef {Object} GameOverHandcardPoptipPayload
  * @property {string} poptipId 结算页手牌入口的稳定 ID
  * @property {string} position 角色在联机状态中的座位标识
  * @property {string} name 结算时的角色显示名
- * @property {Array<unknown[]>} cards get.cardsInfo 生成的卡牌信息
+ * @property {GameOverHandcardCardInfo[]} cards get.cardsInfo 生成的卡牌信息
  */
 ```
 
-`cards` 的运行时校验仍按 `get.cardInfo` 最多五项的数组格式处理，不在本修复中另建一套卡牌协议类型。
+`cards` 的运行时校验按显式 wire tuple 处理：suit 为 string/nullish，number|string|nullish，name 必须 string，nature/cardid 为 string/nullish；拒绝对象、函数等会触发转换或属性键副作用的值，不在本修复中修改通用卡牌协议。
 
 ### 本地 poptip 创建辅助函数
 
@@ -152,9 +156,9 @@ clients[i].send(
    - `poptipId` 必须符合固定前缀格式且在本批次唯一。
    - `position` 必须是非空字符串。
    - `name` 必须是字符串。
-   - `cards` 必须是数组；每项也必须是数组，长度为三至五项，且索引 `2` 的卡牌名必须是字符串。花色、点数、属性和 `cardid` 继续交由现有 `get.infoCard` 兼容处理，避免拒绝已有合法牌型。
+   - `cards` 必须是数组；每项也必须是数组，长度为三至五项。suit 为 string/nullish，number|string|nullish，name 必须 string，nature/cardid 为 string/nullish；拒绝对象、函数等会触发转换或属性键副作用的值。
 5. `position` 用于诊断和匹配实际可见的 `game.players`、`game.dead` 角色；主机不会为 `game.additionaldead` 补建或发送不可见入口载荷。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
-6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。若结果数量与输入不一致，或仍包含 `get.infoCard` 失败时返回的原始数组，则视为恢复失败；否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
+6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。若结果数量与输入不一致，任一恢复项仍是原数组、不是带 string `name` 的 Card，或 name 与对应 wire entry（考虑 `get.infoCard` 对历史 huosha/leisha/cisha 可能原地规范化）不一致，则视为恢复失败；半初始化 Card 也必须拒绝。否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
 7. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
 8. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。
 

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -64,7 +64,7 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
  */
 ```
 
-`cards` 的运行时校验按显式 wire tuple 处理：suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空 string，并拒绝 `__proto__`、`prototype`、`constructor` 等会命中原型属性的危险键，但不要求 `hasOwn(lib.card)`，以保留 `huosha`、`leisha`、`cisha` 和普通扩展卡牌名兼容；nature 为 nullish、空 string，或 `get.natureList(value)` 拆出的每个非空 token 均存在于 `lib.nature` 且不含空白；cardid 为 nullish 或 `get.id` 现有数字字符串格式。对象、函数、`NaN`、`Infinity`、未知/空白 nature token 和原型键在进入 `Card.init` 前被拒绝；不在本修复中修改通用卡牌协议。
+`cards` 的运行时校验按显式 wire tuple 处理：先抽取规范化 clone，镜像 `Card.init` 对 `huosha`、`leisha`、`cisha`、完整非空且已注册 `<nature>sha`、以及 `sha_<nature...>` 的别名路径；`sha_`、`sha_unknown`、`sha_bad nature` 这类空、未知或含空白 token 的 alias 在进入 `Card.init` 前被拒绝，且不修改原输入。随后对规范化 clone 校验 suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空安全 string，但不要求 `hasOwn(lib.card)`，以保留普通扩展卡牌名兼容；nature 为 nullish、空 string，或 `get.natureList(value)` 拆出的每个非空 token 均存在于 `lib.nature` 且不含空白；cardid 为 nullish 或 `get.id` 现有数字字符串格式。对象、函数、`NaN`、`Infinity`、未知/空白 nature token 和原型键在进入 `Card.init` 前被拒绝；不在本修复中修改通用卡牌协议。
 
 ### 本地 poptip 创建辅助函数
 
@@ -93,7 +93,7 @@ function createGameOverHandcardPoptip({ poptipId, name, cards }) {}
 
 ```js
 /**
- * @param {boolean | string} [result]
+ * @param {boolean | string | null} [result]
  * @param {boolean} [bool]
  * @param {GameOverHandcardPoptipPayload[]} [handcardPoptips]
  * @returns
@@ -102,6 +102,7 @@ over(result, bool, handcardPoptips) {}
 ```
 
 第三个参数仅供主机向客机发送结算手牌载荷。省略时沿用现有流程，不尝试恢复注册，也不抛出异常。
+`identity.checkOnlineResult` 可返回 `null`，因此结算结果探针和 `Game.over` JSDoc 均把 `result` 表达为 `boolean | string | null`；参数省略时仍允许 `undefined`。
 
 ## 稳定 ID
 
@@ -156,18 +157,19 @@ clients[i].send(
    - `poptipId` 必须符合固定前缀格式且在本批次唯一。
    - `position` 必须是非空字符串。
    - `name` 必须是字符串。
-   - `cards` 必须是数组；每项也必须是数组，长度为三至五项。suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空安全 string，拒绝 `__proto__`、`prototype`、`constructor` 等原型键但不要求 `hasOwn(lib.card)`；nature 为 nullish、空 string，或经 `get.natureList` 拆出的已注册非空 token；cardid 为 nullish 或数字字符串。拒绝对象、函数、`NaN`、`Infinity`、空白/未知 nature token 和原型键。
+   - `cards` 必须是数组；每项也必须是数组，长度为三至五项，并能生成合法规范化 clone。clone 镜像 `huosha`/`leisha`/`cisha`、合法 `<nature>sha` 和合法 `sha_<nature...>`；拒绝 `sha_`、`sha_unknown`、`sha_bad nature`。随后 suit 为 nullish 或 `lib.suits` 中的 string；number 为 nullish、string 或有限 number；name 为非空安全 string，拒绝 `__proto__`、`prototype`、`constructor` 等原型键但不要求 `hasOwn(lib.card)`；nature 为 nullish、空 string，或经 `get.natureList` 拆出的已注册非空 token；cardid 为 nullish 或数字字符串。拒绝对象、函数、`NaN`、`Infinity`、空白/未知 nature token 和原型键。
 5. `position` 用于诊断和匹配实际可见的 `game.players`、`game.dead` 角色；主机不会为 `game.additionaldead` 补建或发送不可见入口载荷。找不到时输出 `console.warn`，但由于载荷已包含显示名和完整卡牌快照，仍可继续注册该项，不让客户端状态差异破坏可用结果。
-6. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。该调用可能原地规范化 `huosha`、`leisha`、`cisha` 的 wire tuple，因此 postcondition 在调用后逐张比较：恢复项必须是非数组对象且不能仍是原数组；`suit` 与 tuple 一致；`number` 等于 `parseInt(wireNumber) || 0`；`name` 与 tuple 一致；`nature` 按 `get.natureList`、`lib.nature`、`lib.sort.nature`、`lib.natureSeparator` 规范化后一致，且无 nature 时 nullish/空字符串等价；存在 wire cardid 时必须一致。任一不匹配视为恢复失败并跳过整个 payload；半初始化 Card 也必须拒绝。否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
-7. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
-8. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。
+6. 维护 restore 批次级 `Set<string>` 记录非空 cardid。每个通过 payload guard 的 entry 在调用 `get.infoCards` 前，先检查本 entry 内及此前 entry 的 cardid 唯一；重复时告警包含 poptipId/cardid/entry/card 索引并跳过整条 payload，不调用 `get.infoCards`。通过检查的非空 cardid 会在调用前预留，即使恢复抛错或 postcondition 失败，后续 entry 也不得复用。
+7. 使用 `get.infoCards(entry.cards)` 恢复本地 `Card[]`。该调用可能原地规范化 `huosha`、`leisha`、`cisha`、`<nature>sha`、`sha_<nature...>` 的 wire tuple，因此 postcondition 使用规范化 clone 逐张比较：恢复项必须是非数组对象且不能仍是原数组；`suit` 与 clone 一致；`number` 等于 `parseInt(wireNumber) || 0`；`name` 与 clone 一致；`nature` 按 `get.natureList`、`lib.nature`、`lib.sort.nature`、`lib.natureSeparator` 规范化后一致，且无 nature 时 nullish/空字符串等价；存在 wire cardid 时必须一致。任一不匹配视为恢复失败并跳过整个 payload；半初始化 Card 也必须拒绝。否则调用 `createGameOverHandcardPoptip` 注册同一 ID。
+8. 单项恢复抛错或返回无效结果时，输出包含 `poptipId` 和 `position` 的 `console.warn`，跳过该项并处理下一项。
+9. 所有可用项注册完成后，才执行 `dialog.content.innerHTML = result`。自定义元素连接 DOM 时即可读取正确名称和回调。
 
 ## 错误处理
 
 - **缺少第三个参数**：视为旧调用，不告警、不失败。
 - **载荷整体类型错误**：告警一次，忽略载荷，结算 HTML、胜负音效和退出按钮继续正常显示。
 - **条目字段错误**：告警并跳过该条目，不终止循环。
-- **重复或越界 ID**：告警并跳过，防止覆盖本地注册。
+- **重复或越界 poptipId / 重复非空 cardid**：告警并跳过整条 payload，防止覆盖本地注册或复用已污染的 `lib.cardOL` Card。
 - **本地找不到角色**：告警后使用载荷快照继续注册；`position` 用于诊断，不作为渲染的硬依赖。
 - **卡牌恢复失败**：告警并跳过该条目，不使用空数组伪装成功。
 - **零张手牌**：这是有效数据，正常注册并显示“（没有手牌）”，不告警。
@@ -208,8 +210,9 @@ clients[i].send(
 | 重复或非法 `poptipId` | 输出明确 `console.warn`，不覆盖已有 poptip |
 | 第三个参数缺省 | 不报错，结算 HTML、胜负结果和退出流程与旧调用一致 |
 | `cards` 不是数组或卡牌项格式错误 | 输出明确 `console.warn`，不把错误伪装成零手牌 |
-| 合法 card tuple：合法/缺省 suit、有限 number 或 string、单属性/复合属性、`huosha`/`leisha`/`cisha`、三/四/五元组 | guard 通过，`get.infoCards` 规范化后 postcondition 通过 |
-| 非法 card tuple：`bad nature`、空白或未知 nature token、危险 name/cardid、对象/函数字段、`NaN`、`Infinity` | 输出明确“联机结算手牌载荷无效”告警，跳过坏条目，正常条目仍注册 |
+| 合法 card tuple：合法/缺省 suit、有限 number 或 string、单属性/复合属性、`huosha`/`leisha`/`cisha`、`firesha`（或实际已注册 `<nature>sha`）、`sha_fire`、`sha_fire_thunder`、普通扩展 name、三/四/五元组 | guard 通过且不修改原输入，`get.infoCards` 规范化后 postcondition 通过 |
+| 非法 card tuple：`sha_bad nature`、`sha_`、`sha_unknown`、`bad nature`、空白或未知 nature token、危险 name/cardid、对象/函数字段、`NaN`、`Infinity` | 输出明确“联机结算手牌载荷无效”告警，跳过坏条目，正常条目仍注册，且不调用 `get.infoCards` |
+| 重复非空 cardid：同一 payload 内重复、跨 payload 重复、前项恢复失败后后项复用 | 输出包含 poptipId/cardid/索引的明确告警，跳过重复 payload 且不调用 `get.infoCards`，后续不同 id 或无 id payload 正常 |
 | `get.infoCards` 返回半初始化 Card 或 suit/number/name/nature/cardid 与规范化 tuple 不一致 | 输出明确“恢复结果无效”告警，跳过整条 payload |
 | 完整恢复 Card 的标准字段与规范化 tuple 一致 | 正常注册 poptip；若内部可信卡牌定义在标准字段已完整后抛错，不扩大通用 `get.infoCard` API |
 

--- a/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
+++ b/docs/superpowers/specs/2026-07-21-online-game-over-handcards-design.md
@@ -12,7 +12,7 @@
 clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]));
 ```
 
-仅把 HTML 和胜负结果发送给客机。HTML 中包含随机 ID，但客机没有对应的名称、卡牌快照或 `createDialog` 回调，因此无法还原该 poptip。
+这段 direct send 是改动前事实，不是目标调用。现有 `Client.send` 会把首参数函数序列化进 RPC 信封，再由客机侧执行；序列化后的 `Game.over` 不保留模块私有 helper 闭包，也不能携带主机内存中的 poptip 名称、卡牌快照或 `createDialog` 回调。HTML 中包含随机 ID，但客机没有对应的本地注册，因此无法还原该 poptip。
 
 ## 目标
 
@@ -42,7 +42,7 @@ clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clie
 2. **主机载荷收集**：仅为实际可见的 `game.players` 和 `game.dead` 手牌列生成稳定 ID，使用结算开始时的 `hsMap` 快照构造纯数据载荷，并复用辅助函数渲染主机页面。
 3. **客机载荷恢复**：在 `Game.over` 的联机接收分支校验可选载荷，使用 `get.infoCards` 恢复卡牌对象，逐项调用同一辅助函数注册回调，然后再设置 `dialog.content.innerHTML`。
 
-该边界保证网络只传输可序列化数据，不传输函数、DOM 节点或主机闭包。
+该边界把 `handcardPoptips` 业务载荷限定为字符串和 `get.cardsInfo` 数组，不包含回调、DOM 节点或主机闭包；RPC 信封仍沿用现有 `Client.send`，序列化一个固定、无闭包 wrapper，并由客机侧 exec 调用客机本地 `game.over`。
 
 ## 组件接口
 
@@ -183,8 +183,9 @@ clients[i].send(
 ## 安全性与隐私
 
 - 手牌载荷只在 `_status.over` 已进入结算流程、主机准备发送结算 HTML 时发送，不提前广播，不改变对局中的隐藏信息规则。
-- 只传输字符串和 `get.cardsInfo` 产生的数组，不序列化函数、闭包、DOM 或可执行代码。
-- 客机不执行来自网络的回调；回调由本地固定辅助函数创建。
+- `handcardPoptips` 业务载荷只包含字符串和 `get.cardsInfo` 产生的数组；payload 不构造或注入可执行代码。
+- RPC 信封中的固定 wrapper 由现有 `Client.send` 序列化，wrapper 不闭包捕获主机 helper 或状态，客机侧 exec 后调用本地 `game.over`。
+- 客机不会执行来自 payload 的回调；poptip callback 由本地固定辅助函数创建。
 - `poptipId` 使用白名单格式并检查重复，不能借载荷覆盖任意 poptip。
 - 图标 HTML 由本地常量生成；载荷字段不会拼接进主结算 HTML。
 - `name` 来自主机对已存在角色执行的 `get.translation`。它仅用于现有 dialog 标题路径，不扩大当前主机权威模型。


### PR DESCRIPTION
## 问题与根因

联机游戏结束后，主机结算页可以点击角色头像查看剩余手牌，但客机显示异常且点击无内容。

原实现只把结算 HTML 发送给客机；随机 poptip ID、角色名、手牌快照和 dialog 回调仍保存在主机内存中。直接通过 RPC 序列化 `Game.over` 还会丢失模块私有 helper 的词法环境。

## 修复方案

- 为存活和阵亡角色统一生成按结算行递增的稳定 poptip ID。
- 主机仅在 `Game.over` 结算阶段发送 `{ poptipId, position, name, cards }` 纯数据快照，卡牌继续使用 `get.cardsInfo`。
- 客机逐项校验载荷并使用 `get.infoCards` 恢复卡牌，在插入结算 HTML 前注册本地 poptip 回调。
- RPC 发送无闭包 wrapper，由客机调用本地 `game.over`，避免模块 helper 丢失。
- 对坏条目、重复 poptip/cardid、缺失 Player 和半初始化 Card 进行告警与隔离，不影响其余有效结算内容。

## 兼容性与安全性

- `Game.over` 新增参数保持可选，现有两参数调用不受影响。
- 新客机连接旧主机、旧客机连接新主机时均安全退化，不承诺混合版本具备完整手牌交互。
- 手牌快照仅在 `_status.over` 后发送，不改变对局中的隐藏信息同步。
- 业务载荷只包含经过白名单校验的字符串、数字和数组；拒绝危险字段、非法属性别名与重复卡牌标识。
- `game.additionaldead` 保持既有不可见手牌列行为，不扩大本次修复范围。

## 测试

### 代码与构建

- `pnpm --filter noname exec eslint noname/game/index.js`
- `pnpm --filter noname lint`
- `pnpm build`
- `git diff --check upstream/main...HEAD`
- 本地忽略态运行时边界断言 50/50 通过（测试脚本和产物不进入 PR）

### GUI 客观自动验收

- 新版真实主客机 fresh run `2026-07-25T04:41:09.066Z`：连接 `ws://127.0.0.1:8082` 并加入同一房间；主机单向 `game.over(true)` 后，主客机稳定 ID 与点击手牌内容一致，trailing pageerror gate 为 0/0。
- 客户端 fallback fresh run `2026-07-25T04:41:41.047Z`：多张、单张、零张共 4 个入口的注册顺序和点击内容通过，trailing pageerror gate 为 0。
- 混合版本 fresh run `2026-07-25T04:39:40.701Z`：旧主到新客、新主到旧客两个方向均安全兼容；两名 guest 的真实退出通过。房主运行时只提供“重新开始”，故 host exit 按产品语义标记为不适用；两个方向均验证保存原 roomId、调用 reload、结果层消失并到达安全联机目标页。
- 单机 fresh run `2026-07-25T04:32:15.204Z`：存活/阵亡、多张/零张弹窗、重新开始进入 fresh active game、独立窗口全局退出真实关闭、IndexedDB `video` store 新增完整录像且含 `type=over` 结算 HTML，全部通过。
- 异常载荷 fresh run `2026-07-25T04:50:37.499Z`：5 条预期 warning、4 个有效入口、坏条目隔离和后续有效项点击通过，pageerror 为 0。
- 最终选择的 57 张 PNG 全部通过非白像素 gate（最低 `nonWhitePixelRatio=0.0315877`）；10 个 fresh run `pageerrors.json` 均为 `[]`。
- 客观自动验收未留功能缺口。人工只需目视复核下面两张精选 contact sheet；该项是 reviewer 行为，不是未验证功能。

## 精选视觉证据

![核心手牌结果](https://github.com/user-attachments/assets/9744516f-24d4-4418-93d7-a1828788dbc1)

![回归与退出重启结果](https://github.com/user-attachments/assets/8782f193-5330-4732-a8eb-bc28bb8a309b)

Fixes #4042