### PR TITLE
fix: OL南华老仙调整；OL裴秀【尽览】时机调整

### DIFF
--- a/apps/core/character/sp/skill.js
+++ b/apps/core/character/sp/skill.js
@@ -857,7 +857,7 @@ const skills = {
 		},
 		locked: false,
 		audio: 2,
-		trigger: { player: "useCard" },
+		trigger: { player: "useCardAfter" },
 		filter(event, player) {
 			if (player !== _status.currentPhase) return false;
 			const dialog = ui[`olremaozhuMap_${player.playerid}`];
@@ -9014,9 +9014,9 @@ const skills = {
 				toIndex: 1,
 				name: "你可以摸一张牌",
 				effect: {
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.draw();
+						await player.draw();
 					},
 				},
 			},
@@ -9025,12 +9025,12 @@ const skills = {
 				name: "你可以弃置一名角色区域内的一张牌",
 				effect: {
 					filter(event, player) {
-						return game.hasPlayer(target => target.countCards("hej"));
+						return game.hasPlayer(target => target.hasCards("hej"));
 					},
 					async cost(event, trigger, player) {
 						event.result = await player
 							.chooseTarget(get.prompt2(event.skill), (card, player, target) => {
-								return target.countCards("hej");
+								return target.hasCards("hej");
 							})
 							.set("ai", target => {
 								const player = get.player();
@@ -9038,9 +9038,9 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.discardPlayerCard(event.targets[0], "hej", true);
+						await player.discardPlayerCard(event.targets[0], "hej", true);
 					},
 				},
 			},
@@ -9048,9 +9048,9 @@ const skills = {
 				toIndex: 1,
 				name: "你可以观看牌堆顶三张牌，然后将这些牌以任意顺序置于牌堆顶或牌堆底",
 				effect: {
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.chooseToGuanxing(3);
+						await player.chooseToGuanxing(3);
 					},
 				},
 			},
@@ -9059,22 +9059,21 @@ const skills = {
 				name: "你可以弃置任意张牌并摸等量张牌",
 				effect: {
 					filter(event, player) {
-						return player.hasCard(card => {
+						return player.hasCards("he", card => {
 							if (get.position(card) === "h" && _status.connectMode) {
 								return true;
 							}
 							return lib.filter.cardDiscardable(card, player);
-						}, "he");
+						});
 					},
 					async cost(event, trigger, player) {
 						const name = event.skill;
-						event.result = await player.chooseToDiscard(get.prompt2(name), "he", [1, Infinity], "chooseonly").set("ai", lib.skill.zhiheng.check).set("logSkill", name).forResult();
+						event.result = await player.chooseToDiscard(get.prompt2(name), "he", [1, Infinity], "chooseonly", "allowChooseAll").set("ai", lib.skill.zhiheng.check).forResult();
 					},
-					popup: false,
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.discard(event.cards);
-						player.draw(event.cards.length);
+						await player.discard(event.cards);
+						await player.draw(event.cards.length);
 					},
 				},
 			},
@@ -9089,9 +9088,9 @@ const skills = {
 					prompt2(event, player) {
 						return "获得" + get.translation(event.cards.filterInD());
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.gain(trigger.cards.filterInD(), "gain2");
+						await player.gain(trigger.cards.filterInD(), "gain2");
 					},
 				},
 			},
@@ -9106,14 +9105,13 @@ const skills = {
 					direct: true,
 					async content(event, trigger, player) {
 						const card = new lib.element.VCard({ name: "sha", isCard: true });
-						event.result = await player
+						await player
 							.chooseUseTarget(get.prompt2(event.name), card, false, "nodistance")
 							.set("oncard", () => {
 								const event = _status.event.getParent(2);
 								lib.skill.olhedao.tianshuClear(event.name, event.player);
 							})
-							.set("logSkill", event.name)
-							.forResult();
+							.set("logSkill", event.name);
 					},
 				},
 			},
@@ -9122,12 +9120,12 @@ const skills = {
 				name: "你可以获得一名角色区域内的一张牌",
 				effect: {
 					filter(event, player) {
-						return game.hasPlayer(target => target.countCards("hej"));
+						return game.hasPlayer(target => target.hasCards("hej"));
 					},
 					async cost(event, trigger, player) {
 						event.result = await player
 							.chooseTarget(get.prompt2(event.skill), (card, player, target) => {
-								return target.countCards("hej");
+								return target.hasCards("hej");
 							})
 							.set("ai", target => {
 								const player = get.player();
@@ -9135,9 +9133,9 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.gainPlayerCard(event.targets[0], "hej", true);
+						await player.gainPlayerCard(event.targets[0], "hej", true);
 					},
 				},
 			},
@@ -9151,9 +9149,9 @@ const skills = {
 					check(event, player) {
 						return get.recoverEffect(player, player, player) > 0;
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.recover();
+						await player.recover();
 					},
 				},
 			},
@@ -9175,9 +9173,9 @@ const skills = {
 					filter(event, player) {
 						return player.countCards("h") < player.maxHp;
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.drawTo(Math.min(player.maxHp, player.countCards("h") + 5));
+						await player.drawTo(Math.min(player.maxHp, player.countCards("h") + 5));
 					},
 				},
 			},
