### PR TITLE
feat: Android应用build脚本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,12 +172,105 @@ jobs:
           "release/noname.Setup.${VER}.exe.sha256" \
           --clobber
 
+  build-android:
+    name: Build Android packages
+    needs: create-release
+    runs-on: ubuntu-latest
+    env:
+      NONAME_BUILD_CHANNEL: release
+      NONAME_BUILD_COMMIT: ${{ github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: |
+          yes | sdkmanager --licenses >/dev/null || true
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Android signing keystore
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          : "${ANDROID_KEYSTORE_BASE64:?Missing GitHub Secret ANDROID_KEYSTORE_BASE64}"
+          SIGNING_DIR="$RUNNER_TEMP/noname-android-signing"
+          mkdir -p "$SIGNING_DIR"
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$SIGNING_DIR/noname-release.jks"
+          echo "ANDROID_KEYSTORE_PATH=$SIGNING_DIR/noname-release.jks" >> "$GITHUB_ENV"
+
+      - name: Build signed Android APK
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          pnpm -F @noname/mobile build:android
+          cp apps/mobile/android/app/build/outputs/apk/release/app-release.apk release/noname.android.apk
+          sha256sum release/noname.android.apk > release/noname.android.apk.sha256
+
+      - name: Build signed Android App Bundle
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          pnpm -F @noname/mobile build:android -- --aab --skip-web-build
+          cp apps/mobile/android/app/build/outputs/bundle/release/app-release.aab release/noname.android.aab
+          sha256sum release/noname.android.aab > release/noname.android.aab.sha256
+
+      - name: Upload Android packages to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release upload "$TAG" \
+            release/noname.android.apk \
+            release/noname.android.apk.sha256 \
+            release/noname.android.aab \
+            release/noname.android.aab.sha256 \
+            --clobber
+
   release:
     name: Release Version
     runs-on: ubuntu-latest
     needs:
       - build-packages
       - build-installer
+      - build-android
     permissions:
       contents: write
       discussions: write
@@ -204,6 +297,7 @@ jobs:
       - create-release
       - build-packages
       - build-installer
+      - build-android
       - release
     runs-on: ubuntu-latest
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -24,6 +24,30 @@ pnpm -F @noname/mobile build:android -- --aab
 
 The default command builds `android/app/build/outputs/apk/release/app-release.apk`. Use `--variant=debug` for a debug APK, or `--skip-web-build` when `dist` has already been built and you only need to run the Android build. CI machines need Node.js, pnpm, JDK 21, and an Android SDK with the required SDK/build-tools packages; Android Studio itself is not needed.
 
+### Release Signing
+
+Release signing reads values from environment variables first, then from the local `android/keystore.properties` file. If no signing values are provided, the build falls back to the debug keystore for development.
+
+For local builds, create `android/keystore.properties` (this file is ignored by Git):
+
+```properties
+storeFile=C:/path/to/noname-release.jks
+storePassword=your-store-password
+keyAlias=noname
+keyPassword=your-key-password
+```
+
+For CI, set these environment variables instead:
+
+```text
+ANDROID_KEYSTORE_PATH=/secure/path/noname-release.jks
+ANDROID_KEYSTORE_PASSWORD=...
+ANDROID_KEY_ALIAS=noname
+ANDROID_KEY_PASSWORD=...
+```
+
+The release APK/AAB is then signed automatically by `build:android`. Keep the keystore and passwords outside the repository; losing the keystore prevents updates to an already-published app.
+
 Use JDK 21 for Gradle builds. JDK 25 currently fails during Android project configuration.
 
 ## File System Model

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -22,7 +22,27 @@ pnpm -F @noname/mobile build:android
 pnpm -F @noname/mobile build:android -- --aab
 ```
 
-The default command builds `android/app/build/outputs/apk/release/app-release.apk`. Use `--variant=debug` for a debug APK, or `--skip-web-build` when `dist` has already been built and you only need to run the Android build. CI machines need Node.js, pnpm, JDK 21, and an Android SDK with the required SDK/build-tools packages; Android Studio itself is not needed.
+The default command builds `android/app/build/outputs/apk/release/app-release.apk`. Use `--variant=debug` for a debug APK, or `--skip-web-build` when `dist` has already been built and you only need to run the Android build. Build machines need Node.js, pnpm, JDK 21, and an Android SDK with the required SDK/build-tools packages; Android Studio itself is not needed.
+
+Gradle builds require JDK 21. If another Java version is active, set `JAVA_HOME` and prepend its `bin` directory for the current shell before building. This is temporary and does not change the system-wide Java configuration.
+
+Windows PowerShell:
+
+```powershell
+$env:JAVA_HOME = "C:\Program Files\Java\jdk-21"
+$env:Path = "$env:JAVA_HOME\bin;$env:Path"
+pnpm -F @noname/mobile build:android
+```
+
+Linux/macOS or CI Bash:
+
+```bash
+export JAVA_HOME="/path/to/jdk-21"
+export PATH="$JAVA_HOME/bin:$PATH"
+pnpm -F @noname/mobile build:android
+```
+
+The script checks the active Java version before building and stops with a clear error if it is not JDK 21. JDK 25 currently fails during Android project configuration.
 
 ### Release Signing
 
@@ -49,8 +69,6 @@ ANDROID_KEY_PASSWORD=...
 The GitHub Actions release workflow stores the keystore as the `ANDROID_KEYSTORE_BASE64` secret and restores it during the job. Add that secret together with `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and `ANDROID_KEY_PASSWORD` in the repository settings.
 
 The release APK/AAB is then signed automatically by `build:android`. Keep the keystore and passwords outside the repository; losing the keystore prevents updates to an already-published app.
-
-Use JDK 21 for Gradle builds. JDK 25 currently fails during Android project configuration.
 
 ## File System Model
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -13,6 +13,17 @@ pnpm -F @noname/mobile sync
 
 `sync` first bundles `src/preload.ts` into `../../dist/preload.js`, then runs `cap sync`, and finally renames packaged `.pnpm` assets to `_pnpm` for Android assets compatibility. After syncing, open `apps/mobile/android` in Android Studio or build with Gradle.
 
+## CI Build
+
+Android Studio is not required. The Gradle Wrapper and the build script can build the APK or AAB directly:
+
+```bash
+pnpm -F @noname/mobile build:android
+pnpm -F @noname/mobile build:android -- --aab
+```
+
+The default command builds `android/app/build/outputs/apk/release/app-release.apk`. Use `--variant=debug` for a debug APK, or `--skip-web-build` when `dist` has already been built and you only need to run the Android build. CI machines need Node.js, pnpm, JDK 21, and an Android SDK with the required SDK/build-tools packages; Android Studio itself is not needed.
+
 Use JDK 21 for Gradle builds. JDK 25 currently fails during Android project configuration.
 
 ## File System Model

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -46,6 +46,8 @@ ANDROID_KEY_ALIAS=noname
 ANDROID_KEY_PASSWORD=...
 ```
 
+The GitHub Actions release workflow stores the keystore as the `ANDROID_KEYSTORE_BASE64` secret and restores it during the job. Add that secret together with `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and `ANDROID_KEY_PASSWORD` in the repository settings.
+
 The release APK/AAB is then signed automatically by `build:android`. Keep the keystore and passwords outside the repository; losing the keystore prevents updates to an already-published app.
 
 Use JDK 21 for Gradle builds. JDK 25 currently fails during Android project configuration.

--- a/apps/mobile/android/.gitignore
+++ b/apps/mobile/android/.gitignore
@@ -54,8 +54,9 @@ captures/
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -1,3 +1,26 @@
+import java.util.Properties
+
+val signingProperties = Properties()
+val signingPropertiesFile = rootProject.file("keystore.properties")
+if (signingPropertiesFile.exists()) {
+    signingPropertiesFile.inputStream().use(signingProperties::load)
+}
+
+fun signingValue(propertyName: String, environmentName: String): String? =
+    System.getenv(environmentName)?.takeIf(String::isNotBlank)
+        ?: signingProperties.getProperty(propertyName)?.takeIf(String::isNotBlank)
+
+val releaseStoreFile = signingValue("storeFile", "ANDROID_KEYSTORE_PATH")
+val releaseStorePassword = signingValue("storePassword", "ANDROID_KEYSTORE_PASSWORD")
+val releaseKeyAlias = signingValue("keyAlias", "ANDROID_KEY_ALIAS")
+val releaseKeyPassword = signingValue("keyPassword", "ANDROID_KEY_PASSWORD")
+val releaseSigningConfigured = listOf(
+    releaseStoreFile,
+    releaseStorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+).all { it != null }
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -23,6 +46,20 @@ android {
         }
     }
 
+    if (releaseSigningConfigured) {
+        signingConfigs {
+            create("release") {
+                storeFile = rootProject.file(releaseStoreFile!!)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+        logger.lifecycle("Release signing is configured.")
+    } else {
+        logger.warn("Release signing is not configured; falling back to the debug keystore.")
+    }
+
     buildTypes {
         getByName("debug") {
             isDebuggable = true
@@ -36,7 +73,11 @@ android {
                 "proguard-rules.pro"
             )
             manifestPlaceholders["enableAnalytics"] = "false"
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (releaseSigningConfigured) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 

--- a/apps/mobile/buildAndroid.ts
+++ b/apps/mobile/buildAndroid.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const mobileRoot = import.meta.dirname;
+const workspaceRoot = resolve(mobileRoot, "../..");
+const androidRoot = resolve(mobileRoot, "android");
+
+const args = new Set(process.argv.slice(2));
+const variant = process.argv.find((arg) => arg.startsWith("--variant="))?.split("=", 2)[1] ?? "release";
+const normalizedVariant = variant.toLowerCase();
+const task = args.has("--aab") ? `bundle${capitalize(normalizedVariant)}` : `assemble${capitalize(normalizedVariant)}`;
+
+if (!/^[a-z][a-z0-9]*$/.test(normalizedVariant)) {
+	throw new Error(`Invalid Android build variant: ${variant}`);
+}
+
+if (args.has("--help")) {
+	console.log(`Usage: pnpm build:android [options]
+
+Options:
+  --variant=<name>  Gradle variant to build (default: release)
+  --aab             Build an Android App Bundle instead of an APK
+  --skip-web-build  Reuse the existing dist directory
+`);
+	process.exit(0);
+}
+
+checkJavaVersion();
+
+if (args.has("--skip-web-build")) {
+	console.log("--skip-web-build is set; reusing the existing dist directory.");
+} else {
+	run("pnpm", ["build"], workspaceRoot, "Web build");
+}
+
+run("pnpm", ["sync"], mobileRoot, "Capacitor sync");
+
+const gradleCommand = process.platform === "win32" ? "gradlew.bat" : "./gradlew";
+run(gradleCommand, [task, "--no-daemon", "--stacktrace"], androidRoot, `Android ${task}`);
+
+const output = resolve(
+	androidRoot,
+	"app/build/outputs",
+	args.has("--aab") ? `bundle/${normalizedVariant}/app-${normalizedVariant}.aab` : `apk/${normalizedVariant}/app-${normalizedVariant}.apk`
+);
+
+if (!existsSync(output)) {
+	throw new Error(`Gradle completed, but the expected artifact was not found: ${output}`);
+}
+
+console.log(`Android artifact: ${output}`);
+
+function capitalize(value: string) {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function run(command: string, commandArgs: string[], cwd: string, step: string) {
+	console.log(`\n==> ${step}`);
+	const executable = process.platform === "win32" && command === "pnpm" ? "pnpm.cmd" : command;
+	const result = spawnSync(executable, commandArgs, {
+		cwd,
+		stdio: "inherit",
+		shell: process.platform === "win32" && (command === "pnpm" || command.endsWith(".bat")),
+	});
+
+	if (result.error) {
+		throw new Error(`${step} failed: ${result.error.message}`);
+	}
+	if (result.status !== 0) {
+		throw new Error(`${step} failed with exit code ${result.status ?? "unknown"}`);
+	}
+}
+
+function checkJavaVersion() {
+	const result = spawnSync("java", ["-version"], { encoding: "utf8" });
+	const versionOutput = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+	const match = versionOutput.match(/version "(\d+)/);
+	const major = match ? Number(match[1]) : undefined;
+
+	if (major === undefined) {
+		throw new Error("Java was not found. Install JDK 21 and make sure java is available on PATH.");
+	}
+	if (major !== 21) {
+		throw new Error(`JDK 21 is required for this Android build; detected JDK ${major}. Set JAVA_HOME to a JDK 21 installation.`);
+	}
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "sync": "tsx afterSync.ts",
+    "build:android": "tsx buildAndroid.ts",
     "lint": "pnpm eslint src/**"
   },
   "dependencies": {


### PR DESCRIPTION
集成了无需android studio的@noname/mobile构建脚本`pnpm -F @noname/mobile build:android`
将Android应用打包集成到cicd
仓库的github secrets已配置，有需要可以更改