### PR TITLE
feat: 为`Player#randomGain`添加`animate`参数支持

### DIFF
--- a/apps/core/noname/library/element/Player/type.d.ts
+++ b/apps/core/noname/library/element/Player/type.d.ts
@@ -517,6 +517,11 @@ export interface EventRandomGainParams {
 	 * 是否在获取时显示指示线
 	 */
 	line?: boolean;
+
+	/**
+	 * 获得牌时的动画表现，默认为 "giveAuto"
+	 */
+	animate?: GainAnimate;
 }
 
 export interface EventDiscardParams {

--- a/apps/core/noname/library/element/player.js
+++ b/apps/core/noname/library/element/player.js
@@ -7971,6 +7971,8 @@ export class Player extends HTMLDivElement {
 		let num = 1;
 		let target = null;
 		let line = false;
+		/** @type { import("./Player/type.d").GainAnimate } */
+		let animate = "giveAuto";
 
 		const args = [...arguments];
 		if (args.length === 1 && get.is.object(params) && params != null && get.itemtype(params) == null) {
@@ -7978,6 +7980,7 @@ export class Player extends HTMLDivElement {
 			position = params.position ?? position;
 			target = params.target ?? target;
 			line = params.line ?? line;
+			animate = params.animate ?? animate;
 		} else {
 			for (const arg of args) {
 				if (typeof arg == "number") {
@@ -7988,6 +7991,9 @@ export class Player extends HTMLDivElement {
 					target = arg;
 				} else if (typeof arg == "boolean") {
 					line = arg;
+				} else if (typeof arg == "string") {
+					// @ts-ignore
+					animate = arg;
 				}
 			}
 		}
@@ -8004,6 +8010,7 @@ export class Player extends HTMLDivElement {
 		const next = this.gain({
 			cards,
 			source: target,
+			animate,
 			log: true,
 			bySelf: true,
 		});


### PR DESCRIPTION
- 添加“animate”参数支持，默认为“giveAuto”
- 已添加对应ts文档说明

BREAKING CHANGE: 调整了`Player#randomGain`的扩展需要跟进
> 尽管本体没有使用案例，此次改动是做加法