@@ -9206,7 +9204,7 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						const target = event.targets[0];
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						target.addTempSkill("fengyin", { player: "phaseBegin" });
@@ -9252,11 +9250,11 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						const target = event.targets[0];
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						target.draw(2);
-						target.turnOver();
+						await target.draw(2);
+						await target.turnOver();
 					},
 				},
 			},
@@ -9271,7 +9269,7 @@ const skills = {
 					check(event, player) {
 						return get.effect(player, event.card, event.player, player) < 0;
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						trigger.getParent().excluded.add(player);
 						game.log(trigger.card, "对", player, "无效");
@@ -9306,7 +9304,7 @@ const skills = {
 							})
 							.set("judge2", result => (result.bool === false ? true : false))
 							.forResult();
-						if (result.bool === false) {
+						if (result?.bool === false) {
 							await target.damage(2, "thunder");
 						}
 					},
@@ -9392,9 +9390,9 @@ const skills = {
 					check(event, player) {
 						return get.value(event.result.card) > 0;
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.gain(trigger.result.card, "gain2");
+						await player.gain(trigger.result.card, "gain2");
 					},
 				},
 			},
@@ -9406,9 +9404,9 @@ const skills = {
 					filter(event, player) {
 						return game.hasPlayer(t => t.maxHp > player.maxHp);
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.gainMaxHp();
+						await player.gainMaxHp();
 					},
 				},
 			},
@@ -9453,7 +9451,7 @@ const skills = {
 						const target = event.targets[0];
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						const result = await player.chooseToCompare(target).forResult();
-						if (result.bool) {
+						if (result?.bool) {
 							await player.gainPlayerCard(target, 2, "he", true);
 						}
 					},
@@ -9509,7 +9507,7 @@ const skills = {
 				toIndex: 3,
 				name: "你可以获得两张非基本牌",
 				effect: {
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						let list = [];
 						while (list.length < 2) {
@@ -9521,7 +9519,7 @@ const skills = {
 							}
 						}
 						if (list.length) {
-							player.gain(list, "gain2");
+							await player.gain(list, "gain2");
 						}
 					},
 				},
@@ -9530,7 +9528,7 @@ const skills = {
 				toIndex: 3,
 				name: "你可以获得两张锦囊牌",
 				effect: {
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						let list = [];
 						while (list.length < 2) {
@@ -9542,7 +9540,7 @@ const skills = {
 							}
 						}
 						if (list.length) {
-							player.gain(list, "gain2");
+							await player.gain(list, "gain2");
 						}
 					},
 				},
@@ -9551,10 +9549,10 @@ const skills = {
 				toIndex: 3,
 				name: "你可以摸三张牌并将武将牌翻面",
 				effect: {
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.draw(3);
-						player.turnOver();
+						await player.draw(3);
+						await player.turnOver();
 					},
 				},
 			},
@@ -9635,7 +9633,7 @@ const skills = {
 						const target = event.player;
 						return get.damageEffect(target, event.source, player) > 0 && !target.hasSkillTag("filterDamage", null, { player: event.source, card: event.card });
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						trigger.num++;
 						game.log(trigger.player, "受到的伤害", "#y+1");
@@ -9649,10 +9647,10 @@ const skills = {
 					check(event, player) {
 						return player.countCards("hs", card => player.canSaveCard(card, player)) + player.getHp() - 1 > 0;
 					},
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						player.loseHp();
-						player.draw(3);
+						await player.loseHp();
+						await player.draw(3);
 					},
 				},
 			},
@@ -9682,10 +9680,10 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						const { targets } = event;
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						targets[0].swapHandcards(targets[1]);
+						await targets[0].swapHandcards(targets[1]);
 					},
 				},
 			},
@@ -9715,10 +9713,10 @@ const skills = {
 							})
 							.forResult();
 					},
