### PR TITLE
fix: 修复同一原牌类别每回合重复触发

### DIFF
--- a/apps/core/character/newjiang/skill.js
+++ b/apps/core/character/newjiang/skill.js
@@ -3665,20 +3665,20 @@ const skills = {
 		audio: 2,
 		trigger: { player: "equipAfter" },
 		forced: true,
+		getType(card) {
+			const type = get.type2(card, false);
+			return type === "equip" ? get.subtype(card, false) : type;
+		},
 		filter(event, player, name, card) {
-			const subtypes = get.subtypes(card);
-			return !player.getStorage("jingyi_used").some(i => subtypes.includes(i));
+			return !player.getStorage("jingyi_used").includes(lib.skill.jingyi.getType(card));
 		},
 		getIndex(event, player) {
-			return event.vcards?.length ? event.vcards : (event.cards ?? []);
+			return event.cards ?? [];
 		},
 		async content(event, trigger, player) {
-			const card = event.indexedData,
-				subtypes = get.subtypes(card);
+			const type = lib.skill.jingyi.getType(event.indexedData);
 			player.addTempSkill(event.name + "_used");
-			if (subtypes?.length) {
-				player.markAuto(event.name + "_used", subtypes);
-			}
+			player.markAuto(event.name + "_used", [type]);
 			const num = player.getCards("e").reduce((sum, card) => {
 				const num = card.viewAs ? card.cards.length : 1;
 				return sum + num;
@@ -3696,7 +3696,7 @@ const skills = {
 				onremove: true,
 				mark: true,
 				marktext: "益",
-				intro: { content: "本回合已触发装备副类别：$" },
+				intro: { content: "本回合已触发类别：$" },
 			},
 		},
 	},

--- a/apps/core/character/newjiang/skill.js
+++ b/apps/core/character/newjiang/skill.js
@@ -3670,7 +3670,7 @@ const skills = {
 			return !player.getStorage("jingyi_used").some(i => subtypes.includes(i));
 		},
 		getIndex(event, player) {
-			return event.cards ?? [];
+			return event.vcards?.length ? event.vcards : (event.cards ?? []);
 		},
 		async content(event, trigger, player) {
 			const card = event.indexedData,
@@ -3694,6 +3694,9 @@ const skills = {
 			used: {
 				charlotte: true,
 				onremove: true,
+				mark: true,
+				marktext: "益",
+				intro: { content: "本回合已触发装备副类别：$" },
 			},
 		},
 	},
@@ -6966,7 +6969,7 @@ const skills = {
 				check(event, player) {
 					const bool = game.hasPlayer2(current => {
 						return current.hasHistory("damage", evt => evt.card == event.card);
-					}, true)
+					}, true);
 					if (bool) {
 						return true;
 					}


### PR DESCRIPTION
## 变更内容

- 按原牌类别记录每回合触发状态，避免同一类别在多个出牌阶段内重复触发。
- 将基本牌、锦囊牌和各装备副类别分别计次。
- 增加“益”状态标记，显示本回合已经触发的类别，并在回合结束时自动清除。

## 验证方式

- 使用谋大乔“流离”令角色在同一回合执行额外出牌阶段和正常出牌阶段，并在两个阶段分别用基本牌发动“工巧”；第二张基本牌不再重复触发，改用锦囊牌时则作为新类别正常触发。
- 覆盖同一类别不重复触发、不同类别分别触发、同批同类别仅触发一次。
- 通过单文件格式、语法、静态检查和差异检查。

Fixes #4419