### PR TITLE
fix: 修复tw灵宝(twlingbao)backup闭包引用links导致选牌无效

### DIFF
--- a/apps/core/character/tw/skill.js
+++ b/apps/core/character/tw/skill.js
@@ -29027,13 +29027,14 @@ const skills = {
 			backup(links, player) {
 				return {
 					audio: "twlingbao",
+					cards: links,
 					filterCard(card) {
-						return links.includes(card);
+						return get.info("twlingbao_backup").cards.includes(card);
 					},
 					selectCard: -1,
 					position: "x",
 					async content(event, trigger, player) {
-						const cards = links,
+						const cards = get.info("twlingbao_backup").cards,
 							colors = cards.map(card => get.color(card)).unique();
 						await player.draw(2);
 						if (colors.length == 1 && colors[0] == "red") {


### PR DESCRIPTION
修复 tw葛玄 灵宝技能的联机bug。见https://github.com/libnoname/noname/issues/4408

已本地双开 联机模式下测试通过。