-					content() {
+					async content(event, trigger, player) {
 						const { targets } = event;
 						lib.skill.olhedao.tianshuClear(event.name, player);
-						targets[0].swapEquip(targets[1]);
+						await targets[0].swapEquip(targets[1]);
 					},
 				},
 			},
@@ -9740,10 +9738,10 @@ const skills = {
 						return event.source.hasSkillTag("nogain");
 					},
 					logTarget: "source",
-					content() {
+					async content(event, trigger, player) {
 						lib.skill.olhedao.tianshuClear(event.name, player);
 						trigger.cancel();
-						trigger.source.draw(3);
+						await trigger.source.draw(3);
 					},
 				},
 			},
@@ -9833,37 +9831,38 @@ const skills = {
 		async content(event, trigger, player) {
 			let { tianshuTrigger: fromItems, tianshuContent: toItems } = get.info("olhedao");
 			fromItems = fromItems.randomGets(3);
-			event.videoId = lib.status.videoId++;
-			function addFromItems(fromItems, id) {
-				const dialog = ui.create.dialog('###青书：请选择“天书”时机###<div class="text center">时机触发等级将决定后续效果词条的等级</div>');
-				dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
-				dialog.videoId = id;
-				dialog.addNewRow(
-					...fromItems.map((item, index) => {
-						return {
-							item: [`${item.name}<br>（触发等级：${item.fromIndex}）`],
-							custom(itemContainer) {
-								itemContainer.link = index;
-								itemContainer.classList.add("button");
-								dialog.buttons.add(itemContainer);
-							},
-							clickItemContainer(itemContainer, 棍, 母, e) {
-								ui.click.button.call(itemContainer, e);
-							},
-						};
-					})
-				);
-			}
-			if (event.isMine()) {
-				addFromItems(fromItems, event.videoId);
-			} else if (player.isOnline2()) {
-				player.send(addFromItems, fromItems, event.videoId);
-			}
 			const froms = await player
-				.chooseButton(get.idDialog(event.videoId), true)
+				.chooseButton(
+					[
+						'###青书：请选择“天书”时机###<div class="text center">时机触发等级将决定后续效果词条的等级</div>',
+						[
+							dialog => {
+								const { fromItems } = get.event();
+								dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
+								dialog.addNewRow(
+									...fromItems.map((item, index) => {
+										return {
+											item: [`${item.name}<br>（触发等级：${item.fromIndex}）`],
+											custom(itemContainer) {
+												itemContainer.link = index;
+												itemContainer.classList.add("button");
+												dialog.buttons.add(itemContainer);
+											},
+											clickItemContainer(itemContainer, 棍, 母, e) {
+												ui.click.button.call(itemContainer, e);
+											},
+										};
+									})
+								);
+							},
+							"handle",
+						],
+					],
+					true
+				)
+				.set("fromItems", fromItems)
 				.set("ai", () => 1 + Math.random())
 				.forResult();
-			game.broadcastAll("closeDialog", event.videoId);
 			if (!froms?.links?.length) {
 				return;
 			}
@@ -9876,37 +9875,39 @@ const skills = {
 					toItems[get.rand(0, toItems.length - 1)] = levelItem;
 				}
 			}
-			event.videoId = lib.status.videoId++;
-			function addToItems(toItems, from, id) {
-				const dialog = ui.create.dialog('###青书：请选择“天书”效果###<div class="text center">' + from.name + "</div>");
-				dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
-				dialog.videoId = id;
-				dialog.addNewRow(
-					...toItems.map((item, index) => {
-						return {
-							item: [`${["", '<span style="color: #EEC900; text-shadow: 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white;">'][item.toIndex - from.fromIndex]}${item.name}${["", "</span>"][item.toIndex - from.fromIndex]}`],
-							custom(itemContainer) {
-								itemContainer.link = index;
-								itemContainer.classList.add("button");
-								dialog.buttons.add(itemContainer);
-							},
-							clickItemContainer(itemContainer, 棍, 母, e) {
-								ui.click.button.call(itemContainer, e);
-							},
-						};
-					})
-				);
-			}
-			if (event.isMine()) {
-				addToItems(toItems, from, event.videoId);
-			} else if (player.isOnline2()) {
-				player.send(addToItems, toItems, from, event.videoId);
-			}
 			const tos = await player
-				.chooseButton(get.idDialog(event.videoId), true)
+				.chooseButton(
+					[
+						'###青书：请选择“天书”效果###<div class="text center">' + from.name + "</div>",
+						[
+							dialog => {
+								const { toItems, from } = get.event();
+								dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
+								dialog.addNewRow(
+									...toItems.map((item, index) => {
+										return {
+											item: [`${["", '<span style="color: #EEC900; text-shadow: 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white, 0.5px 0.5px 0.5px white;">'][item.toIndex - from.fromIndex]}${item.name}${["", "</span>"][item.toIndex - from.fromIndex]}`],
+											custom(itemContainer) {
+												itemContainer.link = index;
+												itemContainer.classList.add("button");
+												dialog.buttons.add(itemContainer);
+											},
+											clickItemContainer(itemContainer, 棍, 母, e) {
+												ui.click.button.call(itemContainer, e);
+											},
+										};
+									})
+								);
+							},
+							"handle",
+						],
+					],
+					true
+				)
+				.set("toItems", toItems)
+				.set("from", from)
 				.set("ai", () => 1 + Math.random())
 				.forResult();
-			game.broadcastAll("closeDialog", event.videoId);
 			if (!tos?.links?.length) {
 				return;
 			}
@@ -9970,41 +9971,42 @@ const skills = {
 			const skills = player.getSkills(null, false, false).filter(skill => get.info(skill)?.olhedao);
 			const num = skills.length - lib.skill.olhedao.getLimit(player);
 			if (num > 0) {
-				if (num >= skills.length) {
-					player.removeSkill(skills);
-					return;
-				}
-				event.videoId = lib.status.videoId++;
-				function removeTianShu(player, skills, num, id) {
-					const dialog = ui.create.dialog("青书：选择失去" + get.cnNumber(num) + "册多余的“天书”");
-					dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
-					dialog.videoId = id;
-					dialog.addNewRow(
-						...skills.map(item => {
-							return {
-								item: [`${lib.translate[`${item}_info`]}<br>（剩余${player.storage[item][0]}次）`],
-								custom(itemContainer) {
-									itemContainer.link = item;
-									itemContainer.classList.add("button");
-									dialog.buttons.add(itemContainer);
-								},
-								clickItemContainer(itemContainer, 棍, 母, e) {
-									ui.click.button.call(itemContainer, e);
-								},
-							};
-						})
-					);
-				}
-				if (event.isMine()) {
-					removeTianShu(player, skills, num, event.videoId);
-				} else if (player.isOnline2()) {
-					player.send(removeTianShu, player, skills, num, event.videoId);
-				}
-				const result = await player
-					.chooseButton(get.idDialog(event.videoId), num, true)
-					.set("ai", () => 1 + Math.random())
-					.forResult();
-				game.broadcastAll("closeDialog", event.videoId);
+				const result =
+					num < skills.length
+						? await player
+								.chooseButton(
+									[
+										"青书：选择失去" + get.cnNumber(num) + "册多余的“天书”",
+										[
+											dialog => {
+												const { player, skills } = get.event();
+												dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
+												dialog.addNewRow(
+													...skills.map(item => {
+														return {
+															item: [`${lib.translate[`${item}_info`]}<br>（剩余${player.storage[item][0]}次）`],
+															custom(itemContainer) {
+																itemContainer.link = item;
+																itemContainer.classList.add("button");
+																dialog.buttons.add(itemContainer);
+															},
+															clickItemContainer(itemContainer, 棍, 母, e) {
+																ui.click.button.call(itemContainer, e);
+															},
+														};
+													})
+												);
+											},
+											"handle",
+										],
+									],
+									true,
+									num
+								)
+								.set("skills", skills)
+								.set("ai", () => 1 + Math.random())
+								.forResult()
+						: { bool: true, links: skills };
 				if (result?.bool && result.links?.length) {
 					player.removeSkill(result.links);
 				}
@@ -10034,40 +10036,38 @@ const skills = {
 			}
 			const result =
 				skills.length > 1
-					? await (async () => {
-							event.videoId = lib.status.videoId++;
-							function removeTianShu(target, skills, id) {
-								const dialog = ui.create.dialog("授术：请选择你要授予" + get.translation(target) + "的天书");
-								dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
-								dialog.videoId = id;
-								dialog.addNewRow(
-									...skills.map(item => {
-										return {
-											item: [lib.translate[`${item}_info`]],
-											custom(itemContainer) {
-												itemContainer.link = item;
-												itemContainer.classList.add("button");
-												dialog.buttons.add(itemContainer);
-											},
-											clickItemContainer(itemContainer, 棍, 母, e) {
-												ui.click.button.call(itemContainer, e);
-											},
-										};
-									})
-								);
-							}
-							if (event.isMine()) {
-								removeTianShu(target, skills, event.videoId);
-							} else if (player.isOnline2()) {
-								player.send(removeTianShu, target, skills, event.videoId);
-							}
-							const result = await player
-								.chooseButton(get.idDialog(event.videoId), true)
-								.set("ai", () => 1 + Math.random())
-								.forResult();
-							game.broadcastAll("closeDialog", event.videoId);
-							return result;
-						})()
+					? await player
+							.chooseButton(
+								[
+									"授术：请选择你要授予" + get.translation(target) + "的天书",
+									[
+										dialog => {
+											const { skills } = get.event();
+											dialog.css({ top: get.is.phoneLayout() ? "20%" : "25%" });
+											dialog.addNewRow(
+												...skills.map(item => {
+													return {
+														item: [lib.translate[`${item}_info`]],
+														custom(itemContainer) {
+															itemContainer.link = item;
+															itemContainer.classList.add("button");
+															dialog.buttons.add(itemContainer);
+														},
+														clickItemContainer(itemContainer, 棍, 母, e) {
+															ui.click.button.call(itemContainer, e);
+														},
+													};
+												})
+											);
+										},
+										"handle",
+									],
+								],
+								true
+							)
+							.set("skills", skills)
+							.set("ai", () => 1 + Math.random())
+							.forResult()
 					: { bool: true, links: skills };
 			if (result?.bool && result.links?.length) {
 				const [skill] = result.links;

--- a/apps/core/character/sp/translate.js
+++ b/apps/core/character/sp/translate.js
@@ -1642,7 +1642,7 @@ const translates = {
 		return "<br>" + [...mapSkill].map(([mapName, cities]) => `<li>${get.poptip(mapName)}：${cities.map(get.poptip).join("、")}`).join("<br>");
 	},
 	olrejinlan: "尽览",
-	olrejinlan_info: "当你于回合内使用♠/♥/♣/♦牌时，你可以绘制东/西/南/北方位的所有“地图”。你绘制一处城市后，执行对应城市的效果。",
+	olrejinlan_info: "当你于回合内使用♠/♥/♣/♦牌后，你可以绘制东/西/南/北方位的所有“地图”。你绘制一处城市后，执行对应城市的效果。",
 	olcaifeng: "采风",
 	olcaifeng_info: "出牌阶段每张地图限一次，你可以弃置任意张牌，然后从牌堆或弃牌堆中随机获得等量张其余花色的牌。",
 	// 并州


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的代码内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
<!-- 如果是通用的代码，填写无即可。只需要涉及到某个平台才需要填写 -->
全部

### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->

赤子青荒，唯记万变其一
天地万法，皆在此书之中
以小篆记大道，则道可道
此书载天地至理，望汝珍视如命
天书非凡物，字字皆玄机
我得道成仙，当出世化生人中
不参黄泉，难悟大道
道者，亦置之死地而后生
因果开茅塞，轮回似醍醐
尔生异心，必获恶报

凡蜕将终，始窥大道之门，才知生死不过泡影
大道无形，生天地，行日月，同生老病死
生死一线，道心通明，大道至简，如万物归一
天地为卷，众生为墨，此书载风雨雷霆
道法自然，墨绘乾坤，天书成而万物生
道生一，一生二，二生三，三生万物
世人皆慕长生，却不见多少仙人，枯老在这白玉京
今授汝天书三卷，望汝救万民于水火
吾观世间，苦海无边，今以天书为舟，渡尔至彼岸
本欲解万苦，奈何零落万骨


有人反馈牢骚哥修改的OL南华老仙ai报错，因为梦到南华老仙的指示，现在对OL南华老仙进行回调式调整，主要是适配联机和content改成async content提前避免后面编译可能出现的问题；

依旧是牢骚哥反馈OL裴秀【尽览】时机不为使用牌时，为使用牌后，现在调整


总之，牢骚哥（@mengxinzxz）干了

### PR描述
<!-- 详细描述您的更改 -->
1.OL南华老仙【合道】、【青书】、【授术】调整；
2.OL裴秀【尽览】时机调整；


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
已进行联机、托管测试


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
修改了OL南华老仙的扩展需要根据


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]`。注意其中没有空格 -->
- [x] 我没有把该PR提交到`master`分支
- [x] commit中没有无用信息，和没有具体内容的“bugfix”
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 若我拥有PR标签权限，则已确保为该PR打上标签；若我未拥有PR标签权限且该PR仍需继续提交内容，则已确保为该PR名称打上`WIP`直到本PR内容全部提交
- [x] 如果此次PR中添加了新的武将，则我已在`character/rank.js`中添加对应的武将强度评级，并对双人武将/复姓武将添加`name:xxx`的参数
- [x] 如果此次PR中添加了新的语音文件，则我已在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [x] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
