### PR TITLE
fix(card): 修复诏书锦囊召唤不发牌

### DIFF
--- a/apps/core/card/guozhan.js
+++ b/apps/core/card/guozhan.js
@@ -1536,7 +1536,7 @@ export default {
 					const card = list.randomGet();
 					lib.inpile.add(card[2]);
 					await player.gain({
-						cards: game.createCard2(card[2], card[0], card[1], void 0),
+						cards: [game.createCard2(card[2], card[0], card[1], void 0)],
 						animate: "gain2",
 					});
 				}


### PR DESCRIPTION
## 变更内容

`apps/core/card/guozhan.js` 里【诏书】「锦囊召唤」的 `player.gain` 调用，把单张牌套进数组：

```diff
 await player.gain({
-	cards: game.createCard2(card[2], card[0], card[1], void 0),
+	cards: [game.createCard2(card[2], card[0], card[1], void 0)],
 	animate: "gain2",
 });
```

`gain` 在派发前会做 `if (get.itemtype(next.cards) !== "cards") next.cards = [];`（`player.js:8589`），而单张 Card 的 itemtype 是 `"card"` 不是 `"cards"`，于是被清成空数组、什么都不会获得。原因和完整链路见关联的 issue。

保留对象参数形式而不是退回位置参数，是因为 CONTRIBUTING 要求“支持对象参数的 `Player` 事件方法必须用对象参数”。

## 验证方式

改动本身只是参数形状，不涉及游戏逻辑。验证分两步：

一是用不依赖诏书前置条件的最小复现，在控制台对比两种写法：

```js
game.me.gain({ cards: game.createCard2("sha", "spade", 7), animate: "gain2" });    // 修复前的写法：无事发生
game.me.gain({ cards: [game.createCard2("sha", "spade", 7)], animate: "gain2" });  // 本 PR 的写法：正常入手
```

二是实际对局：国战“势备”模式，敕令移出游戏后取得诏书，攒够四种花色的“应”，发动锦囊召唤 —— 修复后能正常获得一张势力锦囊，修复前“应”被弃光且无任何获得。


## 关联 issue

Fixes #4336
